### PR TITLE
#55: ingest user_habitat_classification overlay

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     bcdata,
     bookdown,
     dplyr,
-    fresh (>= 0.17.1),
+    fresh (>= 0.19.0),
     knitr,
     lintr,
     mapgl,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     bcdata,
     bookdown,
     dplyr,
-    fresh (>= 0.20.0),
+    fresh (>= 0.21.0),
     knitr,
     lintr,
     mapgl,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Crossing Connectivity Interpretation
-Version: 0.8.0
+Version: 0.9.0
 Authors@R:
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     bcdata,
     bookdown,
     dplyr,
-    fresh (>= 0.19.0),
+    fresh (>= 0.20.0),
     knitr,
     lintr,
     mapgl,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# link 0.9.0
+
+`lnk_pipeline_classify()` now overlays known habitat from `user_habitat_classification.csv` onto `fresh.streams_habitat` after rule-based classification. Closes [#55](https://github.com/NewGraphEnvironment/link/issues/55).
+
+- After `frs_habitat_classify()` finishes, calls `frs_habitat_overlay()` (fresh ≥ 0.21.0) when the manifest declares `habitat_classification`. Loaded long-format table is overlaid via a 3-way bridge join through `fresh.streams` (range containment on `[drm, urm]`).
+- Closes the gap surfaced in research doc §5/§7: bcfishpass's published `streams_habitat_linear.spawning_sk > 0` blends model + observation-curated knowns; link's pipeline previously only emitted the model side.
+- 5-WSG rerun (digest `0f00c713`) shows BABL SK spawning under bcfishpass bundle rises from 57.6 → 85.2 km (+27.6 km from overlay). ADMS SK +5.14 km, BULK SK +0.8 km. Default bundle similar magnitudes.
+- Requires fresh ≥ 0.21.0 (overlay rename + bridge support; see fresh#175).
+
 # link 0.8.0
 
 Default NewGraph habitat-classification config bundle ships alongside the bcfishpass reproduction bundle ([#51](https://github.com/NewGraphEnvironment/link/issues/51)).

--- a/R/lnk_pipeline_classify.R
+++ b/R/lnk_pipeline_classify.R
@@ -81,18 +81,6 @@ lnk_pipeline_classify <- function(conn, aoi, cfg, schema,
     csv = thresholds_csv,
     rules_yaml = cfg$rules_yaml)
 
-  # Optional known-habitat overlay: when the manifest declares
-  # `user_habitat_classification`, the table was loaded into
-  # `<schema>.user_habitat_classification` by .lnk_pipeline_prep_load_aux.
-  # fresh::frs_habitat_classify(known = ...) then calls
-  # frs_habitat_overlay() as a post-step, ORing in TRUE flags from the
-  # bcfishpass-style {habitat}_{species_lower} columns.
-  known_arg <- if (!is.null(cfg$overrides$user_habitat_classification)) {
-    paste0(schema, ".user_habitat_classification")
-  } else {
-    NULL
-  }
-
   fresh::frs_habitat_classify(conn,
     table = "fresh.streams",
     to = "fresh.streams_habitat",
@@ -102,8 +90,25 @@ lnk_pipeline_classify <- function(conn, aoi, cfg, schema,
     gate = TRUE,
     label_block = "blocked",
     barrier_overrides = paste0(schema, ".barrier_overrides"),
-    known = known_arg,
     verbose = FALSE)
+
+  # Known-habitat overlay (optional). When the manifest declares
+  # `habitat_classification`, the CSV is loaded into
+  # `<schema>.user_habitat_classification` by .lnk_pipeline_prep_load_aux.
+  # We call frs_habitat_overlay directly here (not via classify's
+  # `known =` arg) because the loaded table is long-format
+  # (one row per segment x species x habitat_type with habitat_ind
+  # text), and the classify orchestrator hardcodes wide-format.
+  # See fresh#172 for background.
+  if (!is.null(cfg$habitat_classification)) {
+    fresh::frs_habitat_overlay(conn,
+      table = "fresh.streams_habitat",
+      known = paste0(schema, ".user_habitat_classification"),
+      species = species,
+      format = "long",
+      long_value_col = "habitat_ind",
+      verbose = FALSE)
+  }
 
   invisible(conn)
 }

--- a/R/lnk_pipeline_classify.R
+++ b/R/lnk_pipeline_classify.R
@@ -81,6 +81,18 @@ lnk_pipeline_classify <- function(conn, aoi, cfg, schema,
     csv = thresholds_csv,
     rules_yaml = cfg$rules_yaml)
 
+  # Optional known-habitat overlay: when the manifest declares
+  # `user_habitat_classification`, the table was loaded into
+  # `<schema>.user_habitat_classification` by .lnk_pipeline_prep_load_aux.
+  # fresh::frs_habitat_classify(known = ...) then calls
+  # frs_habitat_overlay() as a post-step, ORing in TRUE flags from the
+  # bcfishpass-style {habitat}_{species_lower} columns.
+  known_arg <- if (!is.null(cfg$overrides$user_habitat_classification)) {
+    paste0(schema, ".user_habitat_classification")
+  } else {
+    NULL
+  }
+
   fresh::frs_habitat_classify(conn,
     table = "fresh.streams",
     to = "fresh.streams_habitat",
@@ -90,6 +102,7 @@ lnk_pipeline_classify <- function(conn, aoi, cfg, schema,
     gate = TRUE,
     label_block = "blocked",
     barrier_overrides = paste0(schema, ".barrier_overrides"),
+    known = known_arg,
     verbose = FALSE)
 
   invisible(conn)

--- a/R/lnk_pipeline_classify.R
+++ b/R/lnk_pipeline_classify.R
@@ -94,16 +94,17 @@ lnk_pipeline_classify <- function(conn, aoi, cfg, schema,
 
   # Known-habitat overlay (optional). When the manifest declares
   # `habitat_classification`, the CSV is loaded into
-  # `<schema>.user_habitat_classification` by .lnk_pipeline_prep_load_aux.
-  # We call frs_habitat_overlay directly here (not via classify's
-  # `known =` arg) because the loaded table is long-format
-  # (one row per segment x species x habitat_type with habitat_ind
-  # text), and the classify orchestrator hardcodes wide-format.
-  # See fresh#172 for background.
+  # `<schema>.user_habitat_classification` (long-format: one row per
+  # segment x species x habitat_type with `habitat_ind` text).
+  # The target `fresh.streams_habitat` is keyed by `id_segment` only,
+  # and the source is keyed by `(blue_line_key, drm)` with range
+  # `[drm, urm]` — so we need a 3-way bridge through `fresh.streams`
+  # for range containment. Requires fresh >= 0.21.0.
   if (!is.null(cfg$habitat_classification)) {
     fresh::frs_habitat_overlay(conn,
-      table = "fresh.streams_habitat",
-      known = paste0(schema, ".user_habitat_classification"),
+      from   = paste0(schema, ".user_habitat_classification"),
+      to     = "fresh.streams_habitat",
+      bridge = "fresh.streams",
       species = species,
       format = "long",
       long_value_col = "habitat_ind",

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,45 +1,35 @@
-# Findings — #51 (configs/default/ + compound rollup)
+# Findings
 
-## Architecture audit already done (before PR)
+## fresh 0.19.0 API to use
 
-- fresh code has zero hardcoded `fresh.streams` references (fresh#163 closed clean). Pipeline helpers honour caller-supplied table paths.
-- `frs_aggregate()` already polygon-capable. `fwa_lakes_poly` + `fwa_wetlands_poly` both have `wscode_ltree`, `localcode_ltree`, `area_ha` — aggregation is a one-liner at the link rollup layer. No fresh extension needed.
-- `frs_habitat_classify()` now has `wetland_rearing` column (fresh 0.16.0 via PR #164). Same pattern as `lake_rearing`, joined to `fwa_wetlands_poly`.
+```r
+fresh::frs_habitat_classify(conn, table, to,
+  species = ..., params = ..., params_fresh = ...,
+  gate = TRUE, label_block = "blocked",
+  barrier_overrides = "<schema>.barrier_overrides",
+  known = "<schema>.user_habitat_classification",   # NEW
+  overwrite = TRUE, verbose = TRUE)
+```
 
-## Source material already in repo
+When `known` is non-NULL, classify calls `frs_habitat_overlay(conn, table = to, known = known, species = species, verbose = verbose)` after the rule-based classification finishes.
 
-- `inst/extdata/parameters_habitat_dimensions.csv` — the newgraph-default dimensions CSV. Per-species booleans for lake/wetland/stream spawn+rear, `river_skip_cw_min`, connectivity requirements. Already encodes the expected deltas from bcfishpass (e.g. BT: `rear_lake=yes, rear_wetland=yes, river_skip_cw_min=yes`; bcfishpass variant has `rear_lake=no, rear_wetland=no`).
-- `inst/extdata/configs/bcfishpass/dimensions.csv` — 19-column schema (has bcfishpass-specific columns like `rear_stream_order_bypass`, `spawn_connected_*`).
-- `inst/extdata/parameters_habitat_dimensions.csv` — 15-column schema (missing the 4 bcfishpass-specific columns).
+## user_habitat_classification table shape
 
-Open question: does `lnk_rules_build()` handle both schemas cleanly? The default CSV is a subset of the bcfishpass CSV columns — probably fine, but verify during Phase 1.
+From `R/lnk_pipeline_prepare.R` (line 170+):
 
-## bcfishpass-specific columns we skip in the default
+```sql
+CREATE TABLE <schema>.user_habitat_classification (
+  -- exactly the bcfishpass user_habitat_classification.csv schema
+  -- has linear_feature_id, blue_line_key, downstream_route_measure,
+  -- upstream_route_measure, plus per-species spawning_<sp> and
+  -- rearing_<sp> columns
+)
+```
 
-`rear_stream_order_bypass`, `spawn_connected_direction`, `spawn_connected_gradient_max`, `spawn_connected_cw_min`, `spawn_connected_edge_types` — these are bcfishpass method-specific features we intentionally don't ship in the default. The default dimensions CSV reflects this by omitting the columns entirely.
+Loaded from `inst/extdata/configs/<bundle>/overrides/user_habitat_classification.csv` by `.lnk_pipeline_prep_load_aux()`.
 
-## Documented biological departures from bcfishpass (to encode + defend)
+The default join key in `frs_habitat_overlay` is `c("blue_line_key", "downstream_route_measure")` — matches the loaded columns directly. No custom `by =` needed.
 
-From archived planning + the dimensions CSV:
+## Gating: table presence check
 
-| Decision | bcfishpass | NGE default | Present in default dimensions.csv |
-|---|---|---|---|
-| Intermittent streams | excluded | included | needs edge-type rule check |
-| Wetland segments | limited | CO rearing 1050/1150 | `rear_wetland=yes` for CO/BT/others |
-| Spawn gradient min | 0 | 0.0025 | check `parameters_fresh.csv` or rules |
-| River polygon cw_min | applied | skipped | `river_skip_cw_min=yes` |
-| Lake rearing species | SK/KO only | expanded | `rear_lake=yes` for BT/CO/ST/WCT |
-
-Research doc captures each with biological rationale + link to literature as discovered.
-
-## Rollup decision (resolved)
-
-Option B — three compound columns. Never fold to one. Enables queries like "areas with lots of wetland but short linear extent" that the user flagged as important.
-
-- `rearing_km` — sum segment length where rearing = TRUE. **Probably exclude lake/wetland centerlines** to avoid double-counting with the `_ha` columns. Finalize in Phase 2.
-- `lake_rearing_ha` — sum `area_ha` from `fwa_lakes_poly` upstream of point + waterbody_key matches accessible segment's lake_rearing = TRUE.
-- `wetland_rearing_ha` — same against `fwa_wetlands_poly`.
-
-## Temperature / thermal out of scope
-
-Deferred to a separate config variant (e.g. `configs/default-thermal/`) once Poisson SSN + Hillcrest CW regression + water-temp-bc compose. Multi-month integration.
+`lnk_pipeline_prepare` only loads `user_habitat_classification` when `cfg$overrides` declares it. Same pattern in `lnk_pipeline_classify`: gate on `cfg$overrides$user_habitat_classification` being non-NULL before passing `known =`.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,30 +1,9 @@
 # Progress
 
-## Session 2026-04-24 — #51 kickoff
+## Session 2026-04-25 — link#55
 
-- fresh#164 merged + tagged v0.16.0 (wetland_rearing column).
-- Branched `51-configs-default-compound-rollup` off link main.
-- M1 synced: fresh 0.16.0 installed, link main up to date.
-- Initialized PWF.
-- Next: Phase 1 scaffolding — DESCRIPTION bump + `inst/extdata/configs/default/` bundle assembly.
-- Phase 1 shipped (commit `9cc30fc`) — `inst/extdata/configs/default/` bundle + fresh pin (>= 0.16.0) + PWF init. `lnk_config("default")` loads cleanly.
-- Comms — closed (not really) then reopened by rtj-claude with explicit asks. Ran `habitat-classify-test` baselines: M4 4m45s, M1 4m20s. Logs + README rows committed to rtj main (`b0345c5`). Thread closed (`3465ec2`).
-- Caveat on those baselines — versions didn't match (M4 fresh 0.14.0 vs M1 fresh 0.16.0; M1 link 0.1.0 vs M4 link 0.7.0). Need rebaseline with version-matched envs.
-- rtj driver patch (`d83cbb5`) — install workloads now use `upgrade = FALSE, ask = FALSE` (caught pak trying to tail-upgrade Rcpp to a CRAN Transit release that doesn't exist).
-- Phase 2 shipped (commit `7ddbac7`) — compound rollup in `compare_bcfishpass_wsg.R`. 4 rows per species (spawning/rearing in km, lake_rearing/wetland_rearing in ha). Option b-amended on bcfishpass side — same methodology joining `habitat_linear_<sp>` + `fwa_*_poly`. Smoke-tested link-side against DEAD: sensible nonzero values.
-- Phase 3 shipped (commit `7f0ff9c`) — `_targets.R` runs both configs side-by-side, unified rollup with `config` identity column.
-- Phase 4 doc scaffold (commit `b534318`) — `research/default_vs_bcfishpass.md` with methodology + departures + TBD tables.
-- Compare fn gate-on-existence fix (commit `0d49bf5`) — species without `habitat_linear_<sp>` (e.g. RB in bcfishpass) now return zeros on the reference side rather than erroring.
-- Full 10-target `tar_make()` on M1: rollup pulled to M4 at `/tmp/rollup_51.rds`, 204 rows, digest `4a04a6e6932262d779e6f0aba7e19723`.
-- Phase 4 tables populated — `research/default_vs_bcfishpass.md` now carries numeric results for all 5 WSGs with observations section.
-- Four key findings captured in research doc: (1) `lake_rearing_ha` / `wetland_rearing_ha` identical across configs — fresh classifier ignores dimensions.csv `rear_lake` / `rear_wetland` flags (gap to file); (2) km inflation under default driven by intermittent + river-polygon + spawn-gradient departures; (3) SK spawning inflates massively because `spawn_connected` rule not yet in default bundle (blocked on fresh#133); (4) RB newly modeled under default across all WSGs.
-- fresh follow-up filed as [fresh#165](https://github.com/NewGraphEnvironment/fresh/issues/165) for the classifier gap on `rear_lake` / `rear_wetland` flags.
-- PR #54 opened targeting main.
-- User feedback: address SK `spawn_connected` distortion in this PR, not defer. Investigation found fresh#133 already merged (2026-04-12) — the bug was entirely in `configs/default/dimensions.csv`: missing 5 columns (`rear_stream_order_bypass`, `spawn_connected_direction`, `spawn_connected_gradient_max`, `spawn_connected_cw_min`, `spawn_connected_edge_types`) that `lnk_rules_build()` needs to emit the `spawn_connected:` YAML block. Without `direction: downstream`, fresh applies the 3km connected-distance filter in any direction.
-- Fix committed (`c215b1f`) — added the 5 columns to the CSV, populated SK + KO with matching bcfishpass values, regenerated `rules.yaml`. First M1 rerun (19m52s) showed SK spawning numbers unchanged — spawn_connected YAML block alone wasn't the driver.
-- Root-caused further: `spawn_lake=yes` in default for SK/KO was emitting a `waterbody_type: L` spawn rule. Lake centerlines (Babine 177 km) were counting as SK spawning habitat within the 3 km connected-distance cap. Real bug.
-- Fix committed (`a65942a`) — `spawn_lake=no` for SK + KO in default, regenerated rules.yaml. Matches bcfishpass convention (stream-spawning sockeye only).
-- Second M1 rerun (19m14s) confirms: SK spawning deltas shrink from 10-20× to order-of-magnitude-reasonable — ADMS +4.45 km, BULK +17.9 km, BABL +93.3 km, DEAD +0 km. Residual lift explained by intermittent + river-polygon departures.
-- Workflow-hygiene lessons codified: `link/CLAUDE.md` gained a "Config change workflow" section (commit `9e45858`); soul r-packages convention updated to "bump version as final branch commit" (soul commit `78cb772`).
-- Research doc per-WSG tables + observation #3 refreshed with post-fix numbers.
-- Next: commit research doc refresh + progress update, verify final state, close PR.
+- Branched `55-call-frs-habitat-overlay` off main (post v0.8.0 tag).
+- fresh v0.19.0 just merged + tagged. API ready: `frs_habitat_classify(known = ...)` calls overlay automatically.
+- PWF baseline. Plan in task_plan.md.
+
+Next: bump fresh pin, install both machines, wire `known` arg in lnk_pipeline_classify.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,56 +1,44 @@
-# Task Plan: configs/default/ + compound rollup (#51)
+# Task: Call frs_habitat_overlay from lnk_pipeline_classify (link#55)
+
+fresh v0.19.0 ships `frs_habitat_overlay()` (renamed from `frs_habitat_known`) plus a `known = NULL` parameter on `frs_habitat_classify()` that calls overlay automatically. link's pipeline already loads `user_habitat_classification.csv` into `<schema>.user_habitat_classification` via `lnk_pipeline_prepare()` — we just need to pass that table to fresh.
 
 ## Goal
 
-Ship a runnable NGE default habitat-classification config bundle, distinct from the bcfishpass reference. Prove the config-swap architecture works end-to-end, surface per-WSG comparison numbers between default + bcfishpass, produce research visuals and rollup tables. Prerequisite fresh PR (#164) shipped as fresh 0.16.0 — `wetland_rearing` boolean column now in `streams_habitat` output.
+Wire `<schema>.user_habitat_classification` into the `frs_habitat_classify()` call inside `lnk_pipeline_classify()` via the new `known` arg. Result: link's pipeline output now matches bcfishpass's `streams_habitat_linear.spawning_sk > 0` (model + known) instead of just `habitat_linear_sk.spawning` (model-only).
 
-Resolved design decisions (from comms thread discussion):
-- Option B rollup: separate columns for `rearing_km`, `lake_rearing_ha`, `wetland_rearing_ha`. No multiplier.
-- New `wetland_rearing` column on `streams_habitat` (shipped in fresh 0.16.0).
-- Species lake-rearing list is already in `inst/extdata/parameters_habitat_dimensions.csv`.
-- Polygon-area aggregation uses existing `frs_aggregate()` — no fresh extension needed.
+Closes the ~60 km BABL SK csv_only gap documented in `research/default_vs_bcfishpass.md` §6/§7.
 
-## Phase 1: config bundle scaffolding
+## Phases
 
-- [ ] `DESCRIPTION` — pin `fresh (>= 0.16.0)` under Imports.
-- [ ] `inst/extdata/configs/default/config.yaml` — manifest mirroring the bcfishpass variant's shape, pointing at the default-specific CSVs and shared override mirror.
-- [ ] `inst/extdata/configs/default/dimensions.csv` — copy of existing `inst/extdata/parameters_habitat_dimensions.csv` (already encodes the newgraph deltas: rear_lake=yes, rear_wetland=yes, river_skip_cw_min=yes for BT, etc.).
-- [ ] `inst/extdata/configs/default/parameters_fresh.csv` — start as copy of bcfishpass variant; annotate deltas if any emerge during testing.
-- [ ] `inst/extdata/configs/default/rules.yaml` — generate via `lnk_rules_build()` from the default dimensions.csv.
-- [ ] `inst/extdata/configs/default/overrides/` — either symlink or copy the bcfishpass mirror (shared physical barriers / modelled fixes / PSCIS overrides are jurisdiction data, not method choice).
-- [ ] Verify: `lnk_config("default")` loads cleanly; fields match bcfishpass variant shape.
+- [ ] Phase 1 — PWF baseline
+- [ ] Phase 2 — Bump link DESCRIPTION → fresh (>= 0.19.0)
+- [ ] Phase 3 — Install fresh 0.19.0 on m4 + m1
+- [ ] Phase 4 — Wire `known = paste0(schema, ".user_habitat_classification")` into the `frs_habitat_classify()` call inside `R/lnk_pipeline_classify.R`. Gate on table existence (matches the pattern already in `lnk_pipeline_prepare`).
+- [ ] Phase 5 — Pre-flight ADMS (single WSG, both bundles). Verify Shass Creek now shows as SK spawning under bcfishpass bundle. Frame against bcfp departures.
+- [ ] Phase 6 — Full 5-WSG rerun via rtj harness. Verify BABL SK spawning under bcfishpass bundle rises from ~57.6 km toward ~132 km.
+- [ ] Phase 7 — Refresh research doc per-WSG tables + observation §6
+- [ ] Phase 8 — NEWS entry + version bump → 0.9.0
+- [ ] Phase 9 — Mocked unit tests on the wiring
+- [ ] Phase 10 — `/code-check` on the diff
+- [ ] Phase 11 — Full link suite via rtj harness
+- [ ] Phase 12 — PR, fix link#55
 
-## Phase 2: compound rollup
+## Critical files
 
-- [ ] `lnk_aggregate()` extended to produce the three-column rollup — `rearing_km` (stream segments), `lake_rearing_ha`, `wetland_rearing_ha`. Polygon-area calls use `frs_aggregate()` with `fwa_lakes_poly` + `fwa_wetlands_poly` as feature tables.
-- [ ] Decide whether to exclude lake/wetland centerline segments from `rearing_km` (to avoid double-counting once area is in its own column). Research doc captures the decision and rationale.
-- [ ] Update `compare_bcfishpass_wsg()` to return the compound rollup — bcfishpass comparison is per-column, not single `diff_pct`.
+- `R/lnk_pipeline_classify.R`
+- `DESCRIPTION`
+- `NEWS.md`
+- `research/default_vs_bcfishpass.md`
 
-## Phase 3: targets pipeline
+## Acceptance
 
-- [ ] `data-raw/_targets.R` — extend with `comparison_default_<wsg>` targets mirroring the bcfishpass ones, using `lnk_config("default")`.
-- [ ] Rollup target gains bundle identity — either long format (`config`, `wsg`, `species`, `habitat_type`, ...) or per-config rollup with a suffix.
-- [ ] Bit-identical reproducibility across consecutive runs per config.
+- ADMS preflight: bcfishpass-bundle SK spawning rises from 88.83 → ~132 km. Shass Creek shows non-zero spawning km.
+- 5-WSG rerun completes clean (~20 min).
+- Research doc tables refreshed.
+- `default_catches_known` bucket non-zero in §6.
 
-## Phase 4: research doc + artifacts
+## Risks
 
-- [ ] `research/default_vs_bcfishpass.md` — per-WSG per-species per-column comparison, biological rationale paragraph per departure.
-- [ ] Visuals for the research doc: per-WSG pivot of rearing_km / lake_rearing_ha / wetland_rearing_ha, highlighted where default > bcfishpass vs default < bcfishpass.
-- [ ] Vignette updates — `reproducing-bcfishpass.Rmd` might need a sibling or a note pointing at default config once shipped.
-
-## Phase 5: ship
-
-- [ ] NEWS entry for 0.8.0.
-- [ ] DESCRIPTION bump 0.7.0 → 0.8.0.
-- [ ] `/code-check` on staged diff.
-- [ ] PR with SRED tag.
-
-## Dispatch strategy
-
-Run heavy work on M1 (targets, local_install, vignette regen) so M4 stays free for interactive work. Always sync M1 (`git pull` + `pak::local_install()`) before dispatching.
-
-## Versions at start
-
-- fresh: 0.16.0 (just shipped)
-- link: 0.7.0 → 0.8.0 target
-- bcfishpass: ea3c5d8 (reference config)
+- **Reproducibility regression** vs v3-v6 expected (the whole point — outputs change).
+- **Performance:** ~40 UPDATEs per WSG (9-11 species × 4 habitat types). Should be fast.
+- **Schema column mismatch:** `user_habitat_classification` loaded by link must have `(blue_line_key, downstream_route_measure)` for the default `by` join key.

--- a/planning/archive/2026-04-issue-51-configs-default/README.md
+++ b/planning/archive/2026-04-issue-51-configs-default/README.md
@@ -1,0 +1,10 @@
+# Issue #51 — configs/default/ + compound rollup
+
+**Closed:** 2026-04-25
+**Tag:** v0.8.0
+**Result:** Default NewGraph config bundle ships alongside bcfishpass reproduction. Per-species rear_lake_ha_min + rear_wetland_ha_min plumbing. Compound rollup with edge-type slices. Full per-WSG comparison + research doc with 9 observations. Three mapgl overlays. fresh#165, #166, #169 surfaced + fixed.
+
+## Closing artefacts
+- PR: https://github.com/NewGraphEnvironment/link/pull/54
+- Tag: v0.8.0
+- Follow-ups: link#55 (this work), link#56 (CSV sync action), fresh#167 (suite speedup)

--- a/planning/archive/2026-04-issue-51-configs-default/findings.md
+++ b/planning/archive/2026-04-issue-51-configs-default/findings.md
@@ -1,0 +1,45 @@
+# Findings — #51 (configs/default/ + compound rollup)
+
+## Architecture audit already done (before PR)
+
+- fresh code has zero hardcoded `fresh.streams` references (fresh#163 closed clean). Pipeline helpers honour caller-supplied table paths.
+- `frs_aggregate()` already polygon-capable. `fwa_lakes_poly` + `fwa_wetlands_poly` both have `wscode_ltree`, `localcode_ltree`, `area_ha` — aggregation is a one-liner at the link rollup layer. No fresh extension needed.
+- `frs_habitat_classify()` now has `wetland_rearing` column (fresh 0.16.0 via PR #164). Same pattern as `lake_rearing`, joined to `fwa_wetlands_poly`.
+
+## Source material already in repo
+
+- `inst/extdata/parameters_habitat_dimensions.csv` — the newgraph-default dimensions CSV. Per-species booleans for lake/wetland/stream spawn+rear, `river_skip_cw_min`, connectivity requirements. Already encodes the expected deltas from bcfishpass (e.g. BT: `rear_lake=yes, rear_wetland=yes, river_skip_cw_min=yes`; bcfishpass variant has `rear_lake=no, rear_wetland=no`).
+- `inst/extdata/configs/bcfishpass/dimensions.csv` — 19-column schema (has bcfishpass-specific columns like `rear_stream_order_bypass`, `spawn_connected_*`).
+- `inst/extdata/parameters_habitat_dimensions.csv` — 15-column schema (missing the 4 bcfishpass-specific columns).
+
+Open question: does `lnk_rules_build()` handle both schemas cleanly? The default CSV is a subset of the bcfishpass CSV columns — probably fine, but verify during Phase 1.
+
+## bcfishpass-specific columns we skip in the default
+
+`rear_stream_order_bypass`, `spawn_connected_direction`, `spawn_connected_gradient_max`, `spawn_connected_cw_min`, `spawn_connected_edge_types` — these are bcfishpass method-specific features we intentionally don't ship in the default. The default dimensions CSV reflects this by omitting the columns entirely.
+
+## Documented biological departures from bcfishpass (to encode + defend)
+
+From archived planning + the dimensions CSV:
+
+| Decision | bcfishpass | NGE default | Present in default dimensions.csv |
+|---|---|---|---|
+| Intermittent streams | excluded | included | needs edge-type rule check |
+| Wetland segments | limited | CO rearing 1050/1150 | `rear_wetland=yes` for CO/BT/others |
+| Spawn gradient min | 0 | 0.0025 | check `parameters_fresh.csv` or rules |
+| River polygon cw_min | applied | skipped | `river_skip_cw_min=yes` |
+| Lake rearing species | SK/KO only | expanded | `rear_lake=yes` for BT/CO/ST/WCT |
+
+Research doc captures each with biological rationale + link to literature as discovered.
+
+## Rollup decision (resolved)
+
+Option B — three compound columns. Never fold to one. Enables queries like "areas with lots of wetland but short linear extent" that the user flagged as important.
+
+- `rearing_km` — sum segment length where rearing = TRUE. **Probably exclude lake/wetland centerlines** to avoid double-counting with the `_ha` columns. Finalize in Phase 2.
+- `lake_rearing_ha` — sum `area_ha` from `fwa_lakes_poly` upstream of point + waterbody_key matches accessible segment's lake_rearing = TRUE.
+- `wetland_rearing_ha` — same against `fwa_wetlands_poly`.
+
+## Temperature / thermal out of scope
+
+Deferred to a separate config variant (e.g. `configs/default-thermal/`) once Poisson SSN + Hillcrest CW regression + water-temp-bc compose. Multi-month integration.

--- a/planning/archive/2026-04-issue-51-configs-default/progress.md
+++ b/planning/archive/2026-04-issue-51-configs-default/progress.md
@@ -1,0 +1,30 @@
+# Progress
+
+## Session 2026-04-24 — #51 kickoff
+
+- fresh#164 merged + tagged v0.16.0 (wetland_rearing column).
+- Branched `51-configs-default-compound-rollup` off link main.
+- M1 synced: fresh 0.16.0 installed, link main up to date.
+- Initialized PWF.
+- Next: Phase 1 scaffolding — DESCRIPTION bump + `inst/extdata/configs/default/` bundle assembly.
+- Phase 1 shipped (commit `9cc30fc`) — `inst/extdata/configs/default/` bundle + fresh pin (>= 0.16.0) + PWF init. `lnk_config("default")` loads cleanly.
+- Comms — closed (not really) then reopened by rtj-claude with explicit asks. Ran `habitat-classify-test` baselines: M4 4m45s, M1 4m20s. Logs + README rows committed to rtj main (`b0345c5`). Thread closed (`3465ec2`).
+- Caveat on those baselines — versions didn't match (M4 fresh 0.14.0 vs M1 fresh 0.16.0; M1 link 0.1.0 vs M4 link 0.7.0). Need rebaseline with version-matched envs.
+- rtj driver patch (`d83cbb5`) — install workloads now use `upgrade = FALSE, ask = FALSE` (caught pak trying to tail-upgrade Rcpp to a CRAN Transit release that doesn't exist).
+- Phase 2 shipped (commit `7ddbac7`) — compound rollup in `compare_bcfishpass_wsg.R`. 4 rows per species (spawning/rearing in km, lake_rearing/wetland_rearing in ha). Option b-amended on bcfishpass side — same methodology joining `habitat_linear_<sp>` + `fwa_*_poly`. Smoke-tested link-side against DEAD: sensible nonzero values.
+- Phase 3 shipped (commit `7f0ff9c`) — `_targets.R` runs both configs side-by-side, unified rollup with `config` identity column.
+- Phase 4 doc scaffold (commit `b534318`) — `research/default_vs_bcfishpass.md` with methodology + departures + TBD tables.
+- Compare fn gate-on-existence fix (commit `0d49bf5`) — species without `habitat_linear_<sp>` (e.g. RB in bcfishpass) now return zeros on the reference side rather than erroring.
+- Full 10-target `tar_make()` on M1: rollup pulled to M4 at `/tmp/rollup_51.rds`, 204 rows, digest `4a04a6e6932262d779e6f0aba7e19723`.
+- Phase 4 tables populated — `research/default_vs_bcfishpass.md` now carries numeric results for all 5 WSGs with observations section.
+- Four key findings captured in research doc: (1) `lake_rearing_ha` / `wetland_rearing_ha` identical across configs — fresh classifier ignores dimensions.csv `rear_lake` / `rear_wetland` flags (gap to file); (2) km inflation under default driven by intermittent + river-polygon + spawn-gradient departures; (3) SK spawning inflates massively because `spawn_connected` rule not yet in default bundle (blocked on fresh#133); (4) RB newly modeled under default across all WSGs.
+- fresh follow-up filed as [fresh#165](https://github.com/NewGraphEnvironment/fresh/issues/165) for the classifier gap on `rear_lake` / `rear_wetland` flags.
+- PR #54 opened targeting main.
+- User feedback: address SK `spawn_connected` distortion in this PR, not defer. Investigation found fresh#133 already merged (2026-04-12) — the bug was entirely in `configs/default/dimensions.csv`: missing 5 columns (`rear_stream_order_bypass`, `spawn_connected_direction`, `spawn_connected_gradient_max`, `spawn_connected_cw_min`, `spawn_connected_edge_types`) that `lnk_rules_build()` needs to emit the `spawn_connected:` YAML block. Without `direction: downstream`, fresh applies the 3km connected-distance filter in any direction.
+- Fix committed (`c215b1f`) — added the 5 columns to the CSV, populated SK + KO with matching bcfishpass values, regenerated `rules.yaml`. First M1 rerun (19m52s) showed SK spawning numbers unchanged — spawn_connected YAML block alone wasn't the driver.
+- Root-caused further: `spawn_lake=yes` in default for SK/KO was emitting a `waterbody_type: L` spawn rule. Lake centerlines (Babine 177 km) were counting as SK spawning habitat within the 3 km connected-distance cap. Real bug.
+- Fix committed (`a65942a`) — `spawn_lake=no` for SK + KO in default, regenerated rules.yaml. Matches bcfishpass convention (stream-spawning sockeye only).
+- Second M1 rerun (19m14s) confirms: SK spawning deltas shrink from 10-20× to order-of-magnitude-reasonable — ADMS +4.45 km, BULK +17.9 km, BABL +93.3 km, DEAD +0 km. Residual lift explained by intermittent + river-polygon departures.
+- Workflow-hygiene lessons codified: `link/CLAUDE.md` gained a "Config change workflow" section (commit `9e45858`); soul r-packages convention updated to "bump version as final branch commit" (soul commit `78cb772`).
+- Research doc per-WSG tables + observation #3 refreshed with post-fix numbers.
+- Next: commit research doc refresh + progress update, verify final state, close PR.

--- a/planning/archive/2026-04-issue-51-configs-default/task_plan.md
+++ b/planning/archive/2026-04-issue-51-configs-default/task_plan.md
@@ -1,0 +1,56 @@
+# Task Plan: configs/default/ + compound rollup (#51)
+
+## Goal
+
+Ship a runnable NGE default habitat-classification config bundle, distinct from the bcfishpass reference. Prove the config-swap architecture works end-to-end, surface per-WSG comparison numbers between default + bcfishpass, produce research visuals and rollup tables. Prerequisite fresh PR (#164) shipped as fresh 0.16.0 — `wetland_rearing` boolean column now in `streams_habitat` output.
+
+Resolved design decisions (from comms thread discussion):
+- Option B rollup: separate columns for `rearing_km`, `lake_rearing_ha`, `wetland_rearing_ha`. No multiplier.
+- New `wetland_rearing` column on `streams_habitat` (shipped in fresh 0.16.0).
+- Species lake-rearing list is already in `inst/extdata/parameters_habitat_dimensions.csv`.
+- Polygon-area aggregation uses existing `frs_aggregate()` — no fresh extension needed.
+
+## Phase 1: config bundle scaffolding
+
+- [ ] `DESCRIPTION` — pin `fresh (>= 0.16.0)` under Imports.
+- [ ] `inst/extdata/configs/default/config.yaml` — manifest mirroring the bcfishpass variant's shape, pointing at the default-specific CSVs and shared override mirror.
+- [ ] `inst/extdata/configs/default/dimensions.csv` — copy of existing `inst/extdata/parameters_habitat_dimensions.csv` (already encodes the newgraph deltas: rear_lake=yes, rear_wetland=yes, river_skip_cw_min=yes for BT, etc.).
+- [ ] `inst/extdata/configs/default/parameters_fresh.csv` — start as copy of bcfishpass variant; annotate deltas if any emerge during testing.
+- [ ] `inst/extdata/configs/default/rules.yaml` — generate via `lnk_rules_build()` from the default dimensions.csv.
+- [ ] `inst/extdata/configs/default/overrides/` — either symlink or copy the bcfishpass mirror (shared physical barriers / modelled fixes / PSCIS overrides are jurisdiction data, not method choice).
+- [ ] Verify: `lnk_config("default")` loads cleanly; fields match bcfishpass variant shape.
+
+## Phase 2: compound rollup
+
+- [ ] `lnk_aggregate()` extended to produce the three-column rollup — `rearing_km` (stream segments), `lake_rearing_ha`, `wetland_rearing_ha`. Polygon-area calls use `frs_aggregate()` with `fwa_lakes_poly` + `fwa_wetlands_poly` as feature tables.
+- [ ] Decide whether to exclude lake/wetland centerline segments from `rearing_km` (to avoid double-counting once area is in its own column). Research doc captures the decision and rationale.
+- [ ] Update `compare_bcfishpass_wsg()` to return the compound rollup — bcfishpass comparison is per-column, not single `diff_pct`.
+
+## Phase 3: targets pipeline
+
+- [ ] `data-raw/_targets.R` — extend with `comparison_default_<wsg>` targets mirroring the bcfishpass ones, using `lnk_config("default")`.
+- [ ] Rollup target gains bundle identity — either long format (`config`, `wsg`, `species`, `habitat_type`, ...) or per-config rollup with a suffix.
+- [ ] Bit-identical reproducibility across consecutive runs per config.
+
+## Phase 4: research doc + artifacts
+
+- [ ] `research/default_vs_bcfishpass.md` — per-WSG per-species per-column comparison, biological rationale paragraph per departure.
+- [ ] Visuals for the research doc: per-WSG pivot of rearing_km / lake_rearing_ha / wetland_rearing_ha, highlighted where default > bcfishpass vs default < bcfishpass.
+- [ ] Vignette updates — `reproducing-bcfishpass.Rmd` might need a sibling or a note pointing at default config once shipped.
+
+## Phase 5: ship
+
+- [ ] NEWS entry for 0.8.0.
+- [ ] DESCRIPTION bump 0.7.0 → 0.8.0.
+- [ ] `/code-check` on staged diff.
+- [ ] PR with SRED tag.
+
+## Dispatch strategy
+
+Run heavy work on M1 (targets, local_install, vignette regen) so M4 stays free for interactive work. Always sync M1 (`git pull` + `pak::local_install()`) before dispatching.
+
+## Versions at start
+
+- fresh: 0.16.0 (just shipped)
+- link: 0.7.0 → 0.8.0 target
+- bcfishpass: ea3c5d8 (reference config)

--- a/research/default_vs_bcfishpass.md
+++ b/research/default_vs_bcfishpass.md
@@ -97,6 +97,7 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 
 
+
 ### ADMS
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
@@ -105,11 +106,11 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | BT | rearing | 666.96 | 786.43 | +119.47 | km |
 | BT | lake_rearing | 0 | 14259.74 | +14259.7 | ha |
 | BT | wetland_rearing | 0 | 926.32 | +926.32 | ha |
-| CH | spawning | 278.92 | 295.4 | +16.48 | km |
+| CH | spawning | 279.01 | 295.5 | +16.49 | km |
 | CH | rearing | 315.42 | 590.26 | +274.84 | km |
 | CH | lake_rearing | 0 | 13936.94 | +13936.9 | ha |
 | CH | wetland_rearing | 0 | 812 | +812 | ha |
-| CO | spawning | 316.08 | 338.67 | +22.59 | km |
+| CO | spawning | 317.73 | 339.54 | +21.81 | km |
 | CO | rearing | 363 | 608.76 | +245.76 | km |
 | CO | lake_rearing | 0 | 14105.71 | +14105.7 | ha |
 | CO | wetland_rearing | 817.06 | 816.71 | -0.35 | ha |
@@ -117,7 +118,7 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | RB | rearing | NA | 690.41 | NA | km |
 | RB | lake_rearing | NA | 14128.54 | NA | ha |
 | RB | wetland_rearing | NA | 834.85 | NA | ha |
-| SK | spawning | 88.83 | 93.28 | +4.45 | km |
+| SK | spawning | 93.97 | 98.42 | +4.45 | km |
 | SK | rearing | 229.85 | 229.85 | +0 | km |
 | SK | lake_rearing | 13820.05 | 13820.05 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
@@ -130,15 +131,15 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | BT | rearing | 2994.99 | 3215.08 | +220.09 | km |
 | BT | lake_rearing | 0 | 4448.63 | +4448.63 | ha |
 | BT | wetland_rearing | 0 | 5901.49 | +5901.49 | ha |
-| CH | spawning | 1277.05 | 1357.11 | +80.06 | km |
+| CH | spawning | 1277.27 | 1357.33 | +80.06 | km |
 | CH | rearing | 1785.52 | 2174.69 | +389.17 | km |
 | CH | lake_rearing | 0 | 2871.94 | +2871.94 | ha |
 | CH | wetland_rearing | 0 | 5546.32 | +5546.32 | ha |
-| CO | spawning | 1822.93 | 1976.53 | +153.6 | km |
-| CO | rearing | 2335.29 | 2506.71 | +171.42 | km |
+| CO | spawning | 1840.24 | 1983.98 | +143.74 | km |
+| CO | rearing | 2335.5 | 2506.71 | +171.21 | km |
 | CO | lake_rearing | 0 | 4213.19 | +4213.19 | ha |
 | CO | wetland_rearing | 5571.02 | 5567 | -4.02 | ha |
-| PK | spawning | 1893.25 | 2040.41 | +147.16 | km |
+| PK | spawning | 1895.42 | 2040.45 | +145.03 | km |
 | PK | rearing | 0 | 0 | +0 | km |
 | PK | lake_rearing | 0 | 0 | +0 | ha |
 | PK | wetland_rearing | 0 | 0 | +0 | ha |
@@ -146,11 +147,11 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | RB | rearing | NA | 3259.23 | NA | km |
 | RB | lake_rearing | NA | 4119.16 | NA | ha |
 | RB | wetland_rearing | NA | 5748.55 | NA | ha |
-| SK | spawning | 24.22 | 42.12 | +17.9 | km |
+| SK | spawning | 25.02 | 42.93 | +17.91 | km |
 | SK | rearing | 64.56 | 64.56 | +0 | km |
 | SK | lake_rearing | 2098.76 | 2098.76 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
-| ST | spawning | 1304.35 | 1385 | +80.65 | km |
+| ST | spawning | 1308.73 | 1386 | +77.27 | km |
 | ST | rearing | 2244.75 | 2717.62 | +472.87 | km |
 | ST | lake_rearing | 0 | 3548.97 | +3548.97 | ha |
 | ST | wetland_rearing | 0 | 5814.03 | +5814.03 | ha |
@@ -163,24 +164,24 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | BT | rearing | 2306.49 | 3016.58 | +710.09 | km |
 | BT | lake_rearing | 0 | 56308.82 | +56308.8 | ha |
 | BT | wetland_rearing | 0 | 6119.08 | +6119.08 | ha |
-| CH | spawning | 362.12 | 497.69 | +135.57 | km |
-| CH | rearing | 732.52 | 2133.35 | +1400.83 | km |
+| CH | spawning | 362.35 | 497.92 | +135.57 | km |
+| CH | rearing | 748.39 | 2134.5 | +1386.11 | km |
 | CH | lake_rearing | 0 | 52765.57 | +52765.6 | ha |
 | CH | wetland_rearing | 0 | 5741.8 | +5741.8 | ha |
-| CO | spawning | 843.52 | 1057.39 | +213.87 | km |
-| CO | rearing | 1436.72 | 2528.07 | +1091.35 | km |
+| CO | spawning | 843.83 | 1057.7 | +213.87 | km |
+| CO | rearing | 1439.76 | 2528.11 | +1088.35 | km |
 | CO | lake_rearing | 0 | 54507.85 | +54507.8 | ha |
 | CO | wetland_rearing | 5796.4 | 5786.74 | -9.66 | ha |
 | RB | spawning | NA | 856.84 | NA | km |
 | RB | rearing | NA | 2470.23 | NA | km |
 | RB | lake_rearing | NA | 50256.96 | NA | ha |
 | RB | wetland_rearing | NA | 4408.58 | NA | ha |
-| SK | spawning | 57.63 | 150.93 | +93.3 | km |
+| SK | spawning | 85.24 | 178.33 | +93.09 | km |
 | SK | rearing | 941.63 | 941.63 | +0 | km |
 | SK | lake_rearing | 52449.98 | 52449.98 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
-| ST | spawning | 362.59 | 498.29 | +135.7 | km |
-| ST | rearing | 912 | 2475.98 | +1563.98 | km |
+| ST | spawning | 362.97 | 498.67 | +135.7 | km |
+| ST | rearing | 930.03 | 2477.83 | +1547.8 | km |
 | ST | lake_rearing | 0 | 53454.87 | +53454.9 | ha |
 | ST | wetland_rearing | 0 | 5906.92 | +5906.92 | ha |
 
@@ -196,8 +197,8 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | RB | rearing | NA | 1842.73 | NA | km |
 | RB | lake_rearing | NA | 493.99 | NA | ha |
 | RB | wetland_rearing | NA | 948.75 | NA | ha |
-| WCT | spawning | 1578.84 | 1630.78 | +51.94 | km |
-| WCT | rearing | 1895.09 | 2014.28 | +119.19 | km |
+| WCT | spawning | 1597.05 | 1648.76 | +51.71 | km |
+| WCT | rearing | 1918.51 | 2036.33 | +117.82 | km |
 | WCT | lake_rearing | 0 | 561.98 | +561.98 | ha |
 | WCT | wetland_rearing | 0 | 1030.3 | +1030.3 | ha |
 
@@ -209,11 +210,11 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | BT | rearing | 291.07 | 314.24 | +23.17 | km |
 | BT | lake_rearing | 0 | 536.97 | +536.97 | ha |
 | BT | wetland_rearing | 0 | 507.46 | +507.46 | ha |
-| CH | spawning | 110.55 | 122.49 | +11.94 | km |
+| CH | spawning | 110.55 | 122.5 | +11.95 | km |
 | CH | rearing | 129.69 | 160.6 | +30.91 | km |
 | CH | lake_rearing | 0 | 108.34 | +108.34 | ha |
 | CH | wetland_rearing | 0 | 274.2 | +274.2 | ha |
-| CO | spawning | 130.74 | 146.63 | +15.89 | km |
+| CO | spawning | 130.75 | 146.64 | +15.89 | km |
 | CO | rearing | 171.98 | 180.32 | +8.34 | km |
 | CO | lake_rearing | 0 | 176.92 | +176.92 | ha |
 | CO | wetland_rearing | 284.51 | 282.6 | -1.91 | ha |
@@ -229,7 +230,7 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 | SK | rearing | 0 | 0 | +0 | km |
 | SK | lake_rearing | 0 | 0 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
-| ST | spawning | 115.5 | 128.87 | +13.37 | km |
+| ST | spawning | 115.51 | 128.88 | +13.37 | km |
 | ST | rearing | 151.83 | 190.64 | +38.81 | km |
 | ST | lake_rearing | 0 | 206.71 | +206.71 | ha |
 | ST | wetland_rearing | 0 | 314.76 | +314.76 | ha |


### PR DESCRIPTION
## Summary

Ingest known habitat from `user_habitat_classification.csv` into `fresh.streams_habitat` after rule-based classification. Closes the long-standing gap surfaced in `research/default_vs_bcfishpass.md` §5/§7: bcfishpass's published `streams_habitat_linear.spawning_sk > 0` blends model + observations; link previously emitted only the model side.

### Mechanism

After `fresh::frs_habitat_classify()` finishes, when the manifest declares `habitat_classification`, `lnk_pipeline_classify()` calls `fresh::frs_habitat_overlay()` (≥0.21.0) with:

```r
fresh::frs_habitat_overlay(conn,
  from   = "<schema>.user_habitat_classification",  # long-format CSV-loaded table
  to     = "fresh.streams_habitat",                  # rule-classified target
  bridge = "fresh.streams",                          # range-containment bridge
  format = "long",
  long_value_col = "habitat_ind",
  ...)
```

The bridge resolves the `id_segment` ↔ `(blue_line_key, downstream_route_measure)` mapping. Range containment: a fresh segment must be fully within the user_habitat row's `[drm, urm]` range to be flipped.

### Results (rollup digest `0f00c713`)

| WSG | bundle | SK spawning v6 | v7 | Δ |
|---|---|---:|---:|---:|
| ADMS | bcfishpass | 88.83 | 94.0 | +5.14 |
| ADMS | default | 93.28 | 98.4 | +5.14 |
| BULK | bcfishpass | 24.22 | 25.0 | +0.8 |
| BULK | default | 42.12 | 42.9 | +0.81 |
| **BABL** | **bcfishpass** | **57.60** | **85.2** | **+27.6** |
| BABL | default | 150.93 | 178.3 | +27.4 |

**Shass Creek (BLK 360886269) under bcfishpass bundle:** 0 km → **0.94 km** SK spawning. (bcfp-published reference = 3.87 km — covers ~24% of the gap.)

### Residual gap

BABL SK bcfp bundle reaches 85.2 km vs bcfp-published 132 km. Range containment is conservative — user_habitat rows whose `[drm, urm]` only partially align with fresh segments don't fully match. Documented as a follow-up:
- 1050/1150 (stream-thru-wetland) edge_type tightening (proposed v0.10.0 work — see chat)
- Edge-type override table for misclassified `waterbody_key` (future)
- Possible relaxation: intersection-vs-full-containment (would require explicit per-segment proportional flagging)

### Test plan

- [x] ADMS preflight: bcfp + default bundles confirm overlay fires (+5.14 km on SK)
- [x] BABL spot-check: Shass Creek BLK 360886269 = 0.94 km (was 0)
- [x] Full 5-WSG rerun: 22m15s, 357 rows, clean exit
- [x] Reproducibility: rollup digest `0f00c713` recorded in NEWS

Requires fresh ≥ 0.21.0 (overlay rename + bridge).

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
