### PR TITLE
v0.10.0: tighten default spawn edge_types to bcfishpass convention

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Crossing Connectivity Interpretation
-Version: 0.9.0
+Version: 0.10.0
 Authors@R:
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# link 0.10.0
+
+Default config bundle now uses explicit FWA `edge_type` codes for spawn and rear-stream predicates, matching bcfishpass's 20-year-validated convention.
+
+- `data-raw/build_rules.R`: switched both default rule-builder calls (`inst/extdata/parameters_habitat_rules.yaml` and `inst/extdata/configs/default/rules.yaml`) from `edge_types = "categories"` to `edge_types = "explicit"`. Predicates now emit `edge_types_explicit: [1000, 1100, 2000, 2300]` in place of `edge_types: [stream, canal]` (which expanded to `1000/1050/1100/1150` + `2000/2100/2300`).
+- Drops `1050/1150` (stream-thru-wetland) and `2100` (rare double-line canal) from spawn AND rear-stream rules. The dedicated wetland-rearing rule (`edge_types_explicit: [1050, 1150]` with `thresholds: false`) is unchanged — `wetland_rearing` flag still captures stream-thru-wetland segments for species with `rear_wetland = yes`. Net `rearing` flag (= `rear_stream OR wetland_rearing OR rear_lake`) is preserved for those species; species with `rear_wetland = no` (GR, KO) lose `1050/1150` from both spawn AND rearing.
+- ADMS preflight (M1, fresh 0.21.0): default-bundle spawning km drops 4-7% across all spawning species (BT 397→368, CH 296→279, CO 340→318, SK 98→94, RB 331→311). Rearing km essentially unchanged for `rear_wetland = yes` species. Full per-WSG numbers in `research/default_vs_bcfishpass.md`.
+- Default and bcfishpass bundles now emit structurally aligned spawn predicates — confirms bcfishpass's edge-type convention is what link ships by default.
+- `tests/testthat/test-lnk_rules_build.R`: regression tests added — default rules.yaml has no `1050/1150/2100` in spawn or rear-stream predicates; the dedicated wetland-rear rule still carries `[1050, 1150]`.
+
 # link 0.9.0
 
 `lnk_pipeline_classify()` now overlays known habitat from `user_habitat_classification.csv` onto `fresh.streams_habitat` after rule-based classification. Closes [#55](https://github.com/NewGraphEnvironment/link/issues/55).

--- a/data-raw/build_rules.R
+++ b/data-raw/build_rules.R
@@ -6,20 +6,27 @@
 # Usage:
 #   source("data-raw/build_rules.R")
 
-# newgraph defaults (categories: stream, canal, wetland)
+# Default rules: explicit FWA edge_type codes [1000, 1100, 2000, 2300]
+# for spawn + rear-stream rules. Drops 1050/1150 (stream-thru-wetland)
+# and 2100 (rare double-line canal). Matches bcfishpass's 20-year-
+# validated convention. The dedicated wetland-rear rule still uses
+# c(1050L, 1150L) hardcoded — unaffected by this setting.
+#
 # Authoritative source — lives at top-level inst/extdata/ for any caller
 # of frs_params() with no config. ALSO mirrored into configs/default/
 # so the config bundle is self-contained.
 link::lnk_rules_build(
   csv = "inst/extdata/parameters_habitat_dimensions.csv",
-  to = "inst/extdata/parameters_habitat_rules.yaml"
+  to = "inst/extdata/parameters_habitat_rules.yaml",
+  edge_types = "explicit"
 )
 link::lnk_rules_build(
   csv = "inst/extdata/configs/default/dimensions.csv",
-  to = "inst/extdata/configs/default/rules.yaml"
+  to = "inst/extdata/configs/default/rules.yaml",
+  edge_types = "explicit"
 )
 
-# bcfishpass comparison variant (explicit edge_type integers)
+# bcfishpass comparison variant (same explicit codes, different dimensions)
 link::lnk_rules_build(
   csv = "inst/extdata/configs/bcfishpass/dimensions.csv",
   to = "inst/extdata/configs/bcfishpass/rules.yaml",

--- a/data-raw/logs/20260424_01_v0.10_adms_default.txt
+++ b/data-raw/logs/20260424_01_v0.10_adms_default.txt
@@ -1,0 +1,73 @@
++ cfg_default dispatched
+✔ cfg_default completed [222ms, 296.49 kB]
++ comparison_default_ADMS dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+✔ comparison_default_ADMS completed [1m 14.3s, 672 B]
+✔ ended pipeline [1m 14.6s, 2 completed, 0 skipped]

--- a/data-raw/logs/20260424_02_v0.10_full_5wsg.txt
+++ b/data-raw/logs/20260424_02_v0.10_full_5wsg.txt
@@ -1,0 +1,655 @@
++ cfg_bcfishpass dispatched
+✔ cfg_bcfishpass completed [226ms, 296.48 kB]
++ comparison_bcfishpass_ELKR dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_elkr.pscis_fixes vs working_elkr.crossings
+  Total overrides:  324
+  Valid (matched):  288
+  Orphans:          36  <-- not found in crossings
+  Duplicates:       0
+Updated 288 of 7306 rows (barrier_status)
+NOTICE:  table "barriers_definite_control" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_wct" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_wct" does not exist, skipping
+
+✔ comparison_bcfishpass_ELKR completed [2m 32.1s, 491 B]
++ comparison_bcfishpass_BABL dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_bcfishpass_BABL completed [1m 50.3s, 660 B]
++ comparison_bcfishpass_DEAD dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_bcfishpass_DEAD completed [42.3s, 643 B]
++ comparison_bcfishpass_ADMS dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+✔ comparison_bcfishpass_ADMS completed [1m 9.2s, 595 B]
++ comparison_bcfishpass_BULK dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_bulk.pscis_fixes vs working_bulk.crossings
+  Total overrides:  580
+  Valid (matched):  514
+  Orphans:          66  <-- not found in crossings
+  Duplicates:       0
+Updated 514 of 5568 rows (barrier_status)
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_bcfishpass_BULK completed [3m 0.2s, 698 B]
++ comparison_default_DEAD dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_default_DEAD completed [46s, 718 B]
++ comparison_default_BABL dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_default_BABL completed [2m 16.5s, 748 B]
++ comparison_default_BULK dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_bulk.pscis_fixes vs working_bulk.crossings
+  Total overrides:  580
+  Valid (matched):  514
+  Orphans:          66  <-- not found in crossings
+  Duplicates:       0
+Updated 514 of 5568 rows (barrier_status)
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+✔ comparison_default_BULK completed [3m 35.2s, 791 B]
++ comparison_default_ELKR dispatched
+NOTICE:  schema "fresh" already exists, skipping
+
+Override validation: working_elkr.pscis_fixes vs working_elkr.crossings
+  Total overrides:  324
+  Valid (matched):  288
+  Orphans:          36  <-- not found in crossings
+  Duplicates:       0
+Updated 288 of 7306 rows (barrier_status)
+NOTICE:  table "barriers_definite_control" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_wct" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_wct" does not exist, skipping
+
+✔ comparison_default_ELKR completed [2m 32.7s, 552 B]
++ rollup dispatched
+✔ rollup completed [2ms, 2.43 kB]
+✔ ended pipeline [18m 25.3s, 11 completed, 2 skipped]

--- a/inst/extdata/configs/bcfishpass/rules.yaml
+++ b/inst/extdata/configs/bcfishpass/rules.yaml
@@ -1,5 +1,5 @@
 # Generated from dimensions.csv
-# Generated: 2026-04-24
+# Generated: 2026-04-26
 # Edge types: explicit
 #
 # DO NOT EDIT — edit the CSV and re-run lnk_rules_build()

--- a/inst/extdata/configs/default/rules.yaml
+++ b/inst/extdata/configs/default/rules.yaml
@@ -1,27 +1,33 @@
 # Generated from dimensions.csv
-# Generated: 2026-04-24
-# Edge types: categories
+# Generated: 2026-04-26
+# Edge types: explicit
 #
 # DO NOT EDIT — edit the CSV and re-run lnk_rules_build()
 
 BT:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 1.0
@@ -29,22 +35,28 @@ BT:
     lake_ha_min: 10.0
 CH:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 1.0
@@ -52,9 +64,11 @@ CH:
     lake_ha_min: 100.0
 CM:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
@@ -62,22 +76,28 @@ CM:
   rear: []
 CO:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 0.5
@@ -85,9 +105,11 @@ CO:
     lake_ha_min: 2.0
 PK:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
@@ -95,9 +117,11 @@ PK:
   rear: []
 SK:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
     requires_connected: rearing
     connected_distance_max: 3000.0
   - waterbody_type: R
@@ -118,22 +142,28 @@ SK:
     bridge_gradient: 0.05
 ST:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 1.0
@@ -141,22 +171,28 @@ ST:
     lake_ha_min: 60.0
 WCT:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 1.0
@@ -164,9 +200,11 @@ WCT:
     lake_ha_min: 10.0
 KO:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
     requires_connected: rearing
     connected_distance_max: 3000.0
   - waterbody_type: R
@@ -187,22 +225,28 @@ KO:
     bridge_gradient: 0.05
 RB:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
     wetland_ha_min: 1.0
@@ -210,17 +254,21 @@ RB:
     lake_ha_min: 10.0
 GR:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0

--- a/inst/extdata/parameters_habitat_rules.yaml
+++ b/inst/extdata/parameters_habitat_rules.yaml
@@ -1,56 +1,70 @@
 # Generated from parameters_habitat_dimensions.csv
-# Generated: 2026-04-24
-# Edge types: categories
+# Generated: 2026-04-26
+# Edge types: explicit
 #
 # DO NOT EDIT — edit the CSV and re-run lnk_rules_build()
 
 BT:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 CH:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 CM:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
@@ -58,30 +72,38 @@ CM:
   rear: []
 CO:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 PK:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
@@ -89,9 +111,11 @@ PK:
   rear: []
 SK:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
     requires_connected: rearing
     connected_distance_max: 3000.0
   - waterbody_type: R
@@ -108,51 +132,65 @@ SK:
     lake_ha_min: 200
 ST:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 WCT:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 KO:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
     requires_connected: rearing
     connected_distance_max: 3000.0
   - waterbody_type: R
@@ -169,38 +207,48 @@ KO:
     lake_ha_min: 200
 RB:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
-  - edge_types: wetland
+  - edge_types_explicit:
+    - 1050
+    - 1150
     thresholds: false
   - waterbody_type: W
   - waterbody_type: L
 GR:
   spawn:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0
     - 9999.0
   rear:
-  - edge_types:
-    - stream
-    - canal
+  - edge_types_explicit:
+    - 1000
+    - 1100
+    - 2000
+    - 2300
   - waterbody_type: R
     channel_width:
     - 0.0

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,130 @@
+# Findings — v0.10.0 spawn edge_types tightening
+
+## What's actually in the categorical `stream` set
+
+`fresh` (or whatever resolves the `edge_types` token) expands `stream` to
+FWA edge_type integers `1000, 1050, 1100, 1150` and `canal` to
+`2000, 2100, 2300`. Reference: bcfishpass per-species access SQL +
+prior link rules audit.
+
+Codes:
+
+| code | meaning |
+|------|---------|
+| 1000 | Stream segment (single-line) |
+| 1050 | Stream-through-wetland (single-line, runs through wetland zone) |
+| 1100 | Stream segment (double-line river) |
+| 1150 | Stream-through-wetland (double-line) |
+| 1200 | Construction line |
+| 1250 | Construction line (other) |
+| 1350 | Construction line (subtype) |
+| 1450 | Connector |
+| 1500 | Lake centerline |
+| 1525 | Lake centerline (subtype) |
+| 1700 | Wetland centerline |
+| 2000 | Canal segment |
+| 2100 | Canal (rare double-line) |
+| 2300 | Canal subtype |
+
+`1050/1150` are **streams that flow through wetland zones**, not wetland
+shorelines. They're flagged separately because the surrounding wetland
+zone affects flow energy and substrate retention — biologically borderline
+for spawning gravel.
+
+`1500/1525/1700` are **lake/wetland centerlines** — these are NOT in the
+default spawn rules today. The dimensions CSV emits a `waterbody_type = L`
+rule only when `spawn_lake = yes`, which is `no` for every species. So
+the user's framing ("we include lake/wetland edges in spawn") is slightly
+imprecise — the actual borderline edges are the stream-thru-wetland
+codes (`1050/1150`), not lake/wetland centerlines.
+
+## What `edge_types = "explicit"` mode emits today
+
+From `R/lnk_rules_build.R:99-104`:
+
+```r
+stream_edges <- if (edge_types == "categories") {
+  list(edge_types = c("stream", "canal"))
+} else {
+  list(edge_types_explicit = c(1000L, 1100L, 2000L, 2300L))
+}
+```
+
+Already drops `1050/1150/2100`. The bcfishpass config has used this since
+day one. The default config has always used `categories`. Switching the
+default config call to `explicit` is a one-line change in
+`data-raw/build_rules.R`.
+
+## Wetland rearing rule is independent
+
+`rear_wetland = yes` species emit a separate rule using **only**
+`1050/1150`:
+
+```r
+rear_rules[[length(rear_rules) + 1]] <- add_rc(list(
+  edge_types_explicit = c(1050L, 1150L), thresholds = FALSE), rear_rc, rear_cdm)
+```
+
+This rule sets the `wetland_rearing` flag in `fresh.streams_habitat`. It's
+unaffected by the global `edge_types` switch — the explicit
+`c(1050L, 1150L)` is hardcoded for both modes.
+
+The `rearing` flag is the OR across `rear_stream` + `rear_lake` +
+`wetland_rearing`. So a `1050/1150` segment that was previously TRUE for
+both `rear_stream` (via category expansion) and `wetland_rearing` (via
+dedicated rule) will, after the switch, be TRUE only via
+`wetland_rearing`. Net `rearing = TRUE` is preserved for any species
+with `rear_wetland = yes`.
+
+## Species-by-species impact prediction
+
+| species | spawn 1050/1150 effect | rear 1050/1150 effect (via wetland_rearing) | net rearing flag |
+|---------|------------------------|---------------------------------------------|------------------|
+| BT | spawn flag drops | wetland_rearing carries it | unchanged |
+| CH | spawn flag drops | wetland_rearing carries it | unchanged |
+| CM | n/a (no spawn output for CM, spawn_stream=no? actually yes — recheck) | n/a | n/a |
+| CO | spawn flag drops | wetland_rearing carries it | unchanged |
+| GR | spawn flag drops | rear_wetland=no → no wetland_rearing | rearing drops |
+| KO | spawn flag drops | rear_wetland=no | rearing drops |
+| PK | n/a (rear_no_fw) | n/a | n/a |
+| RB | spawn flag drops | wetland_rearing carries it | unchanged |
+| SK | spawn flag drops (but spawn_connected_distance_max also gates) | rear_lake_only — no rear_stream rule | unchanged |
+| ST | spawn flag drops | wetland_rearing carries it | unchanged |
+| WCT | spawn flag drops | wetland_rearing carries it | unchanged |
+| CT | spawn flag drops | wetland_rearing carries it | unchanged |
+| DV | spawn flag drops | wetland_rearing carries it | unchanged |
+
+CM and PK have `spawn_stream = yes` per current dimensions CSV, so spawn
+predicates ARE emitted; they'll lose `1050/1150` too. PK has `rear_no_fw`,
+so no rearing rules. CM has `rear_no_fw` too.
+
+Re-check CM/PK in dimensions.csv — task_plan v1 said "NOT for CM/PK which
+have `spawn_stream=no`" — that was wrong; `spawn_stream = yes` for both.
+
+## Test coverage
+
+`tests/testthat/test-lnk_rules_build.R:270` already covers explicit-mode
+emission. We need one more test that loads the **regenerated** default
+rules.yaml and asserts no spawn rule contains `1050`, `1150`, or `2100`.
+That's a regression guard against a future re-introduction of the
+`categories` setting.
+
+## ADMS preflight expectations
+
+ADMS WSG has CH, CO, BT, SK as primary spawning species. Without exact
+1050/1150 km counts in ADMS, expect spawning km to drop a few percent
+across all four. The previous v0.9.0 baseline was:
+
+- BT 397.17 km, CH 295.50 km, CO 339.54 km, SK 98.42 km
+
+Decreases of 1–10% across species are expected and acceptable. Decreases
+of >25% would warrant investigation (could indicate `1050/1150` is a
+larger share of ADMS than expected).
+
+## Reproducibility implications
+
+Stamps + lineage tracking (link#40) make the v0.9.0 → v0.10.0 rollup
+delta explainable: same fwapg, same bcfishobs, but different default
+rules.yaml → different predicates → different outputs. Each WSG's
+rollup row should attribute the delta to "rules.yaml v2" or whatever the
+stamp pins.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -30,3 +30,21 @@
 - Full suite: 360 PASS, 0 FAIL, 1 pre-existing WARN
   (`test-lnk_pipeline_break.R:214` mocked-bindings — unrelated)
 - Next: Phase 7 — ADMS preflight on m1.
+
+### Phase 7-12 done in one session
+- ADMS preflight (M1, fresh 0.21.0, local Docker fwapg + tunnel
+  bcfishpass): BT 397→368 km, CH 296→279, CO 340→318, SK 98→94,
+  RB 331→311. All decreases 4-7%. Rearing flag preserved for
+  `rear_wetland=yes` species. Sane.
+- Full 5-WSG run: 18m 25s, 11 targets completed (2 skipped from preflight).
+  Rollup digest TBD. Key finding: spawning Δ between bundles is now 0 km
+  on every parity species × WSG. Rearing departures persist (intermittent
+  streams + wetland_rearing additions).
+- Refreshed all per-WSG tables in `research/default_vs_bcfishpass.md`
+  (§Results — ADMS, BULK, BABL, ELKR, DEAD).
+- Rewrote observation §2 to reflect spawning alignment (rearing-only
+  inflation now); §3 updated with v0.10.0 narrative; §6 caveat note
+  added (BABL SK source-bucket analysis is pre-v0.10.0).
+- `/code-check` clean round 1.
+- NEWS 0.10.0 + DESCRIPTION bump committed in branch state.
+- Next: stage + commit research/NEWS/DESCRIPTION; open PR.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -12,3 +12,21 @@
   the entire code change.
 - Next: Phase 2 — flip `data-raw/build_rules.R` to `edge_types = "explicit"`
   for both default YAMLs, regenerate, verify diff.
+
+### Phases 2-6 done in one atomic commit
+- `data-raw/build_rules.R`: both default calls now pass
+  `edge_types = "explicit"` (top-level `parameters_habitat_rules.yaml` and
+  `configs/default/rules.yaml`)
+- Regenerated both default YAMLs. bcfishpass yaml regenerated too (only
+  date stamp changed since it was already on `explicit`)
+- Verified: 1050/1150/2100 absent from all spawn rules and from
+  rear-stream predicate rules. 1050/1150 retained in the dedicated
+  wetland-rear rule (the one with `thresholds: false`) per design.
+- Added 2 regression tests in `test-lnk_rules_build.R`:
+  - default rules.yaml has no 1050/1150/2100 in spawn or rear-stream
+    predicates (loops over all species)
+  - BT (representative `rear_wetland=yes` species) still has the
+    dedicated wetland-rear rule with `[1050, 1150]`
+- Full suite: 360 PASS, 0 FAIL, 1 pre-existing WARN
+  (`test-lnk_pipeline_break.R:214` mocked-bindings — unrelated)
+- Next: Phase 7 — ADMS preflight on m1.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,14 @@
+# Progress — v0.10.0 spawn edge_types tightening
+
+## Session 2026-04-24
+
+- Created branch `10-spawn-edge-types-explicit` off `main` (post v0.9.0 merge)
+- PWF baseline: `task_plan.md`, `findings.md`, `progress.md` written
+- Plan revised from "add new `spawn_edge_types_explicit` column" to
+  "switch default config to existing `edge_types = "explicit"` mode" —
+  much simpler, achieves the same end state, infrastructure already exists
+- Verified bcfishpass config already uses `explicit`; default config uses
+  `categories`. Switching the default's `data-raw/build_rules.R` call is
+  the entire code change.
+- Next: Phase 2 — flip `data-raw/build_rules.R` to `edge_types = "explicit"`
+  for both default YAMLs, regenerate, verify diff.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,99 @@
+# Task: Tighten default spawn edge_types (v0.10.0)
+
+Default bundle currently emits `edge_types: [stream, canal]` for spawn (and
+rear-stream) predicates. The `stream` category expands to FWA edge_type
+codes `1000, 1050, 1100, 1150` — which **includes stream-through-wetland**
+(`1050/1150`). Biologically borderline: these are streams flowing through
+wetland zones, often lower-flow-energy and unlikely to retain spawning
+gravel. The `canal` category similarly includes `2100` (rare double-line
+canal).
+
+`lnk_rules_build()` already supports an `edge_types = "explicit"` mode
+that emits integer codes `[1000, 1100, 2000, 2300]` — bcfishpass's
+20-year-validated convention. The bcfishpass config already uses it. The
+default config currently does not.
+
+Switch the default config to `edge_types = "explicit"`. After this lands,
+default and bcfp bundles use the same edge_type set everywhere — which is
+the right end state.
+
+## Goal
+
+Switch default `data-raw/build_rules.R` calls to use `edge_types = "explicit"`,
+regenerate the two default YAMLs, and confirm:
+
+- Spawn predicates no longer include `1050/1150/2100`.
+- Rear-stream predicates no longer include `1050/1150/2100`. The dedicated
+  wetland-rear rule still captures `1050/1150` for the `wetland_rearing`
+  flag (it's emitted as a separate rule per species with `rear_wetland=yes`).
+
+Note on user's framing ("lake and wetland edges for spawn"): the default
+spawn rules do NOT actually include lake (`1500/1525`) or wetland-centerline
+(`1700`) edges — those would only come from a `waterbody_type = L/W` rule
+which the dimensions CSV doesn't generate for spawn. The borderline
+edges are `1050/1150` (stream-thru-wetland), which DO match the categorical
+`stream` set. Document this distinction in the research doc.
+
+## Phases
+
+- [ ] Phase 1 — PWF baseline (task_plan, findings, progress)
+- [ ] Phase 2 — Switch `data-raw/build_rules.R` to `edge_types = "explicit"` for default
+- [ ] Phase 3 — Regenerate `inst/extdata/parameters_habitat_rules.yaml` and `inst/extdata/configs/default/rules.yaml`
+- [ ] Phase 4 — Verify YAML diff: confirm no `1050/1150/2100` in spawn or rear-stream rules; confirm `1050/1150` still present in dedicated wetland-rear rule
+- [ ] Phase 5 — Existing test for explicit mode covers this (`test-lnk_rules_build.R:270`); add a default-config-specific test that asserts default rules.yaml has no `1050/1150/2100` in spawn predicates
+- [ ] Phase 6 — Full devtools::test() suite
+- [ ] Phase 7 — Sync m1; ADMS preflight (BT, CH, CO, SK should all decrease — by how much depends on `1050` prevalence)
+- [ ] Phase 8 — Full 5-WSG rerun via rtj harness if ADMS preflight is sane
+- [ ] Phase 9 — Refresh research doc per-WSG tables; expected pattern: spawning down across species in WSGs with significant `1050` km
+- [ ] Phase 10 — Update research doc §3 ("Intermittent streams included") and §2 (wetland rearing) to clarify the spawn-vs-rear distinction and document that `1050/1150` no longer enter the spawn flag, but DO still enter the wetland_rearing flag via the dedicated rule
+- [ ] Phase 11 — `/code-check` on staged diff
+- [ ] Phase 12 — NEWS entry + version bump 0.9.0 → 0.10.0
+- [ ] Phase 13 — PR
+
+## Critical files
+
+- `data-raw/build_rules.R` — switch default to `edge_types = "explicit"`
+- `inst/extdata/parameters_habitat_rules.yaml` — regenerated
+- `inst/extdata/configs/default/rules.yaml` — regenerated
+- `tests/testthat/test-lnk_rules_build.R` — add test that default-config YAML has no `1050/1150/2100` in spawn predicates
+- `research/default_vs_bcfishpass.md` — refresh tables + clarify §2/§3
+- `NEWS.md` — 0.10.0 entry
+- `DESCRIPTION` — version bump
+
+## Acceptance
+
+- Default and bcfp config bundles emit structurally aligned spawn predicates: `edge_types_explicit: [1000, 1100, 2000, 2300]`
+- `1050/1150/2100` no longer in default spawn or rear-stream predicates
+- Dedicated wetland-rear rule (`edge_types_explicit: [1050, 1150]`) per
+  species still present and unchanged
+- 5-WSG rerun shows spawning km decreases in WSGs with significant
+  `1050/1150` km; rear stream km also decreases (compensated by wetland
+  rear km going up — net `rearing` flag may net flat depending on
+  species)
+
+## Risks
+
+- **Reproducibility regression** vs v6/v7 — expected (this is the whole
+  point); document in NEWS.
+- **Could over-tighten** if some `1050/1150` segments WERE legitimate
+  spawning per known habitat. The overlay (shipping in v0.9.0) catches
+  those via `user_habitat_classification` — overlay-flagged segments stay
+  TRUE even if rule predicate says FALSE.
+- **rearing flag mechanics**: rear-stream loses `1050/1150` but
+  `wetland_rearing` flag still includes them; the `rearing` flag is the OR
+  across rear/wetland_rear — so `rearing = TRUE` for a `1050/1150`
+  segment as long as `rear_wetland = yes` for the species. Net `rearing`
+  km should be roughly unchanged for species with `rear_wetland = yes`
+  (BT, CH, CO, ST, WCT, CT, DV, RB) and decrease for GR (no wetland
+  rearing).
+
+## Not in this PR
+
+- Per-spawn `spawn_edge_types_explicit` column on dimensions.csv —
+  unnecessary complexity. The global `edge_types` switch achieves the
+  same end state.
+- Edge_type override table (per-`waterbody_key` exceptions) — file as
+  separate issue if needed.
+- Per-edge-type gradient floors — defer.
+- Range-containment relaxation in `fresh::frs_habitat_overlay` — file
+  fresh follow-up if user_habitat alignment gap warrants.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -36,12 +36,12 @@ edges are `1050/1150` (stream-thru-wetland), which DO match the categorical
 
 ## Phases
 
-- [ ] Phase 1 — PWF baseline (task_plan, findings, progress)
-- [ ] Phase 2 — Switch `data-raw/build_rules.R` to `edge_types = "explicit"` for default
-- [ ] Phase 3 — Regenerate `inst/extdata/parameters_habitat_rules.yaml` and `inst/extdata/configs/default/rules.yaml`
-- [ ] Phase 4 — Verify YAML diff: confirm no `1050/1150/2100` in spawn or rear-stream rules; confirm `1050/1150` still present in dedicated wetland-rear rule
-- [ ] Phase 5 — Existing test for explicit mode covers this (`test-lnk_rules_build.R:270`); add a default-config-specific test that asserts default rules.yaml has no `1050/1150/2100` in spawn predicates
-- [ ] Phase 6 — Full devtools::test() suite
+- [x] Phase 1 — PWF baseline (task_plan, findings, progress)
+- [x] Phase 2 — Switch `data-raw/build_rules.R` to `edge_types = "explicit"` for default
+- [x] Phase 3 — Regenerate `inst/extdata/parameters_habitat_rules.yaml` and `inst/extdata/configs/default/rules.yaml`
+- [x] Phase 4 — Verify YAML diff: confirm no `1050/1150/2100` in spawn or rear-stream rules; confirm `1050/1150` still present in dedicated wetland-rear rule
+- [x] Phase 5 — Existing test for explicit mode covers this (`test-lnk_rules_build.R:270`); add a default-config-specific test that asserts default rules.yaml has no `1050/1150/2100` in spawn predicates
+- [x] Phase 6 — Full devtools::test() suite
 - [ ] Phase 7 — Sync m1; ADMS preflight (BT, CH, CO, SK should all decrease — by how much depends on `1050` prevalence)
 - [ ] Phase 8 — Full 5-WSG rerun via rtj harness if ADMS preflight is sane
 - [ ] Phase 9 — Refresh research doc per-WSG tables; expected pattern: spawning down across species in WSGs with significant `1050` km

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -42,12 +42,12 @@ edges are `1050/1150` (stream-thru-wetland), which DO match the categorical
 - [x] Phase 4 — Verify YAML diff: confirm no `1050/1150/2100` in spawn or rear-stream rules; confirm `1050/1150` still present in dedicated wetland-rear rule
 - [x] Phase 5 — Existing test for explicit mode covers this (`test-lnk_rules_build.R:270`); add a default-config-specific test that asserts default rules.yaml has no `1050/1150/2100` in spawn predicates
 - [x] Phase 6 — Full devtools::test() suite
-- [ ] Phase 7 — Sync m1; ADMS preflight (BT, CH, CO, SK should all decrease — by how much depends on `1050` prevalence)
-- [ ] Phase 8 — Full 5-WSG rerun via rtj harness if ADMS preflight is sane
-- [ ] Phase 9 — Refresh research doc per-WSG tables; expected pattern: spawning down across species in WSGs with significant `1050` km
-- [ ] Phase 10 — Update research doc §3 ("Intermittent streams included") and §2 (wetland rearing) to clarify the spawn-vs-rear distinction and document that `1050/1150` no longer enter the spawn flag, but DO still enter the wetland_rearing flag via the dedicated rule
-- [ ] Phase 11 — `/code-check` on staged diff
-- [ ] Phase 12 — NEWS entry + version bump 0.9.0 → 0.10.0
+- [x] Phase 7 — ADMS preflight on M1 (local Docker fwapg, fresh 0.21.0): BT spawn 397→368 (-7.3%), CH 296→279 (-5.6%), CO 340→318 (-6.3%), SK 98→94 (-4.5%), RB 331→311 (-6%); rearing essentially unchanged for `rear_wetland=yes` species
+- [x] Phase 8 — Full 5-WSG rerun (18m 25s, 11 targets): spawning Δ = 0 km vs bcfishpass bundle on every parity species/WSG (default and bcfishpass bundles now emit structurally identical spawn predicates)
+- [x] Phase 9 — Refreshed all per-WSG tables in research doc with v0.10.0 numbers
+- [x] Phase 10 — Updated §2 (wetland rearing) and §3 (intermittent streams) prose for spawn-vs-rear distinction + caveat on §6 BABL SK source-bucket analysis (pre-v0.10.0 numbers)
+- [x] Phase 11 — `/code-check` on staged diff: Clean round 1, skipped remaining
+- [x] Phase 12 — NEWS 0.10.0 + DESCRIPTION 0.9.0→0.10.0
 - [ ] Phase 13 — PR
 
 ## Critical files

--- a/research/default_vs_bcfishpass.md
+++ b/research/default_vs_bcfishpass.md
@@ -70,7 +70,18 @@ per population to be refined with regional literature.]
 
 ### 2. Wetland rearing added
 
-`rear_wetland = yes` in default dimensions CSV for BT, CO, CT, DV, GR, RB, SK, ST, WCT. Bcfishpass doesn't flag wetland-rearing at the segment-classification level. Wetland reaches (edge_type 1050/1150) support juvenile CO specifically (side channels, beaver complexes) and sub-adult rearing for resident species. [TODO: citations.]
+`rear_wetland = yes` in default dimensions CSV for BT, CO, CT, DV, GR, RB, SK, ST, WCT. Bcfishpass doesn't flag wetland-rearing at the segment-classification level. Stream-through-wetland reaches (edge_type 1050/1150) support juvenile CO specifically (side channels, beaver complexes) and sub-adult rearing for resident species. [TODO: citations.]
+
+**Spawn-vs-rear distinction (v0.10.0):** as of v0.10.0 the default config
+emits explicit FWA edge_type codes `[1000, 1100, 2000, 2300]` for spawn
+and rear-stream rules — `1050/1150` (stream-thru-wetland) and `2100`
+(rare double-line canal) are dropped. Wetland-flow segments DO still
+flag `wetland_rearing` because the dedicated wetland-rearing rule
+emits `edge_types_explicit: [1050, 1150]` separately, with
+`thresholds: false`. Net: a `1050` segment for a `rear_wetland = yes`
+species is `wetland_rearing = TRUE` AND `rearing = TRUE` (via the
+`rearing = rear_stream OR wetland_rearing OR rear_lake` aggregate),
+but `spawning = FALSE`.
 
 ### 3. Intermittent streams included
 
@@ -78,6 +89,13 @@ bcfishpass excludes intermittent streams; default includes them. Two reasons:
 
 1. FWA's intermittent flag is unreliable — 20+ years of field work consistently finds productive fish-bearing reaches classified as intermittent in FWA.
 2. Documented seasonal use by CO juveniles and other species.
+
+The "intermittent" flag is independent from the `edge_type` integers — a
+segment's edge_type tells you whether it flows as a stream, a canal, a
+lake centerline, etc. The intermittent attribute is a separate field on
+`fwa_stream_networks_sp.fwa_watershed_code`. So the §2 v0.10.0 change
+(dropping `1050/1150` from spawn) is orthogonal to "default includes
+intermittent streams".
 
 [TODO: edge-type mechanism in the rules YAML + citations.]
 
@@ -102,23 +120,23 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
 |---|---|---:|---:|---:|---|
-| BT | spawning | 368.13 | 397.17 | +29.04 | km |
-| BT | rearing | 666.96 | 786.43 | +119.47 | km |
+| BT | spawning | 368.13 | 368.13 | +0 | km |
+| BT | rearing | 666.96 | 785.64 | +118.68 | km |
 | BT | lake_rearing | 0 | 14259.74 | +14259.7 | ha |
 | BT | wetland_rearing | 0 | 926.32 | +926.32 | ha |
-| CH | spawning | 279.01 | 295.5 | +16.49 | km |
+| CH | spawning | 279.01 | 279.01 | +0 | km |
 | CH | rearing | 315.42 | 590.26 | +274.84 | km |
 | CH | lake_rearing | 0 | 13936.94 | +13936.9 | ha |
 | CH | wetland_rearing | 0 | 812 | +812 | ha |
-| CO | spawning | 317.73 | 339.54 | +21.81 | km |
-| CO | rearing | 363 | 608.76 | +245.76 | km |
+| CO | spawning | 317.73 | 317.73 | +0 | km |
+| CO | rearing | 363 | 608.21 | +245.21 | km |
 | CO | lake_rearing | 0 | 14105.71 | +14105.7 | ha |
 | CO | wetland_rearing | 817.06 | 816.71 | -0.35 | ha |
-| RB | spawning | NA | 331.35 | NA | km |
+| RB | spawning | NA | 310.61 | NA | km |
 | RB | rearing | NA | 690.41 | NA | km |
 | RB | lake_rearing | NA | 14128.54 | NA | ha |
 | RB | wetland_rearing | NA | 834.85 | NA | ha |
-| SK | spawning | 93.97 | 98.42 | +4.45 | km |
+| SK | spawning | 93.97 | 93.97 | +0 | km |
 | SK | rearing | 229.85 | 229.85 | +0 | km |
 | SK | lake_rearing | 13820.05 | 13820.05 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
@@ -127,32 +145,32 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
 |---|---|---:|---:|---:|---|
-| BT | spawning | 1904.46 | 2069.15 | +164.69 | km |
-| BT | rearing | 2994.99 | 3215.08 | +220.09 | km |
+| BT | spawning | 1904.46 | 1904.46 | +0 | km |
+| BT | rearing | 2994.99 | 3202.79 | +207.8 | km |
 | BT | lake_rearing | 0 | 4448.63 | +4448.63 | ha |
 | BT | wetland_rearing | 0 | 5901.49 | +5901.49 | ha |
-| CH | spawning | 1277.27 | 1357.33 | +80.06 | km |
-| CH | rearing | 1785.52 | 2174.69 | +389.17 | km |
+| CH | spawning | 1277.27 | 1277.27 | +0 | km |
+| CH | rearing | 1785.52 | 2165.26 | +379.74 | km |
 | CH | lake_rearing | 0 | 2871.94 | +2871.94 | ha |
 | CH | wetland_rearing | 0 | 5546.32 | +5546.32 | ha |
-| CO | spawning | 1840.24 | 1983.98 | +143.74 | km |
-| CO | rearing | 2335.5 | 2506.71 | +171.21 | km |
+| CO | spawning | 1840.24 | 1840.24 | +0 | km |
+| CO | rearing | 2335.5 | 2501.41 | +165.91 | km |
 | CO | lake_rearing | 0 | 4213.19 | +4213.19 | ha |
 | CO | wetland_rearing | 5571.02 | 5567 | -4.02 | ha |
-| PK | spawning | 1895.42 | 2040.45 | +145.03 | km |
+| PK | spawning | 1895.42 | 1895.42 | +0 | km |
 | PK | rearing | 0 | 0 | +0 | km |
 | PK | lake_rearing | 0 | 0 | +0 | ha |
 | PK | wetland_rearing | 0 | 0 | +0 | ha |
-| RB | spawning | NA | 2007.67 | NA | km |
+| RB | spawning | NA | 1850.07 | NA | km |
 | RB | rearing | NA | 3259.23 | NA | km |
 | RB | lake_rearing | NA | 4119.16 | NA | ha |
 | RB | wetland_rearing | NA | 5748.55 | NA | ha |
-| SK | spawning | 25.02 | 42.93 | +17.91 | km |
+| SK | spawning | 25.02 | 25.02 | +0 | km |
 | SK | rearing | 64.56 | 64.56 | +0 | km |
 | SK | lake_rearing | 2098.76 | 2098.76 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
-| ST | spawning | 1308.73 | 1386 | +77.27 | km |
-| ST | rearing | 2244.75 | 2717.62 | +472.87 | km |
+| ST | spawning | 1308.73 | 1308.73 | +0 | km |
+| ST | rearing | 2244.75 | 2708.2 | +463.45 | km |
 | ST | lake_rearing | 0 | 3548.97 | +3548.97 | ha |
 | ST | wetland_rearing | 0 | 5814.03 | +5814.03 | ha |
 
@@ -160,28 +178,28 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
 |---|---|---:|---:|---:|---|
-| BT | spawning | 926.76 | 1154.55 | +227.79 | km |
-| BT | rearing | 2306.49 | 3016.58 | +710.09 | km |
+| BT | spawning | 926.76 | 926.76 | +0 | km |
+| BT | rearing | 2306.49 | 3006.76 | +700.27 | km |
 | BT | lake_rearing | 0 | 56308.82 | +56308.8 | ha |
 | BT | wetland_rearing | 0 | 6119.08 | +6119.08 | ha |
-| CH | spawning | 362.35 | 497.92 | +135.57 | km |
-| CH | rearing | 748.39 | 2134.5 | +1386.11 | km |
+| CH | spawning | 362.35 | 362.35 | +0 | km |
+| CH | rearing | 748.39 | 2124.79 | +1376.4 | km |
 | CH | lake_rearing | 0 | 52765.57 | +52765.6 | ha |
 | CH | wetland_rearing | 0 | 5741.8 | +5741.8 | ha |
-| CO | spawning | 843.83 | 1057.7 | +213.87 | km |
-| CO | rearing | 1439.76 | 2528.11 | +1088.35 | km |
+| CO | spawning | 843.83 | 843.83 | +0 | km |
+| CO | rearing | 1439.76 | 2515.49 | +1075.73 | km |
 | CO | lake_rearing | 0 | 54507.85 | +54507.8 | ha |
 | CO | wetland_rearing | 5796.4 | 5786.74 | -9.66 | ha |
-| RB | spawning | NA | 856.84 | NA | km |
-| RB | rearing | NA | 2470.23 | NA | km |
+| RB | spawning | NA | 696.15 | NA | km |
+| RB | rearing | NA | 2471.88 | NA | km |
 | RB | lake_rearing | NA | 50256.96 | NA | ha |
 | RB | wetland_rearing | NA | 4408.58 | NA | ha |
-| SK | spawning | 85.24 | 178.33 | +93.09 | km |
+| SK | spawning | 85.24 | 85.24 | +0 | km |
 | SK | rearing | 941.63 | 941.63 | +0 | km |
 | SK | lake_rearing | 52449.98 | 52449.98 | +0 | ha |
 | SK | wetland_rearing | 0 | 0 | +0 | ha |
-| ST | spawning | 362.97 | 498.67 | +135.7 | km |
-| ST | rearing | 930.03 | 2477.83 | +1547.8 | km |
+| ST | spawning | 362.97 | 362.97 | +0 | km |
+| ST | rearing | 930.03 | 2468.12 | +1538.09 | km |
 | ST | lake_rearing | 0 | 53454.87 | +53454.9 | ha |
 | ST | wetland_rearing | 0 | 5906.92 | +5906.92 | ha |
 
@@ -189,16 +207,16 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
 |---|---|---:|---:|---:|---|
-| BT | spawning | 1538.96 | 1590.16 | +51.2 | km |
-| BT | rearing | 2079.01 | 2106.79 | +27.78 | km |
+| BT | spawning | 1538.96 | 1538.96 | +0 | km |
+| BT | rearing | 2079.01 | 2104.87 | +25.86 | km |
 | BT | lake_rearing | 0 | 537.41 | +537.41 | ha |
 | BT | wetland_rearing | 0 | 1013.55 | +1013.55 | ha |
-| RB | spawning | NA | 1407.91 | NA | km |
+| RB | spawning | NA | 1359.63 | NA | km |
 | RB | rearing | NA | 1842.73 | NA | km |
 | RB | lake_rearing | NA | 493.99 | NA | ha |
 | RB | wetland_rearing | NA | 948.75 | NA | ha |
-| WCT | spawning | 1597.05 | 1648.76 | +51.71 | km |
-| WCT | rearing | 1918.51 | 2036.33 | +117.82 | km |
+| WCT | spawning | 1597.05 | 1597.05 | +0 | km |
+| WCT | rearing | 1918.51 | 2032.37 | +113.86 | km |
 | WCT | lake_rearing | 0 | 561.98 | +561.98 | ha |
 | WCT | wetland_rearing | 0 | 1030.3 | +1030.3 | ha |
 
@@ -206,23 +224,23 @@ Numbers populate from `tar_read(rollup)` after the first clean `tar_destroy + ta
 
 | Species | Habitat | bcfishpass | default | Δ | Unit |
 |---|---|---:|---:|---:|---|
-| BT | spawning | 163.7 | 194.28 | +30.58 | km |
-| BT | rearing | 291.07 | 314.24 | +23.17 | km |
+| BT | spawning | 163.7 | 163.7 | +0 | km |
+| BT | rearing | 291.07 | 314.15 | +23.08 | km |
 | BT | lake_rearing | 0 | 536.97 | +536.97 | ha |
 | BT | wetland_rearing | 0 | 507.46 | +507.46 | ha |
-| CH | spawning | 110.55 | 122.5 | +11.95 | km |
+| CH | spawning | 110.55 | 110.55 | +0 | km |
 | CH | rearing | 129.69 | 160.6 | +30.91 | km |
 | CH | lake_rearing | 0 | 108.34 | +108.34 | ha |
 | CH | wetland_rearing | 0 | 274.2 | +274.2 | ha |
-| CO | spawning | 130.75 | 146.64 | +15.89 | km |
+| CO | spawning | 130.75 | 130.75 | +0 | km |
 | CO | rearing | 171.98 | 180.32 | +8.34 | km |
 | CO | lake_rearing | 0 | 176.92 | +176.92 | ha |
 | CO | wetland_rearing | 284.51 | 282.6 | -1.91 | ha |
-| PK | spawning | 131.92 | 146.94 | +15.02 | km |
+| PK | spawning | 131.92 | 131.92 | +0 | km |
 | PK | rearing | 0 | 0 | +0 | km |
 | PK | lake_rearing | 0 | 0 | +0 | ha |
 | PK | wetland_rearing | 0 | 0 | +0 | ha |
-| RB | spawning | NA | 157.12 | NA | km |
+| RB | spawning | NA | 137.96 | NA | km |
 | RB | rearing | NA | 291.45 | NA | km |
 | RB | lake_rearing | NA | 258.99 | NA | ha |
 | RB | wetland_rearing | NA | 322.92 | NA | ha |
@@ -269,20 +287,26 @@ Post-fix differentiation:
   (CO at 0.5 ha, others at 1 ha). ADMS example: CO 816.71 ha
   (bit-identical to bcfishpass-bundle 817.06 ha, same rule).
 
-### 2. Linear km inflates under `default` across all species and WSGs
+### 2. Linear km inflates under `default` across all species and WSGs (rearing only — spawning aligned in v0.10.0)
 
-The `rearing` and `spawning` km columns are consistently higher under
-`default`. This is the intended behaviour of the four departures documented
-above: intermittent streams included, `river_skip_cw_min = yes`, and
-spawn gradient floor raised to 0.0025 (which removes some reaches but the
-intermittent/river-polygon additions dominate). Magnitudes vary by WSG — in
-BABL, CH rearing inflates by 1356 km (+185%), reflecting a large base
-network with lots of intermittent contribution; in DEAD it's 27 km (+21%).
+The `rearing` km column is consistently higher under `default` due to
+the deliberate departures (intermittent streams included, `river_skip_cw_min = yes`,
+expanded `rear_wetland`). Magnitudes vary by WSG — in BABL, CH rearing
+inflates by 1376 km (+184%), reflecting a large base network with lots
+of intermittent contribution; in DEAD it's 31 km (+24%).
+
+**Spawning is now identical between bundles** as of v0.10.0. With both
+bundles emitting `edge_types_explicit: [1000, 1100, 2000, 2300]` and
+sharing the same `spawn_lake = no` / `spawn_connected` / connectivity
+gating per species, the spawn predicates are structurally equivalent.
+Spawning Δ = 0 km for every species × WSG combination on the parity
+bundles (BT/CH/CO/PK/SK/ST/WCT). RB is newly modelled under default —
+no bcfishpass reference to compare against, so the column is NA.
 
 ### 3. SK spawning — connectivity now honoured
 
 Two bugs in the initial `default` bundle caused SK spawning to inflate
-10–20× over bcfishpass. Both fixed in this PR:
+10–20× over bcfishpass. Both fixed in earlier PRs:
 
 1. **Missing `spawn_connected` YAML block.** `configs/default/dimensions.csv`
    was missing five columns (`rear_stream_order_bypass`,
@@ -298,10 +322,12 @@ Two bugs in the initial `default` bundle caused SK spawning to inflate
    cap. Set to `no` to match bcfishpass convention — stream-spawning
    sockeye only.
 
-Post-fix SK spawning deltas shrink to the order of the network-level
-departures: ADMS +4 km, BULK +18 km, BABL +93 km, DEAD +0 km. Residual
-lift in BABL traces to intermittent streams and river-polygon reaches
-newly counted under `default`, not to missing connectivity logic.
+Post-fix (v0.10.0) SK spawning deltas are 0 km on every parity WSG
+because the bundles emit identical spawn predicates. Pre-v0.10.0 the
+residual deltas (ADMS +4 km, BULK +18 km, BABL +93 km, DEAD +0 km)
+traced to default's looser categorical edge-types (`[stream, canal]`
+including 1050/1150 stream-thru-wetland) — eliminated when default
+switched to `edge_types = "explicit"`.
 
 Beach-spawning sockeye populations (Babine, Shuswap) exist as a distinct
 phenotype but aren't modelled in the SK category — they would need their
@@ -347,7 +373,16 @@ NOT propagate its `spawning` / `rearing` flags into
 
 Splitting `streams_habitat_linear.spawning_sk` into model (1, 2) vs known
 (3) and spatially intersecting with link's default output gives four
-semantic buckets (BABL SK, shipping state — no gradient floor):
+semantic buckets (BABL SK, shipping state — no gradient floor).
+
+> **Note on numbers below**: this analysis was run before v0.10.0 (when default
+> still used categorical `[stream, canal]` edge types, including stream-
+> thru-wetland 1050/1150). With v0.10.0's tightening, `default_over` is
+> expected to shrink because we no longer credit 1050/1150 as default
+> spawning. `default_catches_known` and `csv_only` should be roughly
+> stable. A re-run of the BABL SK source-bucket analysis is filed as a
+> follow-up.
+
 
 | bucket | km | segments | interpretation |
 |---|---:|---:|---|
@@ -457,8 +492,8 @@ floor's job is to trade `default_over` reduction against
 
 ## Versions
 
-- fresh: 0.16.0
-- link: 0.7.0 → target 0.8.0 at PR merge
+- fresh: 0.21.0
+- link: 0.9.0 → target 0.10.0 at PR merge
 - bcfishpass: ea3c5d8
 - fwapg: Docker (FWA 20240830)
 

--- a/tests/testthat/test-lnk_rules_build.R
+++ b/tests/testthat/test-lnk_rules_build.R
@@ -520,3 +520,59 @@ test_that("rear_stream_order_bypass=yes attaches channel_width_min_bypass to str
   expect_equal(stream_rule$channel_width_min_bypass$stream_order, 1)
   expect_equal(stream_rule$channel_width_min_bypass$stream_order_parent_min, 5)
 })
+
+# -- shipped default config: regression guard against re-introducing
+#    1050 / 1150 / 2100 into spawn or rear-stream predicates ---------------
+
+test_that("default config rules.yaml has no 1050/1150/2100 in spawn or rear-stream predicates", {
+  yaml_path <- system.file("extdata", "configs", "default", "rules.yaml",
+                           package = "link")
+  skip_if(yaml_path == "", "default rules.yaml not installed")
+  rules <- yaml::read_yaml(yaml_path)
+  forbidden <- c(1050L, 1150L, 2100L)
+  for (sp in names(rules)) {
+    spawn <- rules[[sp]]$spawn %||% list()
+    for (r in spawn) {
+      codes <- r[["edge_types_explicit"]]
+      if (!is.null(codes)) {
+        expect_true(length(intersect(as.integer(codes), forbidden)) == 0L,
+          info = sprintf("%s spawn rule contains forbidden code", sp))
+      }
+    }
+    # Rear-stream rule is the predicate-bearing rule. The dedicated
+    # wetland_rearing rule has `thresholds: false` and IS allowed to
+    # carry 1050/1150 (its sole purpose). Check only rules that act as
+    # predicates (no `thresholds: false`).
+    rear <- rules[[sp]]$rear %||% list()
+    for (r in rear) {
+      codes <- r[["edge_types_explicit"]]
+      thr <- r[["thresholds"]]
+      is_wetland_rule <- !is.null(thr) && isFALSE(thr)
+      if (!is.null(codes) && !is_wetland_rule) {
+        expect_true(length(intersect(as.integer(codes), forbidden)) == 0L,
+          info = sprintf("%s rear stream-predicate rule contains forbidden code", sp))
+      }
+    }
+  }
+})
+
+test_that("default config rules.yaml retains 1050/1150 in dedicated wetland-rear rule", {
+  yaml_path <- system.file("extdata", "configs", "default", "rules.yaml",
+                           package = "link")
+  skip_if(yaml_path == "", "default rules.yaml not installed")
+  rules <- yaml::read_yaml(yaml_path)
+  # BT has rear_wetland = yes — wetland-rear rule must be present
+  rear <- rules$BT$rear
+  wetland_rule <- NULL
+  for (r in rear) {
+    if (!is.null(r[["edge_types_explicit"]]) &&
+        !is.null(r[["thresholds"]]) && isFALSE(r[["thresholds"]])) {
+      wetland_rule <- r
+      break
+    }
+  }
+  expect_false(is.null(wetland_rule),
+               info = "BT rear should include dedicated wetland rule")
+  expect_setequal(as.integer(wetland_rule[["edge_types_explicit"]]),
+                  c(1050L, 1150L))
+})


### PR DESCRIPTION
## Summary

- Switch default config spawn predicates from categorical `[stream, canal]` (which expands to FWA edge_type codes `1000/1050/1100/1150/2000/2100/2300`) to explicit `[1000, 1100, 2000, 2300]`. Drops `1050/1150` (stream-thru-wetland) and `2100` (rare double-line canal) from spawn AND rear-stream rules.
- Default and bcfishpass bundles now emit structurally identical spawn predicates. 5-WSG rerun confirms spawning Δ = 0 km on every parity species × WSG.
- Dedicated wetland-rearing rule (`edge_types_explicit: [1050, 1150]` with `thresholds: false`) is unchanged — `wetland_rearing` flag still captures stream-thru-wetland segments for species with `rear_wetland = yes`.

## Numbers

ADMS preflight, link 0.9.0 → 0.10.0:

| species | v0.9.0 spawn km | v0.10.0 spawn km | Δ |
|---------|----------------:|-----------------:|----:|
| BT | 397.17 | 368.13 | -7.3% |
| CH | 295.50 | 279.01 | -5.6% |
| CO | 339.54 | 317.73 | -6.3% |
| SK | 98.42 | 93.97 | -4.5% |
| RB | 331.35 | 310.61 | -6.0% |

Full 5-WSG numbers in `research/default_vs_bcfishpass.md`. Rearing flag preserved for `rear_wetland = yes` species (BT, CH, CO, RB, ST, WCT, CT, DV) via the wetland-rear rule.

## Files

- `data-raw/build_rules.R` — both default rule-builder calls now pass `edge_types = "explicit"`
- `inst/extdata/parameters_habitat_rules.yaml` — regenerated
- `inst/extdata/configs/default/rules.yaml` — regenerated
- `tests/testthat/test-lnk_rules_build.R` — regression tests added
- `research/default_vs_bcfishpass.md` — refreshed per-WSG tables, observations §2/§3/§6 updated
- `NEWS.md` — 0.10.0 entry
- `DESCRIPTION` — 0.9.0 → 0.10.0

## Test plan

- [x] `devtools::test()`: 360 PASS, 0 FAIL, 1 pre-existing WARN
- [x] ADMS preflight (default config, M1, fresh 0.21.0)
- [x] Full 5-WSG run (ADMS, BULK, BABL, ELKR, DEAD; both configs; 18m 25s)
- [x] `/code-check` round 1: Clean
- [x] Visual diff of regenerated `rules.yaml` confirms `1050/1150/2100` only in dedicated wetland-rear rules
- [x] Regression tests: default rules.yaml has no `1050/1150/2100` in spawn or rear-stream predicates; BT wetland-rear rule still has `[1050, 1150]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
