### PR TITLE
SK spawning investigation: root cause and fresh#133 filed

### DIFF
--- a/R/lnk_rules_build.R
+++ b/R/lnk_rules_build.R
@@ -138,7 +138,7 @@ lnk_rules_build <- function(csv,
     if (d$rear_no_fw) {
       rear_rules <- list()
     } else if (d$rear_lake_only) {
-      lake_rule <- list(waterbody_type = "L", thresholds = FALSE)
+      lake_rule <- list(waterbody_type = "L")
       if (!is.na(th$rear_lake_ha_min)) {
         lake_rule$lake_ha_min <- th$rear_lake_ha_min
       }
@@ -160,7 +160,7 @@ lnk_rules_build <- function(csv,
         }
       }
       if (d$rear_lake) {
-        lake_rule <- list(waterbody_type = "L", thresholds = FALSE)
+        lake_rule <- list(waterbody_type = "L")
         if (!is.na(th$rear_lake_ha_min)) {
           lake_rule$lake_ha_min <- th$rear_lake_ha_min
         }

--- a/inst/extdata/parameters_habitat_rules.yaml
+++ b/inst/extdata/parameters_habitat_rules.yaml
@@ -1,5 +1,5 @@
 # Generated from parameters_habitat_dimensions.csv
-# Generated: 2026-04-11
+# Generated: 2026-04-12
 # Edge types: categories
 #
 # DO NOT EDIT — edit the CSV and re-run lnk_rules_build()
@@ -18,7 +18,6 @@ BT:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 CH:
   spawn:
   - edge_types:
@@ -33,7 +32,6 @@ CH:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 CM:
   spawn:
   - edge_types:
@@ -55,7 +53,6 @@ CO:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 PK:
   spawn:
   - edge_types:
@@ -75,7 +72,6 @@ SK:
     requires_connected: rearing
   rear:
   - waterbody_type: L
-    thresholds: false
     lake_ha_min: 200
 ST:
   spawn:
@@ -91,7 +87,6 @@ ST:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 WCT:
   spawn:
   - edge_types:
@@ -106,7 +101,6 @@ WCT:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 KO:
   spawn:
   - edge_types:
@@ -119,7 +113,6 @@ KO:
     requires_connected: rearing
   rear:
   - waterbody_type: L
-    thresholds: false
     lake_ha_min: 200
 RB:
   spawn:
@@ -135,7 +128,6 @@ RB:
   - edge_types: wetland
     thresholds: false
   - waterbody_type: L
-    thresholds: false
 GR:
   spawn:
   - edge_types:
@@ -148,5 +140,4 @@ GR:
     - canal
   - waterbody_type: R
   - waterbody_type: L
-    thresholds: false
 

--- a/inst/extdata/parameters_habitat_rules_bcfishpass.yaml
+++ b/inst/extdata/parameters_habitat_rules_bcfishpass.yaml
@@ -1,5 +1,5 @@
 # Generated from parameters_habitat_dimensions_bcfishpass.csv
-# Generated: 2026-04-11
+# Generated: 2026-04-12
 # Edge types: explicit
 #
 # DO NOT EDIT — edit the CSV and re-run lnk_rules_build()
@@ -102,7 +102,6 @@ SK:
     requires_connected: rearing
   rear:
   - waterbody_type: L
-    thresholds: false
     lake_ha_min: 200
 ST:
   spawn:

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,26 +1,25 @@
-# Task Plan: requires_connected in lnk_rules_build (#27)
+# Task Plan: SK spawning cluster divergence (#29)
 
 ## Goal
-Add `requires_connected` support to dimensions CSV and `lnk_rules_build()` so SK/KO spawning is constrained to lake proximity.
+Close the +54% SK spawning gap between fresh 0.12.6 and bcfishpass v0.5.0.
 
 ## Phases
 
-### Phase 1: CSV + function
-- [x] Add `spawn_requires_connected` and `rear_requires_connected` columns to both dimensions CSVs
-- [x] Update `lnk_rules_build()` to emit `requires_connected` predicate when column value is non-empty
-- [x] Regenerate both YAMLs
-- [x] Code-check (clean), commit
+### Phase 1: Investigate bcfishpass SK spawning logic
+- [ ] Read `load_habitat_linear_sk.sql` spawning sections in detail
+- [ ] Document: how does bcfishpass connect SK spawning to rearing lakes?
+- [ ] Compare to fresh frs_cluster approach
 
-### Phase 2: Test
-- [x] Added cluster_spawning + spawn cluster params to params_fresh_bcfishpass.csv
-- [x] SK spawning: 235 → 132 km (requires_connected working)
-- [x] SK rearing: 134 → 230 km (thresholds: false on lake rules — fresh#131 filed for proper fix)
-- [x] SK rearing now +0.2% vs bcfishpass. SK spawning +54% (cluster method — separate issue).
-- [x] BT/CH/CO all within 5%. SK rearing within 1%.
-- [x] Code-check, commit
+### Phase 2: Identify divergence
+- [x] Adams River: fresh 112 km vs bcfishpass 74 km — fresh extends 10km further downstream
+- [x] Root cause: no downstream distance cap from rearing lake. bcfishpass caps at 3km.
+- [x] SK rearing gap was thresholds on lake segments — fixed by fresh#131, workaround removed
 
-## Design
-Column value is the connected habitat type: `"rearing"`, `"spawning"`, or empty. Not a yes/no — the value IS the predicate argument. Abstracts beyond SK.
+### Phase 3: Fix
+- [x] Filed fresh#133 (connected_distance_max predicate)
+- [x] Removed thresholds: false workaround (fresh#131 handles it natively in 0.12.7)
+- [x] SK rearing +0.2%. SK spawning +54% blocked on fresh#133.
+- [x] Code-check, commit with checkboxes
 
 ## Versions
 - fresh: 0.12.6, bcfishpass: v0.5.0, link: 0.0.0.9000


### PR DESCRIPTION
## Summary
- Investigated SK spawning +54% gap vs bcfishpass v0.5.0
- Root cause: no downstream distance cap from rearing lake. bcfishpass caps at 3km, fresh extends full network.
- Filed fresh#133 (connected_distance_max predicate)
- Removed thresholds: false workaround on lake rules (fresh#131 merged in 0.12.7)

## Results (fresh 0.12.7)
| Species | Habitat | diff |
|---------|---------|------|
| BT | spawning/rearing | -2.6% / -3.0% |
| CH | spawning/rearing | -2.0% / -2.5% |
| CO | spawning/rearing | -2.9% / -5.0% |
| SK | spawning | +54.4% (blocked on fresh#133) |
| SK | rearing | +0.2% |

## Test plan
- [x] 121 tests pass
- [x] SK rearing confirmed +0.2% without workaround
- [x] Root cause documented in planning/findings

Relates to #29
Relates to #16
Relates to NewGraphEnvironment/fresh#133
Relates to NewGraphEnvironment/sred-2025-2026#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)