### PR TITLE
Migrate pipeline probes to manifest-driven gating (#46)

### DIFF
--- a/R/lnk_pipeline_prepare.R
+++ b/R/lnk_pipeline_prepare.R
@@ -81,7 +81,7 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, schema,
   }
 
   .lnk_pipeline_prep_load_aux(conn, aoi, cfg, schema)
-  .lnk_pipeline_prep_gradient(conn, aoi, schema)
+  .lnk_pipeline_prep_gradient(conn, aoi, cfg, schema)
   .lnk_pipeline_prep_natural(conn, schema)
   .lnk_pipeline_prep_overrides(conn, cfg, schema, observations)
   .lnk_pipeline_prep_minimal(conn, aoi, schema)
@@ -152,11 +152,30 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, schema,
   }
 
   # --- Expert habitat confirmations (for barrier skip list) ---
+  # Mirrors the `barriers_definite_control` pattern above — whenever the
+  # manifest declares `habitat_classification`, write a schema-valid
+  # table (populated or empty). `.lnk_pipeline_prep_overrides()` gates on
+  # the manifest key directly; creating an empty stub here keeps that
+  # gate safe for edge-case manifests that declare a header-only CSV.
   hab_df <- cfg$habitat_classification
-  if (!is.null(hab_df) && nrow(hab_df) > 0) {
-    DBI::dbWriteTable(conn,
-      DBI::Id(schema = schema, table = "user_habitat_classification"),
-      hab_df, overwrite = TRUE)
+  if (!is.null(hab_df)) {
+    if (nrow(hab_df) > 0) {
+      DBI::dbWriteTable(conn,
+        DBI::Id(schema = schema, table = "user_habitat_classification"),
+        hab_df, overwrite = TRUE)
+    } else {
+      .lnk_db_execute(conn, sprintf(
+        "DROP TABLE IF EXISTS %s.user_habitat_classification", schema))
+      .lnk_db_execute(conn, sprintf(
+        "CREATE TABLE %s.user_habitat_classification (
+           blue_line_key integer,
+           downstream_route_measure double precision,
+           upstream_route_measure double precision,
+           watershed_group_code text,
+           species_code text,
+           habitat_type text,
+           habitat_ind text)", schema))
+    }
   }
 
   invisible(NULL)
@@ -165,7 +184,7 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, schema,
 
 #' Detect gradient barriers, prune by control, enrich with ltree
 #' @noRd
-.lnk_pipeline_prep_gradient <- function(conn, aoi, schema) {
+.lnk_pipeline_prep_gradient <- function(conn, aoi, cfg, schema) {
   .lnk_db_execute(conn, sprintf(
     "DROP TABLE IF EXISTS %s.streams_blk", schema))
   .lnk_db_execute(conn, sprintf(
@@ -182,12 +201,13 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, schema,
                  "2500" = 0.25, "3000" = 0.30),
     to = paste0(schema, ".gradient_barriers_raw"))
 
-  # Prune passable controls
-  ctrl_exists <- DBI::dbGetQuery(conn, sprintf(
-    "SELECT 1 FROM information_schema.tables
-     WHERE table_schema = %s AND table_name = 'barriers_definite_control'",
-    .lnk_quote_literal(schema)))
-  if (nrow(ctrl_exists) > 0) {
+  # Prune passable controls. Manifest-driven gate — the config key is the
+  # direct contract for whether control semantics are active. Previously
+  # this probed information_schema for the table name; that worked because
+  # .lnk_pipeline_prep_load_aux() writes the table exactly when the
+  # manifest declares the key, but the indirection made an empty-table
+  # edge case easier to miss (see #44 asymmetric-gating fix).
+  if (!is.null(cfg$overrides$barriers_definite_control)) {
     .lnk_db_execute(conn, sprintf(
       "DELETE FROM %s.gradient_barriers_raw g
        USING %s.barriers_definite_control c
@@ -259,12 +279,15 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, schema,
 #' Compute barrier overrides via lnk_barrier_overrides
 #' @noRd
 .lnk_pipeline_prep_overrides <- function(conn, cfg, schema, observations) {
-  habitat_tbl <- paste0(schema, ".user_habitat_classification")
-  habitat_exists <- DBI::dbGetQuery(conn, sprintf(
-    "SELECT 1 FROM information_schema.tables
-     WHERE table_schema = %s AND table_name = 'user_habitat_classification'",
-    .lnk_quote_literal(schema)))
-  habitat_arg <- if (nrow(habitat_exists) > 0) habitat_tbl else NULL
+  # Manifest-driven gate. `.lnk_pipeline_prep_load_aux` writes
+  # `<schema>.user_habitat_classification` exactly when the manifest
+  # declares `habitat_classification`, so the config field is the direct
+  # contract. Consistent with the `barriers_definite_control` gate below.
+  habitat_arg <- if (!is.null(cfg$habitat_classification)) {
+    paste0(schema, ".user_habitat_classification")
+  } else {
+    NULL
+  }
 
   # Manifest-driven gating. `.lnk_pipeline_prep_load_aux` writes
   # `<schema>.barriers_definite_control` exactly when this manifest key

--- a/data-raw/logs/20260423_09_tar_make_46.txt
+++ b/data-raw/logs/20260423_09_tar_make_46.txt
@@ -1,0 +1,365 @@
++ cfg dispatched
+✔ cfg completed [264ms, 296.48 kB]
++ comparison_BABL dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_BABL completed [1m 52.5s, 416 B]
++ comparison_ELKR dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_elkr.pscis_fixes vs working_elkr.crossings
+  Total overrides:  324
+  Valid (matched):  288
+  Orphans:          36  <-- not found in crossings
+  Duplicates:       0
+Updated 288 of 7306 rows (barrier_status)
+NOTICE:  table "barriers_definite_control" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_wct" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_wct" does not exist, skipping
+
+✔ comparison_ELKR completed [2m 45.4s, 318 B]
++ comparison_BULK dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_bulk.pscis_fixes vs working_bulk.crossings
+  Total overrides:  580
+  Valid (matched):  514
+  Orphans:          66  <-- not found in crossings
+  Duplicates:       0
+Updated 514 of 5568 rows (barrier_status)
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_BULK completed [3m 7.7s, 438 B]
++ comparison_ADMS dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+✔ comparison_ADMS completed [1m 12s, 379 B]
++ comparison_DEAD dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_DEAD completed [43.6s, 420 B]
++ rollup dispatched
+✔ rollup completed [1ms, 869 B]
+✔ ended pipeline [9m 41.9s, 7 completed, 0 skipped]

--- a/data-raw/logs/20260423_10_tar_make_46_v2.txt
+++ b/data-raw/logs/20260423_10_tar_make_46_v2.txt
@@ -1,0 +1,365 @@
++ cfg dispatched
+✔ cfg completed [276ms, 296.48 kB]
++ comparison_BABL dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_BABL completed [1m 46.7s, 416 B]
++ comparison_ELKR dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_elkr.pscis_fixes vs working_elkr.crossings
+  Total overrides:  324
+  Valid (matched):  288
+  Orphans:          36  <-- not found in crossings
+  Duplicates:       0
+Updated 288 of 7306 rows (barrier_status)
+NOTICE:  table "barriers_definite_control" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_wct" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_wct" does not exist, skipping
+
+✔ comparison_ELKR completed [2m 46.3s, 318 B]
++ comparison_BULK dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_bulk.pscis_fixes vs working_bulk.crossings
+  Total overrides:  580
+  Valid (matched):  514
+  Orphans:          66  <-- not found in crossings
+  Duplicates:       0
+Updated 514 of 5568 rows (barrier_status)
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_BULK completed [3m 5.4s, 438 B]
++ comparison_ADMS dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+✔ comparison_ADMS completed [1m 10.7s, 379 B]
++ comparison_DEAD dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_DEAD completed [43.5s, 420 B]
++ rollup dispatched
+✔ rollup completed [1ms, 869 B]
+✔ ended pipeline [9m 33.2s, 7 completed, 0 skipped]

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,61 +1,71 @@
-# Findings — #48 (user_barriers_definite bypass)
+# Findings — #46 (manifest-driven probes refactor)
 
-## Pre-fix defect on ELKR (2026-04-23, via post-#47 tar_make state)
+## Probe locations
 
-Query: `SELECT * FROM working_<wsg>.barrier_overrides bo INNER JOIN working_<wsg>.barriers_definite bd ON bd.blue_line_key = bo.blue_line_key AND abs(bd.downstream_route_measure - bo.downstream_route_measure) < 1` across 5 WSGs:
-
-- ADMS: 0 rows in barriers_definite → no matches possible
-- BULK: 87 rows in barriers_definite, 0 matches in barrier_overrides
-- BABL: 0 rows in barriers_definite → no matches possible
-- ELKR: 7 rows in barriers_definite, **4 matches** in barrier_overrides
-- DEAD: 0 rows in barriers_definite → no matches possible
-
-ELKR matches:
-
-| Species | Position | Type | Name |
-|---------|----------|------|------|
-| BT | (356549622, 42) | EXCLUSION | Erickson Creek exclusion (mining impacts per CSV note) |
-| WCT | (356549622, 42) | EXCLUSION | Erickson Creek exclusion |
-| WCT | (356553439, 574) | MISC | Spillway |
-| WCT | (356560765, 2935) | MISC | Spillway |
-
-These are user-definite positions that link's pipeline treats as overridable. Post-fix they should stay as permanent blockers (matching bcfishpass). Current ELKR rollup: BT spawn +3.4% / rear -0.7%; WCT spawn +4.0% / rear +1.6%. Fixing this should bring spawning numbers down toward 0.
-
-## Architecture comparison
-
-**bcfishpass** — `model_access_*.sql`:
-
-```sql
-barriers CTE = gradient + falls + subsurfaceflow    -- NO user_definite
-... (observation filter, habitat filter, control filter all operate on barriers CTE)
-barriers_filtered as (... where n_obs < threshold and h.species_codes is null)
-INSERT INTO barriers_<model>
-  SELECT * FROM barriers_filtered
-  UNION ALL
-  SELECT * FROM bcfishpass.barriers_user_definite WHERE wsg = :wsg   -- appended post-filter
-```
-
-**link today** — `.lnk_pipeline_prep_natural()`:
+**`.lnk_pipeline_prep_gradient()`** (R/lnk_pipeline_prepare.R, around line 180):
 
 ```r
-CREATE TABLE natural_barriers FROM gradient_barriers_raw     -- base
-INSERT INTO natural_barriers SELECT FROM falls               -- + falls
-INSERT INTO natural_barriers SELECT FROM barriers_definite   -- + user-definite (WRONG — subjects to override)
+ctrl_exists <- DBI::dbGetQuery(conn, sprintf(
+  "SELECT 1 FROM information_schema.tables
+   WHERE table_schema = %s AND table_name = 'barriers_definite_control'",
+  .lnk_quote_literal(schema)))
+if (nrow(ctrl_exists) > 0) {
+  .lnk_db_execute(conn, sprintf(
+    "DELETE FROM %s.gradient_barriers_raw g
+     USING %s.barriers_definite_control c ...", schema, schema))
+}
 ```
 
-Then `.lnk_pipeline_prep_overrides()` passes `natural_barriers` to `lnk_barrier_overrides()`, which emits per-species override rows for any barrier meeting threshold — including user-definite.
+Target:
 
-## Shape A (chosen)
+```r
+if (!is.null(cfg$overrides$barriers_definite_control)) {
+  .lnk_db_execute(conn, sprintf(
+    "DELETE FROM %s.gradient_barriers_raw g
+     USING %s.barriers_definite_control c ...", schema, schema))
+}
+```
 
-1. Drop the `INSERT INTO natural_barriers SELECT FROM barriers_definite` block in `.lnk_pipeline_prep_natural()`.
-2. In `.lnk_pipeline_prep_minimal()`, after `frs_barriers_minimal()` emits each per-model reduced table, append `barriers_definite` rows (already WSG-filtered at load time) via `INSERT ... SELECT ... ON CONFLICT DO NOTHING`. Also append to the union that produces `gradient_barriers_minimal` so segmentation breaks include user-definite.
+Signature change: `.lnk_pipeline_prep_gradient(conn, aoi, schema)` → `(conn, aoi, cfg, schema)`.
 
-## natural_barriers callers
+**`.lnk_pipeline_prep_overrides()`** (R/lnk_pipeline_prepare.R, around line 260):
 
-Grep confirms `natural_barriers` only referenced in:
+```r
+habitat_tbl <- paste0(schema, ".user_habitat_classification")
+habitat_exists <- DBI::dbGetQuery(conn, sprintf(
+  "SELECT 1 FROM information_schema.tables
+   WHERE table_schema = %s AND table_name = 'user_habitat_classification'",
+  .lnk_quote_literal(schema)))
+habitat_arg <- if (nrow(habitat_exists) > 0) habitat_tbl else NULL
+```
 
-- `.lnk_pipeline_prep_natural()` (builds)
-- `.lnk_pipeline_prep_overrides()` (passes to `lnk_barrier_overrides()`)
-- `.lnk_pipeline_prep_minimal()` (reads into `frs_barriers_minimal()`)
+Target:
 
-Shape A is safe — no external consumers.
+```r
+habitat_arg <- if (!is.null(cfg$habitat_classification)) {
+  paste0(schema, ".user_habitat_classification")
+} else {
+  NULL
+}
+```
+
+No signature change — `cfg` is already passed in.
+
+## Why manifest-driven is better
+
+The probes work because `.lnk_pipeline_prep_load_aux()` writes the table exactly when the manifest declares it. But that chain is indirect — it relies on the load step's empty-table policy being correct. The asymmetric-gating bug fixed in #44 was rooted in this exact seam (manifest declared the key but load wrote nothing when the AOI had zero rows, causing a downstream probe to skip what the manifest intended).
+
+Reading `cfg$overrides$barriers_definite_control` directly makes the capability activation locally readable — no DB state dependency, no empty-table edge cases.
+
+## Expected rollup behavior
+
+Both probes currently return the same answer the manifest would give on the `bcfishpass` config bundle:
+
+- `working_<wsg>.barriers_definite_control` exists iff manifest has `overrides.barriers_definite_control`
+- `working_<wsg>.user_habitat_classification` exists iff manifest has `habitat_classification`
+
+So the refactor MUST produce a bit-identical rollup. Post-#48 baseline digest: `50908d234e2131fc0842dc3ab653ae78` (46 rows).
+
+If the digest diverges, likely candidates:
+- Some AOI in the manifest has the key but the load step writes an empty table (Phase 2 of #44 established this for `barriers_definite_control`; same pattern may or may not apply to `user_habitat_classification`). In that case pre-refactor the probe would see the empty table and pass; post-refactor the manifest check would pass too, and the downstream join would hit the empty table — same result.
+- An unrelated WSG with the manifest-key absent but a stale table left over from a prior run. Unlikely given tar_destroy before each tar_make.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,9 +1,9 @@
 # Progress
 
-## Session 2026-04-23 — #48 kickoff
+## Session 2026-04-23 — #46 kickoff
 
-- PR #47 merged (link 0.6.0, squash `8eda3fb`). Local main rebased onto origin/main; b330672 dropped as empty (already in squash).
-- Branched `48-user-barriers-definite-bypass` off main.
-- Archived #44 PWF under `planning/archive/2026-04-23-barriers-definite-control/` with README.
-- Pre-flight diagnostic (findings.md): ELKR has 4 user-definite override matches that need fixing; other 4 WSGs are empty for barriers_definite. ELKR is the active test case.
-- Next: Phase 1 — modify `.lnk_pipeline_prep_natural()` and `.lnk_pipeline_prep_minimal()` per Shape A in findings.md.
+- PR #49 merged as link 0.7.0 (squash `5cbd75d`). Tag `v0.7.0` pushed.
+- Archived #48 PWF under `planning/archive/2026-04-23-user-barriers-definite-bypass/`.
+- Branched `46-manifest-driven-probes` off main.
+- Scope: replace two `information_schema.tables` probes with direct `cfg$...` checks. Pure refactor, no behavior change, rollup must be bit-identical to post-#48 (`50908d234e2131fc0842dc3ab653ae78`).
+- Next: Phase 1 code — add `cfg` to `.lnk_pipeline_prep_gradient()` signature + manifest check, replace probe in `.lnk_pipeline_prep_overrides()` with manifest check.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,48 +1,33 @@
-# Task Plan: user_barriers_definite should bypass override (#48)
+# Task Plan: Migrate pipeline probes to manifest-driven gating (#46)
 
 ## Goal
 
-Match bcfishpass's architecture for `user_barriers_definite` rows: they must be appended to each per-model barrier table **post-filter** — always blocking, never eligible for observation override. Same-family fix as #44 but different mechanism.
+Replace two `information_schema.tables` probes with direct manifest-key checks. Pure refactor, no behavior change — rollup must remain bit-identical to the post-#48 baseline (`50908d234e2131fc0842dc3ab653ae78`).
 
-Pre-fix defect on ELKR confirmed: 4 override rows at user-definite positions (Erickson Creek exclusion, 2× Spillway MISC) that bcfishpass would keep as blockers.
+## Phase 1: Code
 
-## Phase 1: Code change (simpler than initially planned)
-
-Investigation showed `barriers_definite` is already wired as a break source in `lnk_pipeline_break` (sequential `frs_break_apply`) and into `fresh.streams_breaks` in `lnk_pipeline_classify` (access-gating barrier table). User-definite positions already end up as segment boundaries AND as blocking barriers at classification — bcfishpass parity on those two surfaces.
-
-The only defect is `.lnk_pipeline_prep_natural()` UNIONing `barriers_definite` into `natural_barriers`. `natural_barriers` is passed to `lnk_barrier_overrides()` which generates per-species override (skip) rows for any barrier with threshold observations upstream. That's what lets user-definite positions be re-opened.
-
-Only `natural_barriers` caller outside prep_natural is `.lnk_pipeline_prep_overrides()` (confirmed via grep). Safe to drop the definite UNION without touching prep_minimal.
-
-- [x] `.lnk_pipeline_prep_natural()` — drop the `INSERT INTO natural_barriers SELECT ... FROM barriers_definite` block. `natural_barriers` becomes gradient + falls only. Inline NOTE comment explains the bcfishpass parity reasoning.
-- [ ] Update tests in `test-lnk_pipeline_prepare.R` — the existing `prep_natural unions gradient + falls + definite` assertion needs to drop the "definite" clause.
+- [ ] `.lnk_pipeline_prep_gradient()` — add `cfg` to signature. Replace the `information_schema.tables` probe for `barriers_definite_control` with `!is.null(cfg$overrides$barriers_definite_control)`. Update the caller (`lnk_pipeline_prepare()`) to pass `cfg`.
+- [ ] `.lnk_pipeline_prep_overrides()` — already receives `cfg`. Replace the `information_schema.tables` probe for `user_habitat_classification` with `!is.null(cfg$habitat_classification)`.
+- [ ] Update mocked tests in `test-lnk_pipeline_prepare.R`. The existing tests mock `dbGetQuery` to fake the probe result — swap those for `cfg` stubs with / without the relevant manifest keys.
 
 ## Phase 2: Verification
 
-- [ ] `devtools::test()` — all green.
-- [ ] `pak::local_install()` and `cd data-raw && tar_destroy + tar_make`.
-- [ ] Query `working_elkr.barrier_overrides` joined to `working_elkr.barriers_definite` — should be empty (pre-fix: 4 matches).
-- [ ] ELKR rollup should shift toward bcfishpass: link BT/WCT spawning currently +3.4% / +4.0%; expected to DECREASE (closer to 0) since upstream habitat at Erickson and Spillway positions now correctly blocked.
-- [ ] Reproducibility: two consecutive `tar_destroy + tar_make` produce bit-identical 46-row rollups.
+- [ ] `devtools::test()` — 279 PASS retained.
+- [ ] `pak::local_install()` + `cd data-raw && tar_destroy + tar_make`.
+- [ ] `digest::digest()` on rollup vs `50908d234e2131fc0842dc3ab653ae78` — **must match** (behavior is unchanged).
+- [ ] If digest differs: stop and root-cause. A mismatch means the refactor has unintentionally changed behavior.
 
-## Phase 3: Artifacts
+## Phase 3: Ship
 
-- [ ] Regenerate vignette artifacts via `data-raw/vignette_reproducing_bcfishpass.R`.
-- [ ] Correct vignette text: user-definite barriers bullet no longer says "eligible for per-species override". Say they always block, are appended post-filter (bcfishpass parity).
-- [ ] `research/bcfishpass_comparison.md` — new row in "Key fixes" table; update ELKR parity table with post-fix numbers; short paragraph describing the fix.
-- [ ] `NEWS.md` 0.7.0 entry.
-- [ ] `DESCRIPTION` 0.6.0 → 0.7.0.
-
-## Phase 4: Ship
-
-- [ ] `/code-check` on staged diff — 2 rounds minimum.
-- [ ] Commit atomically (code + tests, then verification, then artifacts).
-- [ ] Push branch.
-- [ ] Open PR with SRED tag (`Relates to NewGraphEnvironment/sred-2025-2026#24`), link to #48, note closing of #48.
+- [ ] `/code-check` on staged diff.
+- [ ] No version bump (pure refactor, no behavior change).
+- [ ] No NEWS entry (or a terse internal-architecture note — reader opinion).
+- [ ] Commit atomically.
+- [ ] PR with SRED tag (`Relates to NewGraphEnvironment/sred-2025-2026#24`). `Fixes #46`.
 
 ## Versions at start
 
 - fresh: 0.14.0
-- link: main (0.6.0, target 0.7.0)
+- link: main (0.7.0)
 - bcfishpass: ea3c5d8
 - fwapg: Docker (FWA 20240830)

--- a/planning/archive/2026-04-23-user-barriers-definite-bypass/README.md
+++ b/planning/archive/2026-04-23-user-barriers-definite-bypass/README.md
@@ -1,0 +1,13 @@
+# #48 — user_barriers_definite bypass (closed)
+
+PR #49 merged 2026-04-23 as link 0.7.0 (squash commit `5cbd75d`, tagged `v0.7.0`).
+
+Dropped `barriers_definite` from `natural_barriers` in `.lnk_pipeline_prep_natural()` so user-definite positions are no longer eligible for observation-based override. Matches bcfishpass's `model_access_*.sql` post-filter `UNION ALL` shape.
+
+Active defect pre-fix on ELKR: 4 override rows at user-definite positions (Erickson Creek exclusion + 2 Spillway MISC); post-fix: 0 on all 5 WSGs. ELKR rollup shifted toward bcfishpass (BT spawning +3.4% → +2.8%, WCT spawning +4.0% → +2.6%, WCT rearing +1.6% → +0.3%). Other 4 WSGs unchanged (empty `barriers_definite` on 3; BULK's 87 rows had no override matches). Reproducibility verified — digest `50908d234e2131fc0842dc3ab653ae78`, 46 rows identical across two rebuilds.
+
+`barriers_definite` still consumed separately as break source (`lnk_pipeline_break()`) and via `UNION ALL` into `fresh.streams_breaks` (`lnk_pipeline_classify()`). Both surfaces unchanged.
+
+## Next
+
+- #46 — migrate remaining `information_schema.tables` probes in `.lnk_pipeline_prep_gradient()` and `.lnk_pipeline_prep_overrides()` to manifest-driven gating (pure refactor, no behavior change, bit-identical rollup expected).

--- a/planning/archive/2026-04-23-user-barriers-definite-bypass/findings.md
+++ b/planning/archive/2026-04-23-user-barriers-definite-bypass/findings.md
@@ -1,0 +1,61 @@
+# Findings — #48 (user_barriers_definite bypass)
+
+## Pre-fix defect on ELKR (2026-04-23, via post-#47 tar_make state)
+
+Query: `SELECT * FROM working_<wsg>.barrier_overrides bo INNER JOIN working_<wsg>.barriers_definite bd ON bd.blue_line_key = bo.blue_line_key AND abs(bd.downstream_route_measure - bo.downstream_route_measure) < 1` across 5 WSGs:
+
+- ADMS: 0 rows in barriers_definite → no matches possible
+- BULK: 87 rows in barriers_definite, 0 matches in barrier_overrides
+- BABL: 0 rows in barriers_definite → no matches possible
+- ELKR: 7 rows in barriers_definite, **4 matches** in barrier_overrides
+- DEAD: 0 rows in barriers_definite → no matches possible
+
+ELKR matches:
+
+| Species | Position | Type | Name |
+|---------|----------|------|------|
+| BT | (356549622, 42) | EXCLUSION | Erickson Creek exclusion (mining impacts per CSV note) |
+| WCT | (356549622, 42) | EXCLUSION | Erickson Creek exclusion |
+| WCT | (356553439, 574) | MISC | Spillway |
+| WCT | (356560765, 2935) | MISC | Spillway |
+
+These are user-definite positions that link's pipeline treats as overridable. Post-fix they should stay as permanent blockers (matching bcfishpass). Current ELKR rollup: BT spawn +3.4% / rear -0.7%; WCT spawn +4.0% / rear +1.6%. Fixing this should bring spawning numbers down toward 0.
+
+## Architecture comparison
+
+**bcfishpass** — `model_access_*.sql`:
+
+```sql
+barriers CTE = gradient + falls + subsurfaceflow    -- NO user_definite
+... (observation filter, habitat filter, control filter all operate on barriers CTE)
+barriers_filtered as (... where n_obs < threshold and h.species_codes is null)
+INSERT INTO barriers_<model>
+  SELECT * FROM barriers_filtered
+  UNION ALL
+  SELECT * FROM bcfishpass.barriers_user_definite WHERE wsg = :wsg   -- appended post-filter
+```
+
+**link today** — `.lnk_pipeline_prep_natural()`:
+
+```r
+CREATE TABLE natural_barriers FROM gradient_barriers_raw     -- base
+INSERT INTO natural_barriers SELECT FROM falls               -- + falls
+INSERT INTO natural_barriers SELECT FROM barriers_definite   -- + user-definite (WRONG — subjects to override)
+```
+
+Then `.lnk_pipeline_prep_overrides()` passes `natural_barriers` to `lnk_barrier_overrides()`, which emits per-species override rows for any barrier meeting threshold — including user-definite.
+
+## Shape A (chosen)
+
+1. Drop the `INSERT INTO natural_barriers SELECT FROM barriers_definite` block in `.lnk_pipeline_prep_natural()`.
+2. In `.lnk_pipeline_prep_minimal()`, after `frs_barriers_minimal()` emits each per-model reduced table, append `barriers_definite` rows (already WSG-filtered at load time) via `INSERT ... SELECT ... ON CONFLICT DO NOTHING`. Also append to the union that produces `gradient_barriers_minimal` so segmentation breaks include user-definite.
+
+## natural_barriers callers
+
+Grep confirms `natural_barriers` only referenced in:
+
+- `.lnk_pipeline_prep_natural()` (builds)
+- `.lnk_pipeline_prep_overrides()` (passes to `lnk_barrier_overrides()`)
+- `.lnk_pipeline_prep_minimal()` (reads into `frs_barriers_minimal()`)
+
+Shape A is safe — no external consumers.

--- a/planning/archive/2026-04-23-user-barriers-definite-bypass/progress.md
+++ b/planning/archive/2026-04-23-user-barriers-definite-bypass/progress.md
@@ -1,0 +1,9 @@
+# Progress
+
+## Session 2026-04-23 — #48 kickoff
+
+- PR #47 merged (link 0.6.0, squash `8eda3fb`). Local main rebased onto origin/main; b330672 dropped as empty (already in squash).
+- Branched `48-user-barriers-definite-bypass` off main.
+- Archived #44 PWF under `planning/archive/2026-04-23-barriers-definite-control/` with README.
+- Pre-flight diagnostic (findings.md): ELKR has 4 user-definite override matches that need fixing; other 4 WSGs are empty for barriers_definite. ELKR is the active test case.
+- Next: Phase 1 — modify `.lnk_pipeline_prep_natural()` and `.lnk_pipeline_prep_minimal()` per Shape A in findings.md.

--- a/planning/archive/2026-04-23-user-barriers-definite-bypass/task_plan.md
+++ b/planning/archive/2026-04-23-user-barriers-definite-bypass/task_plan.md
@@ -1,0 +1,48 @@
+# Task Plan: user_barriers_definite should bypass override (#48)
+
+## Goal
+
+Match bcfishpass's architecture for `user_barriers_definite` rows: they must be appended to each per-model barrier table **post-filter** — always blocking, never eligible for observation override. Same-family fix as #44 but different mechanism.
+
+Pre-fix defect on ELKR confirmed: 4 override rows at user-definite positions (Erickson Creek exclusion, 2× Spillway MISC) that bcfishpass would keep as blockers.
+
+## Phase 1: Code change (simpler than initially planned)
+
+Investigation showed `barriers_definite` is already wired as a break source in `lnk_pipeline_break` (sequential `frs_break_apply`) and into `fresh.streams_breaks` in `lnk_pipeline_classify` (access-gating barrier table). User-definite positions already end up as segment boundaries AND as blocking barriers at classification — bcfishpass parity on those two surfaces.
+
+The only defect is `.lnk_pipeline_prep_natural()` UNIONing `barriers_definite` into `natural_barriers`. `natural_barriers` is passed to `lnk_barrier_overrides()` which generates per-species override (skip) rows for any barrier with threshold observations upstream. That's what lets user-definite positions be re-opened.
+
+Only `natural_barriers` caller outside prep_natural is `.lnk_pipeline_prep_overrides()` (confirmed via grep). Safe to drop the definite UNION without touching prep_minimal.
+
+- [x] `.lnk_pipeline_prep_natural()` — drop the `INSERT INTO natural_barriers SELECT ... FROM barriers_definite` block. `natural_barriers` becomes gradient + falls only. Inline NOTE comment explains the bcfishpass parity reasoning.
+- [ ] Update tests in `test-lnk_pipeline_prepare.R` — the existing `prep_natural unions gradient + falls + definite` assertion needs to drop the "definite" clause.
+
+## Phase 2: Verification
+
+- [ ] `devtools::test()` — all green.
+- [ ] `pak::local_install()` and `cd data-raw && tar_destroy + tar_make`.
+- [ ] Query `working_elkr.barrier_overrides` joined to `working_elkr.barriers_definite` — should be empty (pre-fix: 4 matches).
+- [ ] ELKR rollup should shift toward bcfishpass: link BT/WCT spawning currently +3.4% / +4.0%; expected to DECREASE (closer to 0) since upstream habitat at Erickson and Spillway positions now correctly blocked.
+- [ ] Reproducibility: two consecutive `tar_destroy + tar_make` produce bit-identical 46-row rollups.
+
+## Phase 3: Artifacts
+
+- [ ] Regenerate vignette artifacts via `data-raw/vignette_reproducing_bcfishpass.R`.
+- [ ] Correct vignette text: user-definite barriers bullet no longer says "eligible for per-species override". Say they always block, are appended post-filter (bcfishpass parity).
+- [ ] `research/bcfishpass_comparison.md` — new row in "Key fixes" table; update ELKR parity table with post-fix numbers; short paragraph describing the fix.
+- [ ] `NEWS.md` 0.7.0 entry.
+- [ ] `DESCRIPTION` 0.6.0 → 0.7.0.
+
+## Phase 4: Ship
+
+- [ ] `/code-check` on staged diff — 2 rounds minimum.
+- [ ] Commit atomically (code + tests, then verification, then artifacts).
+- [ ] Push branch.
+- [ ] Open PR with SRED tag (`Relates to NewGraphEnvironment/sred-2025-2026#24`), link to #48, note closing of #48.
+
+## Versions at start
+
+- fresh: 0.14.0
+- link: main (0.6.0, target 0.7.0)
+- bcfishpass: ea3c5d8
+- fwapg: Docker (FWA 20240830)

--- a/tests/testthat/test-lnk_pipeline_prepare.R
+++ b/tests/testthat/test-lnk_pipeline_prepare.R
@@ -46,6 +46,20 @@ test_that(".lnk_quote_literal doubles single-quotes", {
 
 # -- prep_gradient SQL shape (mocked) ---------------------------------------
 
+.cfg_no_control <- structure(list(overrides = list()),
+  class = c("lnk_config", "list"))
+.cfg_with_control <- structure(list(
+  overrides = list(
+    barriers_definite_control = data.frame(
+      blue_line_key = 1L,
+      downstream_route_measure = 1,
+      barrier_ind = "t",
+      watershed_group_code = "ADMS",
+      stringsAsFactors = FALSE
+    )
+  )
+), class = c("lnk_config", "list"))
+
 test_that(".lnk_pipeline_prep_gradient quotes aoi safely in the streams_blk query", {
   captured <- character(0)
   local_mocked_bindings(
@@ -55,27 +69,23 @@ test_that(".lnk_pipeline_prep_gradient quotes aoi safely in the streams_blk quer
     }
   )
   local_mocked_bindings(
-    dbGetQuery = function(conn, sql, ...) {
-      data.frame()                 # pretend no control table exists
-    },
-    .package = "DBI"
-  )
-  # Mock frs_break_find to no-op so we don't need a DB
-  local_mocked_bindings(
     frs_break_find = function(...) invisible(NULL),
     .package = "fresh"
   )
 
-  .lnk_pipeline_prep_gradient("mock-conn", aoi = "BULK", schema = "w")
+  .lnk_pipeline_prep_gradient("mock-conn", aoi = "BULK",
+    cfg = .cfg_no_control, schema = "w")
 
   joined <- paste(captured, collapse = "\n")
   expect_match(joined, "CREATE TABLE w.streams_blk")
   expect_match(joined, "watershed_group_code = 'BULK'")
   expect_match(joined, "edge_type != 6010")
   expect_match(joined, "ADD COLUMN IF NOT EXISTS wscode_ltree ltree")
+  # Without the manifest key, no control-prune DELETE is emitted.
+  expect_no_match(joined, "DELETE FROM w.gradient_barriers_raw")
 })
 
-test_that(".lnk_pipeline_prep_gradient prunes by control when control table exists", {
+test_that(".lnk_pipeline_prep_gradient prunes when manifest declares control", {
   captured <- character(0)
   local_mocked_bindings(
     .lnk_db_execute = function(conn, sql) {
@@ -84,18 +94,12 @@ test_that(".lnk_pipeline_prep_gradient prunes by control when control table exis
     }
   )
   local_mocked_bindings(
-    dbGetQuery = function(conn, sql, ...) {
-      # Pretend control table exists
-      data.frame(x = 1L)
-    },
-    .package = "DBI"
-  )
-  local_mocked_bindings(
     frs_break_find = function(...) invisible(NULL),
     .package = "fresh"
   )
 
-  .lnk_pipeline_prep_gradient("mock-conn", aoi = "ADMS", schema = "w_adms")
+  .lnk_pipeline_prep_gradient("mock-conn", aoi = "ADMS",
+    cfg = .cfg_with_control, schema = "w_adms")
 
   joined <- paste(captured, collapse = "\n")
   expect_match(joined, "DELETE FROM w_adms.gradient_barriers_raw g")
@@ -222,12 +226,6 @@ test_that(".lnk_pipeline_prep_overrides passes control when manifest declares it
       invisible(NULL)
     }
   )
-  local_mocked_bindings(
-    dbGetQuery = function(conn, sql, ...) {
-      data.frame()                   # no habitat table
-    },
-    .package = "DBI"
-  )
 
   .lnk_pipeline_prep_overrides("mock-conn", cfg = cfg_stub,
     schema = "working_bulk", observations = "bcfishobs.observations")
@@ -255,15 +253,71 @@ test_that(".lnk_pipeline_prep_overrides passes control = NULL when manifest omit
       invisible(NULL)
     }
   )
-  local_mocked_bindings(
-    dbGetQuery = function(conn, sql, ...) {
-      data.frame()
-    },
-    .package = "DBI"
-  )
 
   .lnk_pipeline_prep_overrides("mock-conn", cfg = cfg_stub,
     schema = "working_bulk", observations = "bcfishobs.observations")
 
   expect_null(captured$args$control)
+})
+
+# -- prep_overrides habitat pass-through (manifest-driven) -------------------
+
+test_that(".lnk_pipeline_prep_overrides passes habitat when manifest declares it", {
+  cfg_stub <- structure(list(
+    parameters_fresh = data.frame(
+      species_code = "BT",
+      observation_threshold = 1L,
+      observation_date_min = "2000-01-01",
+      observation_buffer_m = 20,
+      observation_species = "BT",
+      stringsAsFactors = FALSE
+    ),
+    overrides = list(),
+    habitat_classification = data.frame(
+      blue_line_key = 1L,
+      species_code = "BT",
+      stringsAsFactors = FALSE
+    )
+  ), class = c("lnk_config", "list"))
+
+  captured <- list()
+  local_mocked_bindings(
+    lnk_barrier_overrides = function(conn, ...) {
+      captured[["args"]] <<- list(...)
+      invisible(NULL)
+    }
+  )
+
+  .lnk_pipeline_prep_overrides("mock-conn", cfg = cfg_stub,
+    schema = "working_bulk", observations = "bcfishobs.observations")
+
+  expect_equal(captured$args$habitat,
+    "working_bulk.user_habitat_classification")
+})
+
+test_that(".lnk_pipeline_prep_overrides passes habitat = NULL when manifest omits it", {
+  cfg_stub <- structure(list(
+    parameters_fresh = data.frame(
+      species_code = "BT",
+      observation_threshold = 1L,
+      observation_date_min = "2000-01-01",
+      observation_buffer_m = 20,
+      observation_species = "BT",
+      stringsAsFactors = FALSE
+    ),
+    overrides = list()
+  ), class = c("lnk_config", "list"))
+
+  captured <- list()
+  local_mocked_bindings(
+    lnk_barrier_overrides = function(conn, ...) {
+      captured[["args"]] <<- list(...)
+      invisible(NULL)
+    }
+  )
+
+  .lnk_pipeline_prep_overrides("mock-conn", cfg = cfg_stub,
+    schema = "working_bulk", observations = "bcfishobs.observations")
+
+  expect_null(captured$args$habitat)
 })


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Two `information_schema.tables` probes in `R/lnk_pipeline_prepare.R` replaced with direct checks against the `lnk_config` manifest:

- `.lnk_pipeline_prep_gradient()` gains a `cfg` parameter. The probe for `<schema>.barriers_definite_control` before the gradient-barrier `DELETE` is now `!is.null(cfg$overrides$barriers_definite_control)`. Caller in `lnk_pipeline_prepare()` updated.
- `.lnk_pipeline_prep_overrides()` probe for `<schema>.user_habitat_classification` replaced with `!is.null(cfg$habitat_classification)`.

Rationale: the config manifest is the declarative contract for which capabilities a pipeline variant activates. The old probes worked because `.lnk_pipeline_prep_load_aux()` writes each table exactly when the manifest declares the key, but that indirection made empty-table edge cases easier to miss — the asymmetric-gating bug fixed in #44 was rooted in this exact seam. Manifest-key gating is consistent with the per-capability pattern introduced in #44 for the barrier-override control wiring.

## Secondary fix (surfaced by code-check)

Round 1 of `/code-check` caught a matching asymmetry on the habitat side: the new manifest gate at `prep_overrides` would return non-NULL for a degenerate (header-only) `habitat_classification` CSV, but `.lnk_pipeline_prep_load_aux()` wrote no table in that case, so `lnk_barrier_overrides()` would error on `SELECT` from a missing relation. Fixed by mirroring the `barriers_definite_control` pattern: always create a schema-valid `user_habitat_classification` table when the manifest declares the key (empty or populated). The manifest key is now the true contract on both sides.

## Verification

- [x] `devtools::test()` — 282 PASS, 0 FAIL.
- [x] Two consecutive `tar_destroy + tar_make` produce rollup with digest `50908d234e2131fc0842dc3ab653ae78` (46 rows) — **bit-identical** to the post-#48 baseline.
- [x] Second rebuild after the empty-stub fix also bit-identical.
- [x] `/code-check` round 1 clean on the original 4 checks; flagged the empty-stub asymmetry which was fixed before commit.
- [x] Tests: replaced `DBI::dbGetQuery` mocks in `prep_gradient` tests with `cfg` stubs; added two new tests covering the `prep_overrides` habitat gate (declared/omitted).

Fixes #46
Relates to NewGraphEnvironment/sred-2025-2026#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
