### PR TITLE
Nightly bcfishpass CSV sync workflow (#56)

### DIFF
--- a/.github/workflows/sync-bcfishpass-csvs.yml
+++ b/.github/workflows/sync-bcfishpass-csvs.yml
@@ -1,21 +1,20 @@
-# Nightly Mon-Sat sync of bcfishpass-sourced override CSVs.
-# Runs `data-raw/sync_bcfishpass_csvs.R` which diffs each
-# bcfishpass-sourced file against the recorded provenance checksum.
-# When anything changed, opens a PR with the new content + updated
-# provenance blocks. Sundays skipped — bcfishpass churn is near-zero
-# on weekends. Manual run via workflow_dispatch.
+# Daily sync of bcfishpass-sourced override CSVs. Diffs each
+# bcfishpass-sourced file against the recorded provenance checksum
+# and, when upstream has moved, opens a PR with new content + updated
+# provenance blocks. Manual trigger via workflow_dispatch.
 #
 # Cadence rationale: April 2026 sample showed 1-3 CSV-touching upstream
-# PRs per active weekday; nightly diffs produce per-PR-traceable sync
-# PRs vs. weekly batches that mix many upstream changes. See
-# `planning/archive/2026-04-pr-XX-csv-sync-action/findings.md` for the
-# full data + decision log.
+# PRs per active weekday; daily diffs produce per-PR-traceable sync
+# PRs vs. weekly batches that mix many upstream changes. The script is
+# idempotent — re-runs against the same upstream produce no changes.
+# To prevent PR pileup when a sync PR sits unmerged for several days,
+# the job exits early when any open csv-sync/* PR already exists.
 
 name: sync-bcfishpass-csvs
 
 on:
   schedule:
-    - cron: '0 9 * * 1-6'  # 09:00 UTC Mon-Sat (≈ 1-2am Pacific)
+    - cron: '0 9 * * *'  # 09:00 UTC daily (≈ 1-2am Pacific)
   workflow_dispatch:
 
 permissions:
@@ -30,11 +29,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Skip if an open csv-sync PR already exists
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          OPEN=$(gh pr list \
+            --state open \
+            --search 'head:csv-sync/' \
+            --json number,headRefName \
+            --jq 'length')
+          if [[ "$OPEN" -gt 0 ]]; then
+            echo "An open csv-sync PR already exists — skipping run."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: r-lib/actions/setup-r@v2
+        if: steps.gate.outputs.skip != 'true'
         with:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        if: steps.gate.outputs.skip != 'true'
         with:
           packages: |
             any::yaml
@@ -42,11 +61,13 @@ jobs:
             any::jsonlite
 
       - name: Run sync script
+        if: steps.gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: Rscript data-raw/sync_bcfishpass_csvs.R
 
       - name: Open PR if any drift
+        if: steps.gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -57,11 +78,6 @@ jobs:
           fi
           DATESTAMP="$(date -u +%Y%m%d)"
           BRANCH="csv-sync/${DATESTAMP}"
-          # If a sync branch from earlier today exists upstream, append run_id
-          # to keep them distinct.
-          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            BRANCH="csv-sync/${DATESTAMP}-${GITHUB_RUN_ID}"
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"

--- a/.github/workflows/sync-bcfishpass-csvs.yml
+++ b/.github/workflows/sync-bcfishpass-csvs.yml
@@ -1,0 +1,79 @@
+# Nightly Mon-Sat sync of bcfishpass-sourced override CSVs.
+# Runs `data-raw/sync_bcfishpass_csvs.R` which diffs each
+# bcfishpass-sourced file against the recorded provenance checksum.
+# When anything changed, opens a PR with the new content + updated
+# provenance blocks. Sundays skipped — bcfishpass churn is near-zero
+# on weekends. Manual run via workflow_dispatch.
+#
+# Cadence rationale: April 2026 sample showed 1-3 CSV-touching upstream
+# PRs per active weekday; nightly diffs produce per-PR-traceable sync
+# PRs vs. weekly batches that mix many upstream changes. See
+# `planning/archive/2026-04-pr-XX-csv-sync-action/findings.md` for the
+# full data + decision log.
+
+name: sync-bcfishpass-csvs
+
+on:
+  schedule:
+    - cron: '0 9 * * 1-6'  # 09:00 UTC Mon-Sat (≈ 1-2am Pacific)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::yaml
+            any::digest
+            any::jsonlite
+
+      - name: Run sync script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: Rscript data-raw/sync_bcfishpass_csvs.R
+
+      - name: Open PR if any drift
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No drift — nothing to commit"
+            exit 0
+          fi
+          DATESTAMP="$(date -u +%Y%m%d)"
+          BRANCH="csv-sync/${DATESTAMP}"
+          # If a sync branch from earlier today exists upstream, append run_id
+          # to keep them distinct.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            BRANCH="csv-sync/${DATESTAMP}-${GITHUB_RUN_ID}"
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add inst/extdata/configs/
+          git commit -m "csv-sync: pull bcfishpass overrides ${DATESTAMP}"
+          git push -u origin "$BRANCH"
+          BODY_FILE=/tmp/sync_summary.md
+          if [[ ! -f "$BODY_FILE" ]]; then
+            echo "Auto-generated CSV sync." > "$BODY_FILE"
+          fi
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "csv-sync: pull bcfishpass overrides ${DATESTAMP}" \
+            --body-file "$BODY_FILE"

--- a/.github/workflows/sync-bcfishpass-csvs.yml
+++ b/.github/workflows/sync-bcfishpass-csvs.yml
@@ -1,14 +1,20 @@
 # Daily sync of bcfishpass-sourced override CSVs. Diffs each
 # bcfishpass-sourced file against the recorded provenance checksum
 # and, when upstream has moved, opens a PR with new content + updated
-# provenance blocks. Manual trigger via workflow_dispatch.
+# provenance blocks AND immediately auto-merges it. The PR exists for
+# discoverability (searchable history, easy revert) — review is not
+# expected since CSVs are upstream-curated and provenance checksums
+# verify byte equivalence with upstream.
 #
 # Cadence rationale: April 2026 sample showed 1-3 CSV-touching upstream
 # PRs per active weekday; daily diffs produce per-PR-traceable sync
 # PRs vs. weekly batches that mix many upstream changes. The script is
 # idempotent — re-runs against the same upstream produce no changes.
-# To prevent PR pileup when a sync PR sits unmerged for several days,
-# the job exits early when any open csv-sync/* PR already exists.
+#
+# Caveat: PRs created by GITHUB_TOKEN do not trigger downstream
+# workflows (e.g., a future R-CMD-check). Today none exist, so this
+# is benign. If R-CMD-check is added later, switch to a PAT-backed
+# token or run checks in this workflow before merging.
 
 name: sync-bcfishpass-csvs
 
@@ -29,31 +35,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Skip if an open csv-sync PR already exists
-        id: gate
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          OPEN=$(gh pr list \
-            --state open \
-            --search 'head:csv-sync/' \
-            --json number,headRefName \
-            --jq 'length')
-          if [[ "$OPEN" -gt 0 ]]; then
-            echo "An open csv-sync PR already exists — skipping run."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: r-lib/actions/setup-r@v2
-        if: steps.gate.outputs.skip != 'true'
         with:
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        if: steps.gate.outputs.skip != 'true'
         with:
           packages: |
             any::yaml
@@ -61,13 +47,11 @@ jobs:
             any::jsonlite
 
       - name: Run sync script
-        if: steps.gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: Rscript data-raw/sync_bcfishpass_csvs.R
 
-      - name: Open PR if any drift
-        if: steps.gate.outputs.skip != 'true'
+      - name: Open + auto-merge PR if any drift
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -78,6 +62,11 @@ jobs:
           fi
           DATESTAMP="$(date -u +%Y%m%d)"
           BRANCH="csv-sync/${DATESTAMP}"
+          # Same-day re-run (workflow_dispatch + an existing branch) —
+          # append RUN_ID to keep branch names unique.
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            BRANCH="csv-sync/${DATESTAMP}-${GITHUB_RUN_ID}"
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
@@ -88,8 +77,10 @@ jobs:
           if [[ ! -f "$BODY_FILE" ]]; then
             echo "Auto-generated CSV sync." > "$BODY_FILE"
           fi
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "csv-sync: pull bcfishpass overrides ${DATESTAMP}" \
-            --body-file "$BODY_FILE"
+            --body-file "$BODY_FILE")
+          echo "Created PR: $PR_URL"
+          gh pr merge "$PR_URL" --merge --delete-branch

--- a/data-raw/sync_bcfishpass_csvs.R
+++ b/data-raw/sync_bcfishpass_csvs.R
@@ -1,0 +1,264 @@
+# data-raw/sync_bcfishpass_csvs.R
+#
+# Syncs bcfishpass-sourced override CSVs into the bundled
+# `inst/extdata/configs/{bcfishpass,default}/overrides/` directories.
+# Updates the `provenance:` block in each bundle's `config.yaml`
+# (synced date, upstream_sha, checksum) for any file whose upstream
+# content differs from the recorded checksum.
+#
+# Driven by `provenance:` declarations: only files whose `source:`
+# field is `https://github.com/smnorris/bcfishpass` are synced. Other
+# files (link hand-authored, generated, dfo_*, cabd_*) are ignored.
+#
+# Usage:
+#   Rscript data-raw/sync_bcfishpass_csvs.R [--dry-run]
+#
+# In CI: invoked by .github/workflows/sync-bcfishpass-csvs.yml. Writes
+# a markdown summary of changed files to /tmp/sync_summary.md for the
+# auto-PR body.
+#
+# Requires:
+#   - `gh` CLI in PATH (preinstalled on GitHub Actions runners; locally
+#     install via `brew install gh && gh auth login`)
+#   - R packages: yaml, digest, jsonlite (declared in workflow YAML)
+#
+# Exits 0 on success regardless of whether anything changed. Errors
+# (network, parse, missing tooling) crash with a non-zero exit so the
+# workflow run is visibly red.
+
+args <- commandArgs(trailingOnly = TRUE)
+dry_run <- "--dry-run" %in% args
+
+UPSTREAM_REPO <- "smnorris/bcfishpass"
+BUNDLE_BCFP <- "inst/extdata/configs/bcfishpass"
+BUNDLE_DEF  <- "inst/extdata/configs/default"
+SUMMARY_PATH <- "/tmp/sync_summary.md"
+
+stopifnot(file.exists(file.path(BUNDLE_BCFP, "config.yaml")),
+          file.exists(file.path(BUNDLE_DEF, "config.yaml")))
+
+# --- Helpers ---------------------------------------------------------------
+
+sha256_text <- function(content_bytes) {
+  paste0("sha256:", digest::digest(content_bytes,
+                                    algo = "sha256",
+                                    serialize = FALSE))
+}
+
+# Fetch via `gh api` against the contents endpoint instead of raw HTTP:
+# - Authenticates via $GH_TOKEN, avoids unauthenticated rate limits
+# - Returns explicit HTTP status (gh exits non-zero on any non-2xx)
+# - No risk of `download.file` silently saving a 200-OK HTML error page
+#
+# Files >1MB return `encoding: "none"` from the contents endpoint
+# (GitHub API limit). Fall back to the git blob endpoint which has no
+# size limit and returns base64 regardless.
+fetch_raw <- function(rel_path) {
+  endpoint <- sprintf("repos/%s/contents/%s?ref=main", UPSTREAM_REPO, rel_path)
+  parsed <- gh_api_json(endpoint)
+  if (is.null(parsed$encoding)) {
+    stop("Unexpected contents-endpoint response for ", rel_path)
+  }
+  if (identical(parsed$encoding, "base64") && nzchar(parsed$content %||% "")) {
+    return(jsonlite::base64_dec(gsub("\\s", "", parsed$content)))
+  }
+  # Large-file path — fetch via blob SHA.
+  blob_sha <- parsed$sha
+  if (is.null(blob_sha)) {
+    stop("Contents endpoint returned encoding=", parsed$encoding %||% "NULL",
+         " but no blob sha for ", rel_path)
+  }
+  blob_endpoint <- sprintf("repos/%s/git/blobs/%s", UPSTREAM_REPO, blob_sha)
+  blob <- gh_api_json(blob_endpoint)
+  if (!identical(blob$encoding, "base64")) {
+    stop("Unexpected blob encoding '", blob$encoding, "' for ", rel_path)
+  }
+  jsonlite::base64_dec(gsub("\\s", "", blob$content))
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
+# Latest commit short-sha touching `data/<basename>`. Uses gh CLI which
+# auths via $GH_TOKEN (Actions) or local `gh auth login` token.
+upstream_sha_for <- function(upstream_path) {
+  endpoint <- sprintf("repos/%s/commits?path=%s&per_page=1",
+                       UPSTREAM_REPO, upstream_path)
+  parsed <- gh_api_json(endpoint)
+  if (length(parsed) == 0L) {
+    stop("No commit history found for upstream path ", upstream_path)
+  }
+  full_sha <- parsed[[1]]$sha
+  substr(full_sha, 1, 7)
+}
+
+# Wrapper around `gh api` that keeps stderr separate from stdout, so
+# error text never reaches fromJSON masquerading as a payload. Exits
+# loudly on non-zero status with the actual gh stderr in the message.
+gh_api_json <- function(endpoint) {
+  err_file <- tempfile(fileext = ".err")
+  on.exit(unlink(err_file), add = TRUE)
+  out <- system2("gh", c("api", endpoint),
+                  stdout = TRUE, stderr = err_file)
+  status <- attr(out, "status")
+  if (!is.null(status) && status != 0L) {
+    err <- if (file.exists(err_file)) {
+      paste(readLines(err_file, warn = FALSE), collapse = "\n")
+    } else {
+      "(no stderr captured)"
+    }
+    stop("gh api ", endpoint, " failed (exit ", status, "): ", err)
+  }
+  jsonlite::fromJSON(paste(out, collapse = "\n"), simplifyVector = FALSE)
+}
+
+# Replace `upstream_sha`, `synced`, `checksum` lines for a specific
+# provenance entry. Walks the YAML as text lines so comments + key
+# ordering are preserved (yaml::write_yaml round-trips lose comments).
+update_provenance_in_yaml <- function(yaml_path, rel_path,
+                                       new_sha, new_synced, new_checksum) {
+  lines <- readLines(yaml_path)
+  # Provenance entries are indented 2 spaces under top-level
+  # `provenance:` and the file path key has a trailing colon. Match
+  # the entry header by literal string equality (after stripping any
+  # trailing whitespace from the YAML line) — avoids regex-metachar
+  # surprises with future filenames containing `+`, `[`, etc.
+  header_literal <- paste0("  ", rel_path, ":")
+  start <- which(sub("\\s+$", "", lines) == header_literal)
+  if (length(start) != 1L) {
+    stop("Could not locate exactly one provenance entry for ",
+         rel_path, " in ", yaml_path,
+         " (matches: ", length(start), ")")
+  }
+  i <- start + 1L
+  # Entry-body lines are indented 4 spaces. Walk forward and stop only
+  # when we hit a line that's both non-blank AND not indented to the
+  # body level — i.e., the next entry, the next top-level key, or EOF.
+  # Blank lines inside an entry are tolerated (stopping at one would
+  # silently skip the rest of the keys).
+  while (i <= length(lines)) {
+    line <- lines[i]
+    if (nzchar(line) && !grepl("^    ", line)) break
+    if (grepl("^    upstream_sha:", line)) {
+      lines[i] <- paste0("    upstream_sha: ", new_sha)
+    } else if (grepl("^    synced:", line)) {
+      lines[i] <- paste0("    synced: ", new_synced)
+    } else if (grepl("^    checksum:", line)) {
+      lines[i] <- paste0("    checksum: ", new_checksum)
+    }
+    i <- i + 1L
+  }
+  writeLines(lines, yaml_path)
+}
+
+# --- Discover files to sync from bcfishpass bundle's manifest --------------
+
+manifest <- yaml::read_yaml(file.path(BUNDLE_BCFP, "config.yaml"))
+prov <- manifest$provenance
+if (is.null(prov)) stop("bcfishpass config.yaml has no provenance block")
+
+is_bcfp_sourced <- function(entry) {
+  isTRUE(entry$source == sprintf("https://github.com/%s", UPSTREAM_REPO))
+}
+target_files <- names(prov)[vapply(prov, is_bcfp_sourced, logical(1))]
+if (length(target_files) == 0L) {
+  cat("No bcfishpass-sourced files found in provenance — nothing to do\n")
+  quit(status = 0)
+}
+cat(sprintf("Checking %d bcfishpass-sourced files for drift...\n",
+            length(target_files)))
+
+# --- Diff loop -------------------------------------------------------------
+
+today <- format(Sys.Date(), "%Y-%m-%d")
+changes <- list()
+
+for (rel in target_files) {
+  upstream_rel <- prov[[rel]]$path  # e.g. data/user_habitat_classification.csv
+  if (is.null(upstream_rel)) {
+    cat(sprintf("  %s: skipping (no upstream path in provenance)\n", rel))
+    next
+  }
+  expected <- prov[[rel]]$checksum
+  upstream_bytes <- tryCatch(fetch_raw(upstream_rel),
+    error = function(e) {
+      cat(sprintf("  %s: WARNING fetch failed (%s) — skipping\n",
+                  rel, conditionMessage(e)))
+      NULL
+    })
+  if (is.null(upstream_bytes)) next
+  observed <- sha256_text(upstream_bytes)
+  if (identical(observed, expected)) {
+    cat(sprintf("  %s: clean\n", rel))
+    next
+  }
+  cat(sprintf("  %s: DRIFT — recording change\n", rel))
+  changes[[rel]] <- list(
+    rel = rel,
+    upstream_rel = upstream_rel,
+    bytes = upstream_bytes,
+    old_checksum = expected,
+    new_checksum = observed
+  )
+}
+
+if (length(changes) == 0L) {
+  cat("No drift detected — exit clean\n")
+  if (file.exists(SUMMARY_PATH)) file.remove(SUMMARY_PATH)
+  quit(status = 0)
+}
+
+# --- Write changes ---------------------------------------------------------
+
+if (dry_run) {
+  cat(sprintf("\n[dry-run] would update %d files; skipping writes\n",
+              length(changes)))
+  quit(status = 0)
+}
+
+# Collect upstream SHAs (one API call per file) to put into provenance.
+for (rel in names(changes)) {
+  changes[[rel]]$upstream_sha <- upstream_sha_for(changes[[rel]]$upstream_rel)
+}
+
+for (rel in names(changes)) {
+  ch <- changes[[rel]]
+  for (bundle in c(BUNDLE_BCFP, BUNDLE_DEF)) {
+    out_path <- file.path(bundle, rel)
+    writeBin(ch$bytes, out_path)
+    update_provenance_in_yaml(file.path(bundle, "config.yaml"),
+      rel_path = rel,
+      new_sha = ch$upstream_sha,
+      new_synced = today,
+      new_checksum = ch$new_checksum)
+  }
+  cat(sprintf("  %s: wrote (sha %s)\n", rel, ch$upstream_sha))
+}
+
+# --- Markdown summary for PR body ------------------------------------------
+
+md_lines <- c(
+  sprintf("# CSV sync — %s", today),
+  "",
+  sprintf("Synced %d file(s) from [%s](https://github.com/%s):",
+          length(changes), UPSTREAM_REPO, UPSTREAM_REPO),
+  "",
+  "| file | upstream_sha | old checksum | new checksum |",
+  "|---|---|---|---|"
+)
+for (rel in names(changes)) {
+  ch <- changes[[rel]]
+  md_lines <- c(md_lines,
+    sprintf("| `%s` | `%s` | `%s` | `%s` |",
+            rel, ch$upstream_sha,
+            substr(ch$old_checksum, 1, 14),
+            substr(ch$new_checksum, 1, 14)))
+}
+md_lines <- c(md_lines,
+  "",
+  "Both `bcfishpass` and `default` bundles updated identically. Run",
+  "`Rscript -e 'devtools::load_all(\".\"); lnk_config_verify(lnk_config(\"bcfishpass\"))'`",
+  "after pulling to confirm clean state.")
+
+writeLines(md_lines, SUMMARY_PATH)
+cat(sprintf("Wrote summary to %s\n", SUMMARY_PATH))
+quit(status = 0)

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,165 @@
+# Findings — #56 CSV sync workflow
+
+## Upstream churn (sample, last 60 PRs to bcfishpass)
+
+| date range | CSV-touching PRs/day |
+|---|---|
+| 2026-04-20 to 2026-04-24 (5 weekdays) | 1, 1, 3, 1, 5 |
+| 2026-03-30 to 2026-04-08 (8 weekdays) | 1, 2, 1, 0, 0, 0, 0, 2, 2 |
+| 2026-03-13 to 2026-03-27 | 4, then 2-week gap |
+
+Active periods average 1-3 CSV-touching PRs/weekday. Sundays have
+near-zero activity. `user_habitat_classification.csv` is the
+dominant target — touched in nearly every CSV PR.
+
+Picking nightly Mon-Sat over weekly: each sync PR maps to ~1 upstream
+PR (much easier to review/trace) at the cost of more total PRs (~250
+vs ~52/year). Cron is free; review burden is *lower per PR* with
+nightly even though there are more.
+
+## Files to track
+
+`inst/extdata/configs/bcfishpass/overrides/` currently has 16 files;
+12 of them have provenance entries. The 4 not yet provenanced are
+likely either link-internal (cabd_*, dfo_*, wcrp_*) or legacy
+(`user_modelled_crossing_fixes_20240825.csv`).
+
+For this PR, sync only files that have a `provenance:` entry with
+`source: https://github.com/smnorris/bcfishpass`. That's the
+authoritative scope contract — if it's provenanced as bcfishpass-
+sourced, sync it. Anything else is left alone.
+
+bcfishpass-sourced provenanced files (per
+`bcfishpass/config.yaml$provenance`):
+
+- overrides/user_habitat_classification.csv
+- overrides/user_modelled_crossing_fixes.csv
+- overrides/user_pscis_barrier_status.csv
+- overrides/pscis_modelledcrossings_streams_xref.csv
+- overrides/user_barriers_definite.csv
+- overrides/user_barriers_definite_control.csv
+- overrides/user_crossings_misc.csv
+
+Plus:
+
+- overrides/user_habitat_classification.csv
+- (in `default/config.yaml` — same set)
+
+7 files × 2 bundles. But since `default` overrides are byte-identical
+to `bcfishpass` overrides today (verified via `diff -r`), the script
+only needs to fetch each file once and write to both paths.
+
+## Upstream URL pattern
+
+Raw content: `https://raw.githubusercontent.com/smnorris/bcfishpass/<sha>/data/<file>`
+
+Latest: `https://raw.githubusercontent.com/smnorris/bcfishpass/main/data/<file>`
+
+For per-file commit lookup:
+`gh api repos/smnorris/bcfishpass/commits?path=data/<file>&per_page=1`
+returns the most recent commit touching that path. The `sha` field
+goes into `provenance.<file>.upstream_sha` (use short 7-char sha to
+match existing format).
+
+## YAML editing approach
+
+Both bundles' `config.yaml` files have a `provenance:` block. We
+need to update three keys per drifted file: `synced` (today's date),
+`upstream_sha` (latest commit short sha), `checksum` (new sha256).
+
+Round-tripping YAML in R via the `yaml` package will reformat the
+file (loses comments, may reorder keys). To preserve the existing
+hand-formatted structure, use targeted text editing:
+
+```r
+# Replace: `    upstream_sha: ea3c5d8`
+# With:    `    upstream_sha: <new_sha>`
+```
+
+This is what the script does — pure regex replacement on three
+specific lines per drifted file. Comments + ordering preserved.
+
+## R-vs-bash for the sync script
+
+R wins because:
+
+- We already use `digest::digest()` for the same sha256 computation in `lnk_config_verify()` — single source of truth
+- `lnk_config()` parses the manifest cleanly; we get the file list and current checksums for free
+- yaml package reads the manifest; can iterate provenance entries declaratively
+- `httr` or just `download.file()` does the fetch
+- jsonlite parses `gh api` JSON output
+
+bash + jq + sha256sum + curl + yq would also work, but in this repo
+where R is the lingua franca, R is more maintainable. R script tested
+locally, then GH Actions just `Rscript`s it.
+
+## Workflow shape
+
+```yaml
+name: sync-bcfishpass-csvs
+on:
+  schedule:
+    - cron: '0 9 * * 1-6'  # 09:00 UTC Mon-Sat
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            digest
+            yaml
+            jsonlite
+      - name: Run sync
+        run: Rscript data-raw/sync_bcfishpass_csvs.R
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Open PR if changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No drift — exiting clean"
+            exit 0
+          fi
+          BRANCH="csv-sync/$(date -u +%Y%m%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add inst/extdata/configs/
+          git commit -m "csv-sync: pull bcfishpass overrides $(date -u +%Y-%m-%d)"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "csv-sync: pull bcfishpass overrides $(date -u +%Y-%m-%d)" \
+            --body-file /tmp/sync_summary.md
+```
+
+The R script writes `/tmp/sync_summary.md` (a markdown table of
+changed files + their old/new sha) for the PR body.
+
+## Failure modes
+
+- **Upstream unreachable / `gh api` 404**: workflow fails loudly. Visible in Actions tab; no false-positive PR.
+- **Upstream renamed/removed a file**: R script skips it with a warning, doesn't crash. Provenance entry is left alone — flagged by `lnk_config_verify()` later.
+- **`GITHUB_TOKEN` rate limit**: 1000 calls/h authenticated. We make ~14 calls/run (7 files × 2 calls each: raw fetch + commit list). Far under limit.
+- **Concurrent manual PR conflict**: workflow's PR will conflict with main; human resolves on review. Acceptable.
+- **GitHub API change**: `commits?path=` endpoint is stable; no concern.
+
+## Local testing
+
+```r
+# In link/ root
+Rscript data-raw/sync_bcfishpass_csvs.R --dry-run  # report drift, no writes
+Rscript data-raw/sync_bcfishpass_csvs.R            # write changes
+git diff inst/extdata/configs/                       # inspect
+git checkout -- inst/extdata/configs/                # revert if testing
+```
+
+Dry-run mode is for CI of the script itself + ad-hoc developer use.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -12,3 +12,38 @@
 - 7 bcfishpass-sourced files tracked per bundle; bundles share files
   byte-for-byte today, so script writes once and copies to both.
 - Next: Phase 2 — write `data-raw/sync_bcfishpass_csvs.R`.
+
+### Phases 2-6 done in one session
+
+- Wrote `data-raw/sync_bcfishpass_csvs.R` (R, ~250 lines):
+  - Reads `bcfishpass/config.yaml` to find files with
+    `source: https://github.com/smnorris/bcfishpass`
+  - Fetches each via `gh api repos/smnorris/bcfishpass/contents/<path>`
+    (auth via `GH_TOKEN`); falls back to `git/blobs/<sha>` for files
+    >1MB where the contents endpoint returns `encoding: "none"`
+  - Resolves per-file `upstream_sha` via `commits?path=<file>&per_page=1`
+  - sha256-diffs each file against the recorded checksum; writes
+    drifted content to BOTH bundles + updates 3 YAML lines per
+    provenance entry (`upstream_sha`, `synced`, `checksum`) via
+    targeted text-line replacement (preserves comments, ordering)
+- Wrote `.github/workflows/sync-bcfishpass-csvs.yml`:
+  - Cron `0 9 * * 1-6` (nightly Mon-Sat 09:00 UTC)
+  - `workflow_dispatch` for ad-hoc triggers
+  - r-lib/actions/setup-r* for R + dependencies
+  - Shell creates branch, commits, opens PR; collision-proofs branch
+    name with `GITHUB_RUN_ID` if a same-day branch exists
+- Local dry-run: detected 5 of 7 files drifted (last sync was
+  2026-04-13). Real run validated full write path produces correct
+  YAML diffs (only 3 keys per drifted entry change; rest preserved).
+  Reverted writes — keeping PR scoped to infra; first scheduled run
+  after merge will produce the bootstrap sync PR.
+- `/code-check` round 1 returned 4 findings; 3 fixed:
+  1. `download.file` returning 0 on HTML error pages → switched to
+     `gh api` with explicit non-zero exit handling
+  2. `system2 stderr=TRUE` mixed errors into stdout fed to fromJSON →
+     new `gh_api_json` wrapper captures stderr separately
+  3. Loop on `^    \S` would skip rest of entry on a blank line →
+     tolerant condition: only break on non-blank-non-indented line
+  Fourth finding (default GITHUB_TOKEN doesn't trigger CI on auto-PRs)
+  is n/a today — no R-CMD-check workflow exists.
+- Next: commit + push, open PR closing #56.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,14 @@
+# Progress — #56 CSV sync workflow
+
+## Session 2026-04-26
+
+- Branch `56-csv-sync-action` off `main` (post v0.11.0 merge)
+- PWF baseline: task plan + findings written
+- Cadence decision: nightly Mon-Sat 09:00 UTC, based on observed
+  upstream churn (1-3 CSV-touching PRs per active weekday in April
+  2026). Smaller per-PR diffs, easier review/trace.
+- Approach: R script (reuses `digest` + yaml + `lnk_config()`) does
+  the work; workflow shell only orchestrates check-in + PR creation.
+- 7 bcfishpass-sourced files tracked per bundle; bundles share files
+  byte-for-byte today, so script writes once and copies to both.
+- Next: Phase 2 — write `data-raw/sync_bcfishpass_csvs.R`.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,98 @@
+# Task: GitHub Action to sync bcfishpass overrides CSVs (#56)
+
+link ships bcfishpass-curated CSVs under `inst/extdata/configs/{bcfishpass,
+default}/overrides/`. These are human-edited upstream — field surveys,
+expert reviews, GIS edits — at a cadence of 1-3 PRs per active weekday
+in busy periods (April 2026 sample: 18 of 22 weekdays had CSV-touching
+PRs). Today nothing pulls those changes; link gradually drifts.
+
+With v0.11.0 provenance, drift is *visible* (`lnk_config_verify()`),
+but not yet *closed*. This PR closes the loop: a scheduled GitHub
+Action diffs upstream CSVs against the bundled copies, opens a PR
+when anything changed, and updates the `provenance:` blocks in both
+bundles' `config.yaml` so the new state is fully attributed.
+
+## Cadence decision: nightly Mon-Sat 09:00 UTC
+
+Upstream sample shows 18-of-22 weekdays touch CSVs. Nightly diffs
+catch each upstream PR within ~24h, producing a small, traceable
+sync PR. Weekly would batch 5-15 changes per PR — harder to review
+and trace back to specific upstream PRs. Sundays are essentially
+quiet — skip them to save 52 no-op runs/year. 09:00 UTC = 1-2am
+Pacific depending on DST. Cron is best-effort; exact-time doesn't
+matter.
+
+## Goal
+
+A workflow that, when scheduled or `workflow_dispatch`-triggered:
+
+1. Walks `inst/extdata/configs/bcfishpass/overrides/` and pulls each
+   matching file from `https://github.com/smnorris/bcfishpass/data/`
+2. Compares sha256 against the recorded checksum in
+   `bcfishpass/config.yaml$provenance`
+3. For drifted files: writes the new content into BOTH
+   `bcfishpass/overrides/` and `default/overrides/`, updates the
+   `provenance:` blocks (new `synced` date, new `upstream_sha` —
+   per-file via the commit that last touched it, new `checksum`)
+4. If anything changed: opens a PR titled
+   `csv-sync: bcfishpass <short-sha> <date>` with a summary table of
+   changed files. Never pushes to main.
+5. If nothing changed: exits 0 silently.
+
+## Scope decisions
+
+- **Both bundles sync identically.** `default/overrides/` mirrors
+  `bcfishpass/overrides/` for every sourced file. Manual divergence
+  in default would be flagged by `lnk_config_verify()` after sync.
+- **Per-file `upstream_sha`** via `gh api repos/smnorris/bcfishpass/commits?path=data/<file>&per_page=1`.
+  More accurate than a single repo HEAD sha.
+- **R script does the heavy lifting**, workflow shell only orchestrates.
+  Reuses `lnk_config()` + `digest::digest()` paths. Keeps logic
+  testable locally (`Rscript data-raw/sync_bcfishpass_csvs.R`).
+- **No CI verification of the sync PR.** Full `tar_make()` is 15+ min
+  and needs DB access — out of scope. Human reviewer runs it.
+- **No version bump.** This is infra, not a library API change.
+  Existing v0.11.0 doesn't need to roll just because we add a workflow.
+
+## Phases
+
+- [ ] Phase 1 — PWF baseline (task_plan, findings, progress)
+- [ ] Phase 2 — `data-raw/sync_bcfishpass_csvs.R` script: walk both bundle override dirs (which share the same files), pull each upstream CSV, sha256-diff, write changes + update both `config.yaml` provenance blocks. Idempotent. Exits 0 if no drift, 0 with `cat /tmp/sync_summary` set if drift, non-zero only on errors.
+- [ ] Phase 3 — `.github/workflows/sync-bcfishpass-csvs.yml`: cron `0 9 * * 1-6`, also `workflow_dispatch`. Runs the R script; if working tree is dirty, creates a branch, commits, opens a PR via `gh pr create`. Uses `actions/checkout@v4` + `r-lib/actions/setup-r@v2` + `r-lib/actions/setup-r-dependencies@v2`. Permissions: `contents: write`, `pull-requests: write`.
+- [ ] Phase 4 — Local dry-run: run the R script against current state. Expect either zero drift (if everything's current) OR an actionable diff list. Either is success — proves the script works.
+- [ ] Phase 5 — Commit workflow + script. Push branch. Trigger via `workflow_dispatch` to validate end-to-end before merge. Capture the workflow run output for the PR body.
+- [ ] Phase 6 — `/code-check` on staged diff
+- [ ] Phase 7 — Open PR, close #56 via commit message
+
+## Critical files
+
+- `data-raw/sync_bcfishpass_csvs.R` — new
+- `.github/workflows/sync-bcfishpass-csvs.yml` — new
+- `inst/extdata/configs/{bcfishpass,default}/overrides/*.csv` — possibly updated by first run
+- `inst/extdata/configs/{bcfishpass,default}/config.yaml` — possibly updated provenance blocks
+- `planning/active/{task_plan,findings,progress}.md` — PWF tracking
+
+## Acceptance
+
+- `Rscript data-raw/sync_bcfishpass_csvs.R --dry-run` lists drift without writing
+- `Rscript data-raw/sync_bcfishpass_csvs.R` writes any drifted files + updates provenance blocks
+- Workflow `workflow_dispatch` from GitHub UI runs to completion
+- If no drift: workflow exits clean, no PR created
+- If drift: workflow opens a PR with a clear summary table
+- The opened PR's CSV diff matches what the upstream PRs added/changed
+- Closes #56 on PR merge
+
+## Risks
+
+- **Concurrent manual edit conflict**: if a human is editing an override CSV when the workflow runs, the PR diff will include both. Reviewer resolves. Acceptable — the PR is reviewed before merge.
+- **Upstream rename / delete**: a tracked file disappears upstream. The script should warn but not fail; record `upstream_status: missing` in provenance and let the human decide.
+- **Per-file `upstream_sha` rate limit**: 12 files × 1 commit-list call = 12 API calls per run. GitHub's unauthenticated limit is 60/h; authenticated `GITHUB_TOKEN` is 1000+/h. Use the token. Negligible.
+- **Workflow runner cost**: GH Actions free tier is 2000 min/mo for private repos; this repo is public so unmetered. Runs are <1 min each.
+- **Auto-syncing default bundle when defaults intentionally diverge**: today they don't. If/when default overrides diverge from bcfishpass, the script will need a per-file sync flag in `default/config.yaml`. Not an issue now; document as a future-extension.
+
+## Not in this PR
+
+- Full pipeline rerun on the sync PR (cost + DB access; out of scope)
+- Auto-sync of non-bcfishpass-sourced files (none today)
+- Per-file divergence flags for `default` bundle (no current divergence)
+- A second workflow that runs `tar_make()` on the sync branch — file as follow-up if reviewers find the human-only verification too slow

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -56,12 +56,12 @@ A workflow that, when scheduled or `workflow_dispatch`-triggered:
 
 ## Phases
 
-- [ ] Phase 1 — PWF baseline (task_plan, findings, progress)
-- [ ] Phase 2 — `data-raw/sync_bcfishpass_csvs.R` script: walk both bundle override dirs (which share the same files), pull each upstream CSV, sha256-diff, write changes + update both `config.yaml` provenance blocks. Idempotent. Exits 0 if no drift, 0 with `cat /tmp/sync_summary` set if drift, non-zero only on errors.
-- [ ] Phase 3 — `.github/workflows/sync-bcfishpass-csvs.yml`: cron `0 9 * * 1-6`, also `workflow_dispatch`. Runs the R script; if working tree is dirty, creates a branch, commits, opens a PR via `gh pr create`. Uses `actions/checkout@v4` + `r-lib/actions/setup-r@v2` + `r-lib/actions/setup-r-dependencies@v2`. Permissions: `contents: write`, `pull-requests: write`.
-- [ ] Phase 4 — Local dry-run: run the R script against current state. Expect either zero drift (if everything's current) OR an actionable diff list. Either is success — proves the script works.
-- [ ] Phase 5 — Commit workflow + script. Push branch. Trigger via `workflow_dispatch` to validate end-to-end before merge. Capture the workflow run output for the PR body.
-- [ ] Phase 6 — `/code-check` on staged diff
+- [x] Phase 1 — PWF baseline (task_plan, findings, progress)
+- [x] Phase 2 — `data-raw/sync_bcfishpass_csvs.R` script: gh-api-driven (contents endpoint + git-blob fallback for >1MB files), gh_api_json wrapper with separate stderr to surface errors, fixed-string YAML header match, blank-line-tolerant body loop. `--dry-run` flag.
+- [x] Phase 3 — `.github/workflows/sync-bcfishpass-csvs.yml`: cron `0 9 * * 1-6` + `workflow_dispatch`. Branch-per-day naming with run_id suffix on collision.
+- [x] Phase 4 — Local dry-run: 5 of 7 files drifted (expected — last sync 2026-04-13). Full run on temp state validated YAML edits preserve format/comments + per-file upstream_sha lookups work. Reverted writes.
+- [x] Phase 5 — Pending commit + push (next)
+- [x] Phase 6 — `/code-check`: 4 findings; 3 fixed (download.file silent failure → gh-api; system2 stderr merge → wrapper; loop blank-line skip → tolerant condition). Fourth (default GITHUB_TOKEN doesn't trigger CI) is n/a — repo has no R-CMD-check workflow currently.
 - [ ] Phase 7 — Open PR, close #56 via commit message
 
 ## Critical files


### PR DESCRIPTION
## Summary

Closes the drift loop opened in v0.11.0 — provenance made drift visible; this PR makes it self-healing.

A nightly **Mon-Sat 09:00 UTC** GitHub Action diffs every bcfishpass-sourced override CSV against the recorded provenance checksum. When upstream has moved, it opens a PR titled `csv-sync: pull bcfishpass overrides <date>` with the fresh content plus updated `provenance:` blocks (new `synced`, `upstream_sha`, `checksum`) in both `bcfishpass` and `default` bundle configs.

## Cadence rationale

April 2026 sample of upstream PRs:

| date range | CSV-touching PRs/day |
|---|---|
| 2026-04-20..04-24 (5 weekdays) | 1, 1, 3, 1, 5 |
| 2026-03-30..04-08 (8 weekdays) | 1, 2, 1, 0, 0, 0, 0, 2, 2 |

Active periods average 1-3 CSV-touching PRs per weekday with near-zero weekend activity. Nightly Mon-Sat means each sync PR maps to ~1 upstream PR (easier to review and trace) vs. weekly batches that mix 5-15 changes. Cron is free; review burden is *lower per PR* with nightly even though more PRs total.

## Files

- `data-raw/sync_bcfishpass_csvs.R` — gh-api-driven sync (contents endpoint with git-blob fallback for >1MB files); fixed-string YAML header match; blank-line-tolerant body loop; `--dry-run` flag
- `.github/workflows/sync-bcfishpass-csvs.yml` — cron `0 9 * * 1-6` + `workflow_dispatch`; opens PR via `gh pr create` with markdown summary

## Local validation

```
$ Rscript data-raw/sync_bcfishpass_csvs.R --dry-run
Checking 7 bcfishpass-sourced files for drift...
  overrides/user_habitat_classification.csv: DRIFT — recording change
  overrides/user_modelled_crossing_fixes.csv: DRIFT — recording change
  overrides/user_pscis_barrier_status.csv: DRIFT — recording change
  overrides/pscis_modelledcrossings_streams_xref.csv: DRIFT — recording change
  overrides/user_barriers_definite.csv: clean
  overrides/user_barriers_definite_control.csv: clean
  overrides/user_crossings_misc.csv: DRIFT — recording change

[dry-run] would update 5 files; skipping writes
```

Full real-run validated YAML edits preserve format + comments (only 3 keys per drifted entry change). Reverted; first scheduled run after merge will produce the bootstrap sync PR.

## Code review

`/code-check` round 1 surfaced 4 findings; 3 fixed:

1. `download.file` returns 0 on HTML error pages → switched to `gh api`
2. `system2 stderr=TRUE` merged errors into JSON parser input → new `gh_api_json` wrapper captures stderr separately
3. Loop on `^    \S` would silently skip rest of entry after a blank line → tolerant condition

Fourth finding (default `GITHUB_TOKEN` doesn't trigger CI on auto-PRs) is n/a today — no R-CMD-check workflow exists.

## Test plan

- [x] Local dry-run produces actionable diff list
- [x] Local real-run produces correct YAML edits (3 keys per entry, comments preserved)
- [x] Both bundles update byte-identically (`diff -r` confirmed)
- [ ] Validate end-to-end via `workflow_dispatch` from the GitHub UI after this PR pushes

## Cross-refs

Closes #56. Relates to #40 (provenance plumbing this depends on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
