### PR TITLE
Pull bcfishpass vignette to dev/ until tighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,12 +86,15 @@ fresh::frs_habitat(conn, "MORR",
 lnk_aggregate(conn, "working.crossings", "fresh.streams_habitat")
 ```
 
-## Full pipeline (reproducing bcfishpass)
+## Full pipeline (linear habitat classification)
 
-The primitives above assemble into a six-phase pipeline that reproduces
-bcfishpass's freshwater habitat classification for any watershed group.
-A config bundle declares the manifest of rules, parameters, and override
-CSVs that drive a run.
+The primitives above assemble into a six-phase pipeline that classifies
+spawning + rearing habitat per segment for any watershed group. A
+config bundle declares the manifest of rules, parameters, and override
+CSVs that drive a run; the bundled `"bcfishpass"` config expresses
+bcfishpass's classification slice (spawning + rearing predicates,
+natural-barrier modelling, observation-based access overrides) as a
+self-contained input.
 
 ```r
 cfg <- lnk_config("bcfishpass")
@@ -105,9 +108,10 @@ lnk_pipeline_connect(conn, aoi = "BULK", cfg = cfg, schema = "working_bulk")
 ```
 
 `data-raw/_targets.R` wraps this over five validated WSGs (ADMS, BULK,
-BABL, ELKR, DEAD) with `targets` for caching and reproducibility. See
-the [Reproducing bcfishpass](https://newgraphenvironment.github.io/link/articles/reproducing-bcfishpass.html)
-vignette for the full story.
+BABL, ELKR, DEAD) with `targets` for caching and cross-WSG regression.
+A vignette walking through the bundled bcfishpass config is in
+preparation; meanwhile the per-phase detail lives in
+[`research/bcfishpass_comparison.md`](https://github.com/NewGraphEnvironment/link/blob/main/research/bcfishpass_comparison.md).
 
 ## Ecosystem
 

--- a/dev/habitat-bcfishpass.Rmd.draft
+++ b/dev/habitat-bcfishpass.Rmd.draft
@@ -1,8 +1,8 @@
 ---
-title: "Reproducing bcfishpass with link + fresh"
+title: "Modelling spawning and rearing habitat using bcfishpass defaults"
 output: bookdown::html_vignette2
 vignette: >
-  %\VignetteIndexEntry{Reproducing bcfishpass with link + fresh}
+  %\VignetteIndexEntry{Modelling spawning and rearing habitat using bcfishpass defaults}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -19,12 +19,22 @@ options(knitr.kable.NA = "—")
 library(link)
 ```
 
-[bcfishpass](https://github.com/smnorris/bcfishpass) is the reference
-model for freshwater habitat classification and fish passage
-prioritization in British Columbia. link + [fresh](https://newgraphenvironment.github.io/fresh/)
-provide a configurable, reproducible R-side pipeline. The bundled
-`"bcfishpass"` config reproduces bcfishpass's classification method.
-Other configs can express other methods; the package is method-agnostic.
+[bcfishpass](https://github.com/smnorris/bcfishpass) is a province-wide
+modelling framework for British Columbia. Its scope is broader than
+linear habitat classification — PSCIS road and rail crossing
+assessment, fish passage barrier identification, watershed
+connectivity analysis, and restoration prioritization (Watershed
+Connectivity Restoration Plans). This vignette covers only the
+per-segment linear habitat classification slice — the layer that
+feeds the others.
+
+The bundled `"bcfishpass"` config in link expresses the per-segment
+linear habitat classification (spawning + rearing), natural-barrier
+modelling (gradient, falls, user-identified definite barriers), and
+observation-based access overrides of bcfishpass as a self-contained
+input bundle. The broader bcfishpass scope — PSCIS crossing
+assessment, WCRP, restoration prioritization — is bcfishpass-side and
+out of link's scope.
 
 This vignette walks through what the bcfishpass configuration does, how
 to run it, and how the output compares to bcfishpass reference tables.
@@ -224,29 +234,37 @@ bypass. Numeric impact and the reasoning are in
 
 ## Running the pipeline
 
+The user-facing entry point is six `lnk_pipeline_*` phase calls
+driven by an `lnk_config()` bundle. Each phase writes to a working
+schema in PostgreSQL; the final `fresh.streams_habitat` table holds
+per-segment booleans for `spawning`, `rearing`, `lake_rearing`, and
+`wetland_rearing`, per species.
+
 ```{r entrypoint, eval = FALSE}
 library(link)
-library(targets)
+library(DBI)
 
-# `_targets.R` lives in data-raw/; run from that directory.
-setwd("data-raw")
+conn   <- lnk_db_conn()
+cfg    <- lnk_config("bcfishpass")
+schema <- "working_bulk"
 
-tar_make()                  # 5 WSGs, serial
-rollup <- tar_read(rollup)  # per-WSG × species × habitat tibble
+lnk_pipeline_setup(   conn,                  schema, overwrite = TRUE)
+lnk_pipeline_load(    conn, aoi = "BULK", cfg = cfg, schema)
+lnk_pipeline_prepare( conn, aoi = "BULK", cfg = cfg, schema)
+lnk_pipeline_break(   conn, aoi = "BULK", cfg = cfg, schema)
+lnk_pipeline_classify(conn, aoi = "BULK", cfg = cfg, schema)
+lnk_pipeline_connect( conn, aoi = "BULK", cfg = cfg, schema)
 ```
 
-`tar_make()` runs
-[`compare_bcfishpass_wsg()`](https://github.com/NewGraphEnvironment/link/blob/main/data-raw/compare_bcfishpass_wsg.R)
-once each for Adams (ADMS), Bulkley (BULK), Babine (BABL), Elk
-(ELKR), and Deadman (DEAD), binding the per-WSG tibbles into one
-rollup. Each call exercises the six `lnk_pipeline_*` phases. ADMS/BULK/
-BABL/ELKR span the species assemblages used in bcfishpass validation —
-BT with CH, CO, SK on ADMS; PK and ST added on BULK and BABL; BT with
-WCT on ELKR. DEAD is an end-to-end test for the
-`barriers_definite_control` wiring: it has a single `barrier_ind = TRUE`
-control row with enough anadromous observations upstream to exercise
-the filter, which the other four WSGs don't. Method agreement across
-this spread is stronger evidence than agreement on a single WSG.
+Run the same six phases per AOI to build a province-wide picture, or
+plug them into a `targets` pipeline as
+[`data-raw/_targets.R`](https://github.com/NewGraphEnvironment/link/blob/main/data-raw/_targets.R)
+does for cross-WSG regression — Adams (ADMS), Bulkley (BULK), Babine
+(BABL), Elk (ELKR), and Deadman (DEAD), binding per-WSG tibbles into
+one rollup. ADMS/BULK/BABL/ELKR span the species assemblages used in
+bcfishpass validation; DEAD exercises the `barriers_definite_control`
+filter. Method agreement across that spread is stronger evidence than
+agreement on a single WSG.
 
 ## The rollup
 
@@ -303,6 +321,13 @@ The watershed upstream of the Neexdzii Kwa / Wetzin Kwa (Bulkley /
 Morice) confluence, built via `FWA_WatershedAtMeasure(360873822,
 166030.4)`. Sits inside the BULK watershed group, so the BULK rollup
 above aggregates this area along with the rest of the Bulkley.
+
+The pipeline produces per-segment linear classification across
+`spawning`, `rearing`, `lake_rearing`, and `wetland_rearing` for every
+species in the bundle. The map below visualizes the spawning/rearing
+slice for chinook (CH) — the simplest cut available; per-species ha
+rollups, lake/wetland decomposition, and other species are also in
+`fresh.streams_habitat`.
 
 The link pipeline layer is visible by default; toggle on the
 bcfishpass reference layer to compare.


### PR DESCRIPTION
## Summary

Pull the bcfishpass vignette out of the public pkgdown site until the content is tight enough to publish. Same pattern as scoring-crossings — move to `dev/.draft` (build-path-excluded), preserve for resumption, return when ready.

## Why

Now that the pkgdown site is public, half-baked vignettes shouldn't render. Open issues with this vignette before it can land:

- Title overstates the scope ("Reproducing bcfishpass" — we reproduce only the linear classification slice; bcfishpass is province-wide and does much more).
- Entry-point code chunk uses `setwd("data-raw"); tar_make()` — the dev/regression pattern, not the user-facing API.
- Rollup table compares link (post-overlay) vs `habitat_linear_<sp>` (model-only) — the +43.8% on BABL SK reads as a parity gap when it's actually link-with-overlay vs bcfishpass-without. Should retarget to `streams_habitat_linear` (model + known); separate work.
- Map framing implies the pipeline only does spawning/rearing — actually does spawning/rearing/lake_rearing/wetland_rearing per species; map just shows the spawning/rearing CH slice.

## Content updates applied before the move

So the `dev/` draft is closer to landing-ready:

- Title + VignetteIndexEntry → "Modelling spawning and rearing habitat using bcfishpass defaults"
- New top-of-vignette scope paragraph clarifying bcfishpass's broader scope (PSCIS, fish passage modelling, WCRP, restoration prioritization) and what link's bundled config covers
- bcfishpass-config sentence rewritten: linear classification + natural-barrier modelling + observation-based access overrides; broader scope explicitly out of scope
- Entrypoint replaced with six explicit `lnk_pipeline_*` calls; `data-raw/_targets.R` mentioned as cross-WSG regression infra, not entry point
- Map framing clarified: linear classification covers all four habitat fields per species; map shows CH spawning/rearing slice as the simplest visualization

## README

`README.md` "Full pipeline (reproducing bcfishpass)" → "Full pipeline (linear habitat classification)" with parallel framing tweak; removed the now-broken pkgdown vignette link.

## Test plan

- [x] `devtools::test()`: 453 PASS, 0 FAIL
- [x] `vignettes/` no longer contains a `.Rmd`; pkgdown won't try to render
- [x] `dev/habitat-bcfishpass.Rmd.draft` carries the updated content for resumption
- [x] `inst/extdata/vignette-data/*.rds` kept in place so the draft renders locally without re-running the pipeline

## Follow-ups when we resume

- Retarget the rollup query in `data-raw/compare_bcfishpass_wsg.R` from `habitat_linear_<sp>` to `streams_habitat_linear.<spawning|rearing>_<sp> > 0` for apples-to-apples post-overlay comparison
- Consider regenerating the rollup with the corrected query before re-publishing
- Address the range-containment relaxation in `fresh::frs_habitat_overlay` (separate fresh follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
