### PR TITLE
Shape fingerprint + halt auto-merge on shape drift (#64)

### DIFF
--- a/.github/workflows/sync-bcfishpass-csvs.yml
+++ b/.github/workflows/sync-bcfishpass-csvs.yml
@@ -1,10 +1,18 @@
 # Daily sync of bcfishpass-sourced override CSVs. Diffs each
-# bcfishpass-sourced file against the recorded provenance checksum
-# and, when upstream has moved, opens a PR with new content + updated
-# provenance blocks AND immediately auto-merges it. The PR exists for
-# discoverability (searchable history, easy revert) — review is not
-# expected since CSVs are upstream-curated and provenance checksums
-# verify byte equivalence with upstream.
+# bcfishpass-sourced file against the recorded provenance byte +
+# shape checksums.
+#
+# Drift kinds:
+#   - byte  — file content changed but column structure didn't.
+#             Auto-PR opens AND auto-merges. Discoverability via the
+#             PR list; review is not expected (CSVs are upstream-
+#             curated and shape stayed the same).
+#   - shape — column rename / add / remove / reshape. Auto-PR opens
+#             with `schema-drift` label, NOT auto-merged. Workflow
+#             exits non-zero so the Actions tab shows red. Coordinated
+#             review across link / fresh / crate is required before
+#             merging — see link#64.
+#   - none  — no drift, exit clean.
 #
 # Cadence rationale: April 2026 sample showed 1-3 CSV-touching upstream
 # PRs per active weekday; daily diffs produce per-PR-traceable sync
@@ -51,19 +59,34 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: Rscript data-raw/sync_bcfishpass_csvs.R
 
-      - name: Open + auto-merge PR if any drift
+      - name: Open PR (auto-merge byte drift; halt on shape drift)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          DRIFT_KIND="$(cat /tmp/sync_drift_kind 2>/dev/null || echo none)"
+          echo "Drift kind: $DRIFT_KIND"
+          case "$DRIFT_KIND" in
+            none)
+              echo "No drift — exit clean"
+              exit 0
+              ;;
+            byte|shape)
+              # fallthrough to PR creation
+              ;;
+            *)
+              echo "Unknown drift kind: '$DRIFT_KIND' — failing loud"
+              exit 1
+              ;;
+          esac
+
           if [[ -z "$(git status --porcelain)" ]]; then
-            echo "No drift — nothing to commit"
-            exit 0
+            echo "Drift kind reported $DRIFT_KIND but working tree clean — bug"
+            exit 1
           fi
+
           DATESTAMP="$(date -u +%Y%m%d)"
           BRANCH="csv-sync/${DATESTAMP}"
-          # Same-day re-run (workflow_dispatch + an existing branch) —
-          # append RUN_ID to keep branch names unique.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             BRANCH="csv-sync/${DATESTAMP}-${GITHUB_RUN_ID}"
           fi
@@ -71,16 +94,42 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add inst/extdata/configs/
-          git commit -m "csv-sync: pull bcfishpass overrides ${DATESTAMP}"
+          if [[ "$DRIFT_KIND" == "shape" ]]; then
+            git commit -m "csv-sync: SHAPE DRIFT — pull bcfishpass overrides ${DATESTAMP}"
+          else
+            git commit -m "csv-sync: pull bcfishpass overrides ${DATESTAMP}"
+          fi
           git push -u origin "$BRANCH"
+
           BODY_FILE=/tmp/sync_summary.md
           if [[ ! -f "$BODY_FILE" ]]; then
             echo "Auto-generated CSV sync." > "$BODY_FILE"
           fi
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "csv-sync: pull bcfishpass overrides ${DATESTAMP}" \
-            --body-file "$BODY_FILE")
-          echo "Created PR: $PR_URL"
-          gh pr merge "$PR_URL" --merge --delete-branch
+
+          if [[ "$DRIFT_KIND" == "shape" ]]; then
+            # Ensure label exists; ignore "already exists" error.
+            gh label create schema-drift \
+              --color B60205 \
+              --description "Upstream CSV shape changed (column rename / add / remove / reshape) — coordinated link/fresh/crate review needed before merging" \
+              || true
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "csv-sync: SHAPE DRIFT — pull bcfishpass overrides ${DATESTAMP}" \
+              --body-file "$BODY_FILE" \
+              --label schema-drift)
+            echo "Created shape-drift PR (NOT auto-merged): $PR_URL"
+            # Fail loud so the Actions tab shows red and someone notices.
+            exit 2
+          else
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "csv-sync: pull bcfishpass overrides ${DATESTAMP}" \
+              --body-file "$BODY_FILE")
+            echo "Created byte-drift PR: $PR_URL"
+            # `--auto` queues the merge if branch protection adds
+            # required checks later (e.g., R-CMD-check). Today no
+            # required checks → behaves identically to immediate merge.
+            gh pr merge "$PR_URL" --merge --auto --delete-branch
+          fi

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Crossing Connectivity Interpretation
-Version: 0.12.0
+Version: 0.13.0
 Authors@R:
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# link 0.13.0
+
+Shape fingerprint + halt auto-merge on shape drift ([#64](https://github.com/NewGraphEnvironment/link/issues/64)).
+
+`data-raw/sync_bcfishpass_csvs.R` and the daily `sync-bcfishpass-csvs.yml` cron previously compared each bcfishpass-sourced CSV against a recorded sha256 byte checksum and auto-merged any drift. That worked for value drift (rows added/edited) but was blind to shape drift — bcfishpass's 2026-04-26 long→wide reshape (with column type change) passed straight through and broke link's pipeline downstream. This release adds a separate **shape fingerprint** alongside the byte checksum; the workflow auto-merges byte-only drift as before but halts shape drift for coordinated review.
+
+- New `shape_checksum` field in the `provenance:` block of each bundle's `config.yaml`. Computed as sha256 of the file's first line (whitespace-normalized). Catches column rename / add / remove / reshape — the dominant failure mode. Type changes within stable columns are out of scope (rarer; can extend later if needed).
+- `data-raw/sync_bcfishpass_csvs.R` computes shape fingerprint at sync time, classifies each file's drift as `byte` or `shape`, writes the overall drift kind to `/tmp/sync_drift_kind` for the workflow to consume.
+- `.github/workflows/sync-bcfishpass-csvs.yml` reads the drift kind. Byte-only drift → auto-PR + auto-merge as today. Shape drift → auto-PR opens with `schema-drift` label, NOT auto-merged, workflow exits non-zero (red on Actions tab) so the change is visible. Coordinated review across link / fresh / crate is required before merging.
+- `lnk_config_verify()` extended with `shape_drift` column. **Breaking** (pre-1.0): old single `drift` column renamed to `byte_drift`; existing tibble shape now `(file, byte_expected, byte_observed, byte_drift, shape_expected, shape_observed, shape_drift, missing)`.
+- `lnk_stamp()` markdown rendering surfaces both byte and shape drift counts in the provenance summary.
+- 15 new tests (468 total, was 453) — `.lnk_shape_fingerprint()` helper + shape-drift detection + missing-file handling + backward-compat path for bundles without `shape_checksum:` field.
+
+Coordinates with crate's adapter pattern (link#65, crate#2) — when shape drift fires, crate's normalize handler is the right place to absorb the upstream change before link's pipeline sees it.
+
 # link 0.12.0
 
 Pick up `fresh 0.22.0` overlay simplification — caller-side update for the canonical-shape contract.

--- a/R/lnk_config_verify.R
+++ b/R/lnk_config_verify.R
@@ -1,29 +1,51 @@
-#' Verify Config Bundle File Checksums
+#' Verify Config Bundle File Checksums and Shape
 #'
-#' Recomputes sha256 for every file declared in the bundle's
-#' `provenance:` block and compares against the recorded checksum.
-#' Returns a tibble of expected vs observed; flags drift.
+#' Recomputes sha256 byte and shape checksums for every file declared
+#' in the bundle's `provenance:` block and compares against the
+#' recorded values. Returns a tibble of expected vs observed; flags
+#' drift on each axis separately.
 #'
-#' Use this at run time to detect silent drift — a file that was edited
-#' without re-recording its checksum, or an external CSV that was
-#' re-synced under the same path. Drift between two pipeline runs on
-#' the same DB state with the same package versions almost always
+#' **Byte drift** (`byte_drift`) — file content changed (rows
+#' added/edited/removed, or whole-file re-shape). Detected via sha256
+#' of the full file. Catches every kind of change but doesn't tell you
+#' WHAT kind.
+#'
+#' **Shape drift** (`shape_drift`) — file's *header* changed (column
+#' added / renamed / removed / reshaped). Detected via sha256 of the
+#' first line of the file (whitespace-normalized). A pure-value
+#' change (rows added with no column change) shows `byte_drift = TRUE`
+#' but `shape_drift = FALSE`. A column rename shows both TRUE.
+#' Header-only fingerprint catches the dominant failure mode (column
+#' structure change); type changes within stable columns are not
+#' detected — they require value-level inspection that's out of scope
+#' here.
+#'
+#' Use this at run time to detect silent drift — a file that was
+#' edited without re-recording its checksum, or an external CSV that
+#' was re-synced under the same path. Drift between two pipeline runs
+#' on the same DB state with the same package versions almost always
 #' traces back to a config-file edit; `lnk_config_verify()` is the
 #' fastest way to localize the change.
 #'
 #' @param cfg An `lnk_config` object from [lnk_config()].
-#' @param strict Logical. When `TRUE`, errors if any file has drifted.
-#'   Default `FALSE` warns and returns the tibble for inspection.
+#' @param strict Logical. When `TRUE`, errors if any file has drifted
+#'   on either axis. Default `FALSE` warns and returns the tibble for
+#'   inspection.
 #'
 #' @return A tibble with columns:
 #'
 #'   - `file` — path relative to `cfg$dir`
-#'   - `expected` — checksum recorded in the manifest (sha256 hex)
-#'   - `observed` — checksum recomputed from the current file (sha256
-#'     hex)
-#'   - `drift` — logical, `TRUE` when expected != observed
+#'   - `byte_expected` — byte checksum recorded in the manifest
+#'   - `byte_observed` — byte checksum recomputed from the current file
+#'   - `byte_drift` — logical, `TRUE` when byte checksums differ
+#'   - `shape_expected` — shape checksum recorded in the manifest, or
+#'     `NA` when the manifest has no `shape_checksum` field
+#'   - `shape_observed` — shape checksum recomputed from the current
+#'     file's header line
+#'   - `shape_drift` — logical, `TRUE` when shape checksums differ
+#'     (and the manifest had a `shape_expected` to compare against)
 #'   - `missing` — logical, `TRUE` when the file no longer exists on
-#'     disk (observed is `NA` in this case)
+#'     disk (observed values are `NA`)
 #'
 #'   The tibble carries one row per provenanced file. When the bundle
 #'   has no `provenance:` block (`cfg$provenance` is `NULL`) returns
@@ -39,7 +61,7 @@
 #' verify
 #'
 #' \dontrun{
-#' # In a verification log: error if anything drifted
+#' # In a verification log: error on either drift kind
 #' lnk_config_verify(cfg, strict = TRUE)
 #' }
 lnk_config_verify <- function(cfg, strict = FALSE) {
@@ -63,37 +85,58 @@ lnk_config_verify <- function(cfg, strict = FALSE) {
   }
 
   rows <- lapply(names(prov), function(rel) {
-    expected <- prov[[rel]][["checksum"]] %||% NA_character_
+    byte_expected  <- prov[[rel]][["checksum"]]       %||% NA_character_
+    shape_expected <- prov[[rel]][["shape_checksum"]] %||% NA_character_
     abs_path <- file.path(cfg$dir, rel)
     if (!file.exists(abs_path)) {
       return(data.frame(
-        file     = rel,
-        expected = expected,
-        observed = NA_character_,
-        drift    = TRUE,
-        missing  = TRUE,
+        file           = rel,
+        byte_expected  = byte_expected,
+        byte_observed  = NA_character_,
+        byte_drift     = TRUE,
+        shape_expected = shape_expected,
+        shape_observed = NA_character_,
+        shape_drift    = !is.na(shape_expected),
+        missing        = TRUE,
         stringsAsFactors = FALSE
       ))
     }
-    observed <- paste0("sha256:",
-                       digest::digest(file = abs_path, algo = "sha256"))
+    byte_observed <- paste0("sha256:",
+                            digest::digest(file = abs_path, algo = "sha256"))
+    shape_observed <- .lnk_shape_fingerprint(abs_path)
+    # `shape_drift` requires a non-empty recorded shape_checksum to
+    # compare against — guard with both is.na() and nzchar() to swallow
+    # the malformed-YAML case (`shape_checksum:` with no value parses
+    # to empty string in some yaml versions, NULL in others).
+    has_recorded <- !is.na(shape_expected) && nzchar(shape_expected)
     data.frame(
-      file     = rel,
-      expected = expected,
-      observed = observed,
-      drift    = !identical(expected, observed),
-      missing  = FALSE,
+      file           = rel,
+      byte_expected  = byte_expected,
+      byte_observed  = byte_observed,
+      byte_drift     = !identical(byte_expected, byte_observed),
+      shape_expected = shape_expected,
+      shape_observed = shape_observed,
+      shape_drift    = has_recorded &&
+                         !identical(shape_expected, shape_observed),
+      missing        = FALSE,
       stringsAsFactors = FALSE
     )
   })
   out <- do.call(rbind, rows)
 
-  if (any(out$drift)) {
-    drifted <- out[out$drift, "file", drop = TRUE]
+  drifted_any <- out$byte_drift | out$shape_drift
+  if (any(drifted_any)) {
+    drifted <- out[drifted_any, ]
+    parts <- vapply(seq_len(nrow(drifted)), function(i) {
+      kinds <- c(if (drifted$byte_drift[i])  "byte",
+                 if (drifted$shape_drift[i]) "shape")
+      sprintf("  - %s (%s drift)", drifted$file[i],
+              paste(kinds, collapse = " + "))
+    }, character(1))
     msg <- paste0(
-      "Config bundle '", cfg$name, "' has ", length(drifted),
-      " file(s) drifted from recorded checksum:\n  - ",
-      paste(drifted, collapse = "\n  - "))
+      "Config bundle '", cfg$name, "' has ", nrow(drifted),
+      " file(s) drifted from recorded checksum:\n",
+      paste(parts, collapse = "\n"))
     if (strict) {
       stop(msg, call. = FALSE)
     }
@@ -103,13 +146,35 @@ lnk_config_verify <- function(cfg, strict = FALSE) {
   out
 }
 
+#' Compute a shape fingerprint for a CSV / YAML / TSV file
+#'
+#' Hashes the first line (whitespace-normalized) with sha256. Catches
+#' header changes — column rename / add / remove / reshape — but not
+#' type changes within stable columns.
+#' @noRd
+.lnk_shape_fingerprint <- function(file_path) {
+  first_line <- tryCatch(
+    readLines(file_path, n = 1, warn = FALSE),
+    error = function(e) character(0))
+  if (length(first_line) == 0L) return(NA_character_)
+  # Normalize trailing whitespace + carriage return to avoid false
+  # drifts from CRLF vs LF or trailing spaces in the header.
+  normalized <- sub("\\s+$", "", first_line)
+  paste0("sha256:", digest::digest(normalized,
+                                    algo = "sha256",
+                                    serialize = FALSE))
+}
+
 .lnk_verify_empty <- function() {
   data.frame(
-    file     = character(0),
-    expected = character(0),
-    observed = character(0),
-    drift    = logical(0),
-    missing  = logical(0),
+    file           = character(0),
+    byte_expected  = character(0),
+    byte_observed  = character(0),
+    byte_drift     = logical(0),
+    shape_expected = character(0),
+    shape_observed = character(0),
+    shape_drift    = logical(0),
+    missing        = logical(0),
     stringsAsFactors = FALSE
   )
 }

--- a/R/lnk_stamp.R
+++ b/R/lnk_stamp.R
@@ -160,8 +160,10 @@ print.lnk_stamp <- function(x, ...) {
   cat("  link:       ", x$software$link$version, "\n", sep = "")
   cat("  fresh:      ", x$software$fresh$version, "\n", sep = "")
   if (!is.null(x$provenance)) {
+    n_byte <- sum(x$provenance$byte_drift)
+    n_shape <- sum(x$provenance$shape_drift)
     cat("  provenance: ", nrow(x$provenance), " files (",
-        sum(x$provenance$drift), " drifted)\n", sep = "")
+        n_byte, " byte, ", n_shape, " shape drifted)\n", sep = "")
   }
   if (!is.null(x$db)) {
     cat("  db:         bcfishobs.observations=",
@@ -215,18 +217,20 @@ format.lnk_stamp <- function(x, type = c("markdown", "text"), ...) {
   }
 
   if (!is.null(x$provenance) && nrow(x$provenance) > 0L) {
-    drifted <- sum(x$provenance$drift)
+    n_byte  <- sum(x$provenance$byte_drift)
+    n_shape <- sum(x$provenance$shape_drift)
     lines <- c(lines,
       "",
-      sprintf("### Config provenance (%d files, %d drifted)",
-              nrow(x$provenance), drifted),
+      sprintf("### Config provenance (%d files, %d byte / %d shape drifted)",
+              nrow(x$provenance), n_byte, n_shape),
       "",
-      "| file | drift |",
-      "|---|---|")
+      "| file | byte drift | shape drift |",
+      "|---|---|---|")
     for (i in seq_len(nrow(x$provenance))) {
-      lines <- c(lines, sprintf("| `%s` | %s |",
+      lines <- c(lines, sprintf("| `%s` | %s | %s |",
                                  x$provenance$file[i],
-                                 if (x$provenance$drift[i]) "**yes**" else "no"))
+                                 if (x$provenance$byte_drift[i]) "**yes**" else "no",
+                                 if (x$provenance$shape_drift[i]) "**yes**" else "no"))
     }
   }
   paste(lines, collapse = "\n")

--- a/data-raw/sync_bcfishpass_csvs.R
+++ b/data-raw/sync_bcfishpass_csvs.R
@@ -33,6 +33,7 @@ UPSTREAM_REPO <- "smnorris/bcfishpass"
 BUNDLE_BCFP <- "inst/extdata/configs/bcfishpass"
 BUNDLE_DEF  <- "inst/extdata/configs/default"
 SUMMARY_PATH <- "/tmp/sync_summary.md"
+DRIFT_KIND_PATH <- "/tmp/sync_drift_kind"
 
 stopifnot(file.exists(file.path(BUNDLE_BCFP, "config.yaml")),
           file.exists(file.path(BUNDLE_DEF, "config.yaml")))
@@ -41,6 +42,20 @@ stopifnot(file.exists(file.path(BUNDLE_BCFP, "config.yaml")),
 
 sha256_text <- function(content_bytes) {
   paste0("sha256:", digest::digest(content_bytes,
+                                    algo = "sha256",
+                                    serialize = FALSE))
+}
+
+# Shape fingerprint: sha256 of normalized first line. Catches column
+# rename/add/remove/reshape but not type changes within stable columns.
+# Mirrors `link:::.lnk_shape_fingerprint()` so sync-time and runtime
+# computations agree.
+shape_fingerprint <- function(content_bytes) {
+  text <- rawToChar(content_bytes)
+  first_line <- sub("\n.*$", "", text)
+  if (!nzchar(first_line)) return(NA_character_)
+  normalized <- sub("\\s+$", "", first_line)
+  paste0("sha256:", digest::digest(normalized,
                                     algo = "sha256",
                                     serialize = FALSE))
 }
@@ -111,11 +126,13 @@ gh_api_json <- function(endpoint) {
   jsonlite::fromJSON(paste(out, collapse = "\n"), simplifyVector = FALSE)
 }
 
-# Replace `upstream_sha`, `synced`, `checksum` lines for a specific
-# provenance entry. Walks the YAML as text lines so comments + key
-# ordering are preserved (yaml::write_yaml round-trips lose comments).
+# Replace `upstream_sha`, `synced`, `checksum`, `shape_checksum` lines
+# for a specific provenance entry. Walks the YAML as text lines so
+# comments + key ordering are preserved (yaml::write_yaml round-trips
+# lose comments).
 update_provenance_in_yaml <- function(yaml_path, rel_path,
-                                       new_sha, new_synced, new_checksum) {
+                                       new_sha, new_synced,
+                                       new_checksum, new_shape_checksum) {
   lines <- readLines(yaml_path)
   # Provenance entries are indented 2 spaces under top-level
   # `provenance:` and the file path key has a trailing colon. Match
@@ -142,8 +159,11 @@ update_provenance_in_yaml <- function(yaml_path, rel_path,
       lines[i] <- paste0("    upstream_sha: ", new_sha)
     } else if (grepl("^    synced:", line)) {
       lines[i] <- paste0("    synced: ", new_synced)
-    } else if (grepl("^    checksum:", line)) {
+    } else if (grepl("^    checksum:", line) &&
+               !grepl("^    shape_checksum:", line)) {
       lines[i] <- paste0("    checksum: ", new_checksum)
+    } else if (grepl("^    shape_checksum:", line)) {
+      lines[i] <- paste0("    shape_checksum: ", new_shape_checksum)
     }
     i <- i + 1L
   }
@@ -178,7 +198,8 @@ for (rel in target_files) {
     cat(sprintf("  %s: skipping (no upstream path in provenance)\n", rel))
     next
   }
-  expected <- prov[[rel]]$checksum
+  expected_byte  <- prov[[rel]]$checksum
+  expected_shape <- prov[[rel]]$shape_checksum
   upstream_bytes <- tryCatch(fetch_raw(upstream_rel),
     error = function(e) {
       cat(sprintf("  %s: WARNING fetch failed (%s) — skipping\n",
@@ -186,20 +207,39 @@ for (rel in target_files) {
       NULL
     })
   if (is.null(upstream_bytes)) next
-  observed <- sha256_text(upstream_bytes)
-  if (identical(observed, expected)) {
+  observed_byte  <- sha256_text(upstream_bytes)
+  observed_shape <- shape_fingerprint(upstream_bytes)
+  if (identical(observed_byte, expected_byte)) {
     cat(sprintf("  %s: clean\n", rel))
     next
   }
-  cat(sprintf("  %s: DRIFT — recording change\n", rel))
+  shape_drift <- !is.null(expected_shape) &&
+                  !identical(observed_shape, expected_shape)
+  cat(sprintf("  %s: %s DRIFT — recording change\n",
+              rel, if (shape_drift) "SHAPE" else "byte"))
   changes[[rel]] <- list(
     rel = rel,
     upstream_rel = upstream_rel,
     bytes = upstream_bytes,
-    old_checksum = expected,
-    new_checksum = observed
+    old_checksum  = expected_byte,
+    new_checksum  = observed_byte,
+    old_shape     = expected_shape,
+    new_shape     = observed_shape,
+    shape_drift   = shape_drift
   )
 }
+
+# Determine overall drift kind for the workflow gate.
+drift_kind <- if (length(changes) == 0L) {
+  "none"
+} else if (any(vapply(changes, function(ch) isTRUE(ch$shape_drift),
+                       logical(1)))) {
+  "shape"
+} else {
+  "byte"
+}
+writeLines(drift_kind, DRIFT_KIND_PATH)
+cat(sprintf("Drift kind: %s (-> %s)\n", drift_kind, DRIFT_KIND_PATH))
 
 if (length(changes) == 0L) {
   cat("No drift detected — exit clean\n")
@@ -224,32 +264,52 @@ for (rel in names(changes)) {
   ch <- changes[[rel]]
   for (bundle in c(BUNDLE_BCFP, BUNDLE_DEF)) {
     out_path <- file.path(bundle, rel)
+    # writeBin (NOT writeLines) — preserves bytes verbatim so the
+    # sync-time sha256 of `ch$bytes` matches the runtime sha256 of
+    # the on-disk file (lnk_config_verify hashes by file path).
+    # writeLines on Windows would translate \n -> \r\n and break parity.
     writeBin(ch$bytes, out_path)
     update_provenance_in_yaml(file.path(bundle, "config.yaml"),
       rel_path = rel,
       new_sha = ch$upstream_sha,
       new_synced = today,
-      new_checksum = ch$new_checksum)
+      new_checksum = ch$new_checksum,
+      new_shape_checksum = ch$new_shape)
   }
-  cat(sprintf("  %s: wrote (sha %s)\n", rel, ch$upstream_sha))
+  cat(sprintf("  %s: wrote (sha %s%s)\n",
+              rel, ch$upstream_sha,
+              if (ch$shape_drift) " — SHAPE DRIFT, do NOT auto-merge" else ""))
 }
 
 # --- Markdown summary for PR body ------------------------------------------
 
+any_shape_drift <- any(vapply(changes,
+  function(ch) isTRUE(ch$shape_drift), logical(1)))
 md_lines <- c(
-  sprintf("# CSV sync — %s", today),
+  sprintf("# CSV sync — %s%s", today,
+          if (any_shape_drift) " — SHAPE DRIFT" else ""),
   "",
+  if (any_shape_drift) c(
+    "> :warning: One or more files changed shape (column rename / add /",
+    "> remove / reshape). This PR is **not** auto-merged — the link",
+    "> pipeline and downstream consumers (`fresh::frs_habitat_overlay`,",
+    "> reporting repos, db_newgraph schema views) likely need a",
+    "> coordinated update before merging. See [link#64](https://github.com/NewGraphEnvironment/link/issues/64)",
+    "> + crate's adapter for the recommended workflow.",
+    ""
+  ) else character(0),
   sprintf("Synced %d file(s) from [%s](https://github.com/%s):",
           length(changes), UPSTREAM_REPO, UPSTREAM_REPO),
   "",
-  "| file | upstream_sha | old checksum | new checksum |",
-  "|---|---|---|---|"
+  "| file | upstream_sha | drift | old byte | new byte |",
+  "|---|---|---|---|---|"
 )
 for (rel in names(changes)) {
   ch <- changes[[rel]]
   md_lines <- c(md_lines,
-    sprintf("| `%s` | `%s` | `%s` | `%s` |",
+    sprintf("| `%s` | `%s` | %s | `%s` | `%s` |",
             rel, ch$upstream_sha,
+            if (ch$shape_drift) "**shape**" else "byte",
             substr(ch$old_checksum, 1, 14),
             substr(ch$new_checksum, 1, 14)))
 }

--- a/inst/extdata/configs/bcfishpass/config.yaml
+++ b/inst/extdata/configs/bcfishpass/config.yaml
@@ -42,65 +42,77 @@ provenance:
     generated_by: lnk_rules_build
     generator_sha: 8f1890564b9148573535a679f2e5563aebe74207
     checksum: sha256:b4a693cf204c2ee23f1672521f051c32c805e2417858eaf24661c1e354daf6b7
+    shape_checksum: sha256:4fec0f2db7523d71ba7542e0d52217c91d9bab5b55d714b689f614380f5c2eb9
   dimensions.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:650ab993d23fba8b88cdbbb43030d8f6595b320bb20044db88aaff951cc8a15d
+    shape_checksum: sha256:8809a1067d9721c56b585bed71e0e4800c9bcf01c5daac8908b5c89a052d47d2
   parameters_fresh.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:1cc4c33c729d37a40672540dfb92f4f7dadf50653bd4f211a485c9d51722088f
+    shape_checksum: sha256:52dcadd062f584fa7e7828d580fbf6f3dd44261d6a6d37e7b831aa0e0b9be2d3
   overrides/user_habitat_classification.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_habitat_classification.csv
     upstream_sha: 40c4a0a
     synced: 2026-04-27
     checksum: sha256:c605a8aa61b127f3525562e24ae3ab8f26cd62c1e3e556edf5b8c564c735b830
+    shape_checksum: sha256:35604598f352c0cc958e8330e80627ec65154e4eaba9dbba8cac92c8516706a0
   overrides/observation_exclusions.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:ad901c57ca42e71e4affffd6e583045a2ce423f15088c211c9c2f72976f5d36a
+    shape_checksum: sha256:c0c0c5a6e478bae9d98c0251870fb73ef12ec5033de08589bad08ed03be02a31
   overrides/wsg_species_presence.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:3c3dc66d1b9b299d91e73d6edcccb56cc827641be494e26981ed580ff51e15ec
+    shape_checksum: sha256:161bef58151083d80bd226022a46aed5a35a5acd1526dfc3deac42cb6ae952fc
   overrides/user_modelled_crossing_fixes.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_modelled_crossing_fixes.csv
     upstream_sha: 1c7a436
     synced: 2026-04-27
     checksum: sha256:0c0e97f8f0d4c834837631f68f10aa8fc8f502cad954fd266fe41d4e1f214d10
+    shape_checksum: sha256:acbddab3bd06ac4790eb129201198e614c1d4c08b83cd18ee94e4cdfafa09ab2
   overrides/user_pscis_barrier_status.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_pscis_barrier_status.csv
     upstream_sha: e48d713
     synced: 2026-04-27
     checksum: sha256:9b4929f882ac46e5632bdbe3c587421be42ac31c0005cd2b7e4d1028fa2a47ac
+    shape_checksum: sha256:fb611fc77ebbe15429826d7acfe57d487118d7815dea9b2ad5a3f94f03a487e8
   overrides/pscis_modelledcrossings_streams_xref.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/pscis_modelledcrossings_streams_xref.csv
     upstream_sha: 40c4a0a
     synced: 2026-04-27
     checksum: sha256:f76470febe3a4d26e13ada144b594c2571033fa00676b7622f3c628fed21206f
+    shape_checksum: sha256:c2cebcc7398ddd12d0803eefafbe219f3551e6948051f18d89d7984130c1589d
   overrides/user_barriers_definite.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_barriers_definite.csv
     upstream_sha: ea3c5d8
     synced: 2026-04-13
     checksum: sha256:56c66cddf279a1c2b0c0be1fc9ba9c758dc93d4ad820e0bf2c5caf4ecce05fb6
+    shape_checksum: sha256:d39b1ef2a8b3fd26974a3138a3f4e9516a65bddd34e9b50ab65c50a0cbfdc9c1
   overrides/user_barriers_definite_control.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_barriers_definite_control.csv
     upstream_sha: ea3c5d8
     synced: 2026-04-13
     checksum: sha256:8f34e2c006733e0f06248a90dc0b8abe4719880590f497581f80fe5f62fde203
+    shape_checksum: sha256:2a6dd20fd0fe0d9ebc4d54bedafa95054ba3167ac255f98cd2a76dd082800591
   overrides/user_crossings_misc.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_crossings_misc.csv
     upstream_sha: cb4dd1a
     synced: 2026-04-27
     checksum: sha256:19fa9f1322f78e0b2025aed509b7ac1402b7f99876e7b9e6404b22cce5491d5e
+    shape_checksum: sha256:463bc63156786be38c39d5479bfe07ce7b593e1174ecba6f7d9e5ac52c2c6bfd

--- a/inst/extdata/configs/default/config.yaml
+++ b/inst/extdata/configs/default/config.yaml
@@ -47,65 +47,77 @@ provenance:
     generated_by: lnk_rules_build
     generator_sha: 8f1890564b9148573535a679f2e5563aebe74207
     checksum: sha256:fd8f3dc7ff072381289acfab86d125ab85302cdb66968e633ec539fa03de2e4b
+    shape_checksum: sha256:4fec0f2db7523d71ba7542e0d52217c91d9bab5b55d714b689f614380f5c2eb9
   dimensions.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:6f510fa767cbdb9bb29778d475570c84b3c5c295d65ef1f56cde9f931dc5a760
+    shape_checksum: sha256:c55199e8702b89079e57cae321d5307b90d1e411e9e64fac3e8b743e44de2788
   parameters_fresh.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:1cc4c33c729d37a40672540dfb92f4f7dadf50653bd4f211a485c9d51722088f
+    shape_checksum: sha256:52dcadd062f584fa7e7828d580fbf6f3dd44261d6a6d37e7b831aa0e0b9be2d3
   overrides/user_habitat_classification.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_habitat_classification.csv
     upstream_sha: 40c4a0a
     synced: 2026-04-27
     checksum: sha256:c605a8aa61b127f3525562e24ae3ab8f26cd62c1e3e556edf5b8c564c735b830
+    shape_checksum: sha256:35604598f352c0cc958e8330e80627ec65154e4eaba9dbba8cac92c8516706a0
   overrides/observation_exclusions.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:ad901c57ca42e71e4affffd6e583045a2ce423f15088c211c9c2f72976f5d36a
+    shape_checksum: sha256:c0c0c5a6e478bae9d98c0251870fb73ef12ec5033de08589bad08ed03be02a31
   overrides/wsg_species_presence.csv:
     source: link (hand-authored)
     upstream_sha: 8f1890564b9148573535a679f2e5563aebe74207
     synced: 2026-04-26
     checksum: sha256:3c3dc66d1b9b299d91e73d6edcccb56cc827641be494e26981ed580ff51e15ec
+    shape_checksum: sha256:161bef58151083d80bd226022a46aed5a35a5acd1526dfc3deac42cb6ae952fc
   overrides/user_modelled_crossing_fixes.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_modelled_crossing_fixes.csv
     upstream_sha: 1c7a436
     synced: 2026-04-27
     checksum: sha256:0c0e97f8f0d4c834837631f68f10aa8fc8f502cad954fd266fe41d4e1f214d10
+    shape_checksum: sha256:acbddab3bd06ac4790eb129201198e614c1d4c08b83cd18ee94e4cdfafa09ab2
   overrides/user_pscis_barrier_status.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_pscis_barrier_status.csv
     upstream_sha: e48d713
     synced: 2026-04-27
     checksum: sha256:9b4929f882ac46e5632bdbe3c587421be42ac31c0005cd2b7e4d1028fa2a47ac
+    shape_checksum: sha256:fb611fc77ebbe15429826d7acfe57d487118d7815dea9b2ad5a3f94f03a487e8
   overrides/pscis_modelledcrossings_streams_xref.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/pscis_modelledcrossings_streams_xref.csv
     upstream_sha: 40c4a0a
     synced: 2026-04-27
     checksum: sha256:f76470febe3a4d26e13ada144b594c2571033fa00676b7622f3c628fed21206f
+    shape_checksum: sha256:c2cebcc7398ddd12d0803eefafbe219f3551e6948051f18d89d7984130c1589d
   overrides/user_barriers_definite.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_barriers_definite.csv
     upstream_sha: ea3c5d8
     synced: 2026-04-13
     checksum: sha256:56c66cddf279a1c2b0c0be1fc9ba9c758dc93d4ad820e0bf2c5caf4ecce05fb6
+    shape_checksum: sha256:d39b1ef2a8b3fd26974a3138a3f4e9516a65bddd34e9b50ab65c50a0cbfdc9c1
   overrides/user_barriers_definite_control.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_barriers_definite_control.csv
     upstream_sha: ea3c5d8
     synced: 2026-04-13
     checksum: sha256:8f34e2c006733e0f06248a90dc0b8abe4719880590f497581f80fe5f62fde203
+    shape_checksum: sha256:2a6dd20fd0fe0d9ebc4d54bedafa95054ba3167ac255f98cd2a76dd082800591
   overrides/user_crossings_misc.csv:
     source: https://github.com/smnorris/bcfishpass
     path: data/user_crossings_misc.csv
     upstream_sha: cb4dd1a
     synced: 2026-04-27
     checksum: sha256:19fa9f1322f78e0b2025aed509b7ac1402b7f99876e7b9e6404b22cce5491d5e
+    shape_checksum: sha256:463bc63156786be38c39d5479bfe07ce7b593e1174ecba6f7d9e5ac52c2c6bfd

--- a/man/lnk_config_verify.Rd
+++ b/man/lnk_config_verify.Rd
@@ -2,26 +2,32 @@
 % Please edit documentation in R/lnk_config_verify.R
 \name{lnk_config_verify}
 \alias{lnk_config_verify}
-\title{Verify Config Bundle File Checksums}
+\title{Verify Config Bundle File Checksums and Shape}
 \usage{
 lnk_config_verify(cfg, strict = FALSE)
 }
 \arguments{
 \item{cfg}{An \code{lnk_config} object from \code{\link[=lnk_config]{lnk_config()}}.}
 
-\item{strict}{Logical. When \code{TRUE}, errors if any file has drifted.
-Default \code{FALSE} warns and returns the tibble for inspection.}
+\item{strict}{Logical. When \code{TRUE}, errors if any file has drifted
+on either axis. Default \code{FALSE} warns and returns the tibble for
+inspection.}
 }
 \value{
 A tibble with columns:
 \itemize{
 \item \code{file} — path relative to \code{cfg$dir}
-\item \code{expected} — checksum recorded in the manifest (sha256 hex)
-\item \code{observed} — checksum recomputed from the current file (sha256
-hex)
-\item \code{drift} — logical, \code{TRUE} when expected != observed
+\item \code{byte_expected} — byte checksum recorded in the manifest
+\item \code{byte_observed} — byte checksum recomputed from the current file
+\item \code{byte_drift} — logical, \code{TRUE} when byte checksums differ
+\item \code{shape_expected} — shape checksum recorded in the manifest, or
+\code{NA} when the manifest has no \code{shape_checksum} field
+\item \code{shape_observed} — shape checksum recomputed from the current
+file's header line
+\item \code{shape_drift} — logical, \code{TRUE} when shape checksums differ
+(and the manifest had a \code{shape_expected} to compare against)
 \item \code{missing} — logical, \code{TRUE} when the file no longer exists on
-disk (observed is \code{NA} in this case)
+disk (observed values are \code{NA})
 }
 
 The tibble carries one row per provenanced file. When the bundle
@@ -29,15 +35,31 @@ has no \verb{provenance:} block (\code{cfg$provenance} is \code{NULL}) returns
 an empty tibble with the same columns.
 }
 \description{
-Recomputes sha256 for every file declared in the bundle's
-\verb{provenance:} block and compares against the recorded checksum.
-Returns a tibble of expected vs observed; flags drift.
+Recomputes sha256 byte and shape checksums for every file declared
+in the bundle's \verb{provenance:} block and compares against the
+recorded values. Returns a tibble of expected vs observed; flags
+drift on each axis separately.
 }
 \details{
-Use this at run time to detect silent drift — a file that was edited
-without re-recording its checksum, or an external CSV that was
-re-synced under the same path. Drift between two pipeline runs on
-the same DB state with the same package versions almost always
+\strong{Byte drift} (\code{byte_drift}) — file content changed (rows
+added/edited/removed, or whole-file re-shape). Detected via sha256
+of the full file. Catches every kind of change but doesn't tell you
+WHAT kind.
+
+\strong{Shape drift} (\code{shape_drift}) — file's \emph{header} changed (column
+added / renamed / removed / reshaped). Detected via sha256 of the
+first line of the file (whitespace-normalized). A pure-value
+change (rows added with no column change) shows \code{byte_drift = TRUE}
+but \code{shape_drift = FALSE}. A column rename shows both TRUE.
+Header-only fingerprint catches the dominant failure mode (column
+structure change); type changes within stable columns are not
+detected — they require value-level inspection that's out of scope
+here.
+
+Use this at run time to detect silent drift — a file that was
+edited without re-recording its checksum, or an external CSV that
+was re-synced under the same path. Drift between two pipeline runs
+on the same DB state with the same package versions almost always
 traces back to a config-file edit; \code{lnk_config_verify()} is the
 fastest way to localize the change.
 }
@@ -47,7 +69,7 @@ verify <- lnk_config_verify(cfg)
 verify
 
 \dontrun{
-# In a verification log: error if anything drifted
+# In a verification log: error on either drift kind
 lnk_config_verify(cfg, strict = TRUE)
 }
 }

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,157 @@
+# Findings — link#64 shape fingerprint
+
+## What "shape" actually means
+
+Two dimensions of source-table change can break consumers:
+
+1. **Column structure** — names added / renamed / removed / reshaped.
+   Caught by hashing the header line.
+2. **Column types** — same headers, different value types (e.g.,
+   `'t'`/`'f'` text → `1`/`0` integer). Caught only by sampling
+   actual data and inferring types.
+
+The 2026-04-26 break was BOTH (long → wide reshape AND text → integer
+indicators). Either fingerprint type would catch it. Header-only is
+much simpler and sufficient for the current failure mode. Type
+fingerprint can extend later if a type-only break ever surfaces.
+
+## Fingerprint algorithm
+
+```r
+shape_fingerprint <- function(file_path) {
+  first_line <- readLines(file_path, n = 1, warn = FALSE)
+  if (length(first_line) == 0) return(NA_character_)
+  # Normalize: strip trailing whitespace + carriage return, force
+  # consistent line ending. Avoids false drifts from CRLF vs LF or
+  # trailing spaces in the header.
+  normalized <- sub("\\s+$", "", first_line)
+  paste0("sha256:", digest::digest(normalized,
+                                    algo = "sha256",
+                                    serialize = FALSE))
+}
+```
+
+Implementation in both:
+- `data-raw/sync_bcfishpass_csvs.R` (sync time, against fetched bytes)
+- `R/lnk_config_verify.R` (verify time, against on-disk file)
+
+## Computing baseline shape_checksum for current files
+
+For each tracked file in `inst/extdata/configs/<bundle>/overrides/`,
+hash the first line. Both bundles share the same files byte-for-byte
+today (post auto-sync), so the fingerprint pairs match.
+
+Quick recon to validate the algorithm — e.g., from one file:
+```bash
+head -1 inst/extdata/configs/bcfishpass/overrides/user_habitat_classification.csv \
+  | tr -d '\r' | sed 's/[[:space:]]*$//' \
+  | shasum -a 256
+```
+
+## Workflow flag mechanism
+
+Existing pattern in `sync-bcfishpass-csvs.yml`: R script writes
+`/tmp/sync_summary.md`; subsequent shell step reads it. Extending:
+
+```r
+# In sync_bcfishpass_csvs.R, after diff loop:
+drift_kind <- if (length(shape_drifts) > 0) "shape" else
+              if (length(byte_drifts) > 0) "byte" else "none"
+writeLines(drift_kind, "/tmp/sync_drift_kind")
+```
+
+```yaml
+# In workflow YAML:
+- name: Open + auto-merge PR if any drift
+  run: |
+    DRIFT_KIND=$(cat /tmp/sync_drift_kind 2>/dev/null || echo "none")
+    case "$DRIFT_KIND" in
+      none)  echo "No drift — exit clean"; exit 0 ;;
+      byte)  # existing auto-PR + auto-merge path
+             ...
+             gh pr merge "$PR_URL" --merge --delete-branch ;;
+      shape) # new path: open PR with label, no auto-merge, fail loud
+             gh pr create ... --label schema-drift ...
+             gh label create schema-drift --color B60205 --description "..." || true
+             # Don't auto-merge; exit non-zero so the Actions tab shows red
+             exit 2 ;;
+    esac
+```
+
+Need to ensure the `schema-drift` label exists before applying. The
+`gh label create` is idempotent if `|| true` swallows the
+"already exists" error.
+
+## lnk_config_verify integration
+
+Current `lnk_config_verify()` returns:
+
+```
+file | expected | observed | drift | missing
+```
+
+Where `expected` and `observed` are the byte sha256s; `drift` is TRUE
+when they differ.
+
+Extension:
+
+```
+file | byte_expected | byte_observed | byte_drift |
+       shape_expected | shape_observed | shape_drift | missing
+```
+
+Or — to avoid widening the tibble — stack with a `kind` column:
+
+```
+file | kind  | expected | observed | drift | missing
+foo   | byte  | sha256:.. | sha256:..  | FALSE | FALSE
+foo   | shape | sha256:.. | sha256:..  | FALSE | FALSE
+```
+
+Long format is more queryable but breaks existing test assertions.
+Wide format with `byte_drift` and `shape_drift` columns is
+backward-compatible: rename current `drift` → `byte_drift`, add
+`shape_drift`. Document the rename in NEWS.
+
+Going wide. Keeps the function shape easy to read at the REPL.
+
+## Test fixture for shape drift
+
+The 2026-04-26 reshape changed the first line from:
+```
+blue_line_key,downstream_route_measure,upstream_route_measure,watershed_group_code,species_code,habitat_type,habitat_ind,reviewer_name,review_date,source,notes
+```
+to:
+```
+blue_line_key,downstream_route_measure,upstream_route_measure,watershed_group_code,species_code,spawning,rearing,reviewer_name,review_date,source,notes
+```
+
+Test pattern:
+1. Build a tmp config bundle with one CSV at original shape
+2. Verify clean
+3. Mutate the CSV's first line (replace `habitat_type,habitat_ind` with
+   `spawning,rearing`)
+4. Verify reports `shape_drift = TRUE`
+
+Mirrors the existing byte-drift test pattern in
+`test-lnk_config_verify.R`.
+
+## Workflow integration test
+
+Hard to test the GHA YAML directly without running a full Actions
+workflow. Acceptable for v1: rely on the unit test of the R script's
+drift-kind output + manual workflow_dispatch validation post-merge
+(same pattern used to validate the original sync workflow when it
+first landed in PR #60).
+
+## Version bump
+
+0.12.0 → 0.13.0 — minor. Adds a new field to `provenance:` schema and
+a new column to `lnk_config_verify()`'s return; renames `drift` →
+`byte_drift`. Pre-1.0; renames are documented and backward-compat-
+breaking is acceptable per existing convention.
+
+## Pacing
+
+Independent of crate's work. Ships standalone. Lands today if the
+implementation goes smoothly.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,12 @@
+# Progress — link#64 shape fingerprint
+
+## Session 2026-04-27
+
+- link 0.12.0 quick-fix shipped (PR #66 merged, tagged) — pipeline
+  unblocked against fresh 0.22.0
+- Branch `64-shape-fingerprint` off main
+- PWF baseline written
+- crate-Claude scaffolding crate#2 in parallel (per
+  `comms/crate/20260427_bcfp_ingest_impl_plan.md`); link#64 ships
+  independent of crate
+- Next: Phase 2 — compute shape checksums for both bundles.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,84 @@
+# Task: Shape fingerprint + halt auto-merge on shape drift (link#64)
+
+`data-raw/sync_bcfishpass_csvs.R` and the daily `sync-bcfishpass-csvs.yml`
+GHA cron compare each bcfishpass-sourced CSV against a recorded sha256
+**byte** checksum. When upstream changes the file BYTES, an auto-PR
+opens and auto-merges. This works for value drift (rows added/edited)
+but is **blind to shape drift** — yesterday's `user_habitat_classification.csv`
+long→wide reshape (with column type change) passed straight through and
+broke link's pipeline downstream (fixed today via fresh#177 + link 0.12.0).
+
+This PR adds a **shape fingerprint** alongside the byte checksum, branches
+the sync logic, and surfaces shape drift as a halt-on-merge signal so
+downstream consumers don't get silently broken again.
+
+## Goal
+
+```
+Drift type            Action
+─────────────────────  ─────────────────────────────────────────────
+Byte drift, shape ✓    Auto-PR + auto-merge as today
+Shape drift            Auto-PR opens, labelled `schema-drift`,
+                       NOT auto-merged, GHA exits non-zero
+```
+
+Scope:
+
+1. New `shape_checksum` field in the `provenance:` block of each
+   bundle's `config.yaml`, computed from each CSV's header line
+   (sha256 of the first line, normalized). Catches column rename /
+   add / remove / reshape — the dominant failure mode. Type changes
+   within stable columns are out of scope (rarer; can extend later).
+2. `data-raw/sync_bcfishpass_csvs.R` computes and compares shape
+   checksums. On shape drift, sets a flag the workflow reads.
+3. `.github/workflows/sync-bcfishpass-csvs.yml` branches: byte-only
+   drift → auto-PR + auto-merge as today; shape drift → auto-PR with
+   `schema-drift` label, NO auto-merge, workflow exits non-zero
+   (red X on Actions tab).
+4. `lnk_config_verify()` extended to surface shape drift alongside
+   byte drift; new column in the returned tibble.
+
+## Phases
+
+- [ ] Phase 1 — PWF baseline (this file + findings + progress)
+- [ ] Phase 2 — Compute shape checksums for all 12 currently-tracked files in both bundles. Add `shape_checksum: sha256:<hex>` field to each entry in `inst/extdata/configs/{bcfishpass,default}/config.yaml`'s `provenance:` block.
+- [ ] Phase 3 — Update `data-raw/sync_bcfishpass_csvs.R`: compute shape checksum from each fetched file's header line; compare against recorded; tag drifts as `byte_only` or `shape`. Write `/tmp/sync_summary.md` with per-file drift type. Write `/tmp/sync_drift_kind` (single-line file containing `byte` or `shape` or `none`) for the workflow to read.
+- [ ] Phase 4 — Update `.github/workflows/sync-bcfishpass-csvs.yml`: read `/tmp/sync_drift_kind`; on `shape`, label PR `schema-drift`, skip auto-merge, exit non-zero; on `byte`, behave as today; on `none`, exit clean. Test the label step is idempotent (re-runs don't error).
+- [ ] Phase 5 — Extend `R/lnk_config_verify.R`: compute shape checksum at runtime (read first line, sha256), compare to provenance's `shape_checksum`, add `shape_drift` column to the returned tibble. Update existing tests + add new test covering shape drift detection.
+- [ ] Phase 6 — Tests: extend `test-lnk_config_verify.R` for shape drift. Add a tiny sync-script integration test that simulates the 2026-04-26 reshape (column rename) on a temp dir and confirms shape-drift detection.
+- [ ] Phase 7 — `/code-check` on staged diff
+- [ ] Phase 8 — Full devtools::test() suite
+- [ ] Phase 9 — NEWS entry; version bump 0.12.0 → 0.13.0 (minor — adds provenance field + verify column; pre-1.0 still)
+- [ ] Phase 10 — PR (closes #64)
+
+## Critical files
+
+- `data-raw/sync_bcfishpass_csvs.R` — extend with shape fingerprint
+- `.github/workflows/sync-bcfishpass-csvs.yml` — branch on drift kind
+- `inst/extdata/configs/bcfishpass/config.yaml` — `shape_checksum` field per file
+- `inst/extdata/configs/default/config.yaml` — same
+- `R/lnk_config_verify.R` — extend with shape checking
+- `tests/testthat/test-lnk_config_verify.R` — extend
+- `NEWS.md`, `DESCRIPTION` — release artifacts
+
+## Acceptance
+
+- Both bundles' config.yaml `provenance:` blocks have `shape_checksum: sha256:<hex>` for every smnorris-sourced file
+- `lnk_config_verify(cfg)` returns a tibble with a `shape_drift` column alongside `drift` (byte) and `missing`
+- Local dry-run of `sync_bcfishpass_csvs.R` against current state reports clean (no drift)
+- Simulated header rename (e.g., adding a column to a fixture's first line) flips `shape_drift` to TRUE and `/tmp/sync_drift_kind` to `shape`
+- Workflow YAML branches correctly on the drift kind file
+- All existing tests pass; new tests cover shape detection
+
+## Risks
+
+- **Header-only fingerprint misses type changes within stable columns**: documented limitation. The 2026-04-26 break was both header AND type change, so header-only catches it. A type fingerprint can be added later if a type-only break surfaces. YAGNI for now.
+- **First-line whitespace / line-ending differences**: normalize before hashing — strip trailing whitespace, force `\n` line ending. Avoid false drifts from CRLF vs LF or trailing spaces.
+- **Workflow drift-flag file mechanism**: relies on `/tmp/sync_drift_kind` being readable by the next step. GHA runners have a shared `/tmp` per job, so this works — verified pattern in the existing workflow file (`/tmp/sync_summary.md`).
+- **Concurrent sync runs**: not a real concern since only one workflow run executes at a time per branch (GHA default for `schedule:` and `workflow_dispatch:`).
+
+## Not in this PR
+
+- Type-fingerprint extension (column-level type signature) — file as follow-up issue if a type-only break surfaces
+- crate's `lnk_load_overrides()` integration (link#65) — separate PR after crate v0.0.1 ships
+- Vignette-tighten resumption — separate PR after this lands (vignette stays in dev/ for now)

--- a/tests/testthat/test-lnk_config_verify.R
+++ b/tests/testthat/test-lnk_config_verify.R
@@ -1,25 +1,28 @@
-# lnk_config_verify recomputes sha256 of every provenanced file and
-# reports drift. Tests use temp config bundles to control the file
-# state precisely.
+# lnk_config_verify recomputes byte + shape checksums for every
+# provenanced file and reports drift on each axis. Tests use temp
+# config bundles to control the file state precisely.
 
 skip_if_no_digest <- function() {
   testthat::skip_if_not_installed("digest")
 }
 
-# Helper: build a tmp config dir with a known file + a provenance entry
-# referencing the file's actual sha256. Returns the tmp dir path.
-.build_tmp_cfg <- function(content = "alpha\n") {
+# Helper: build a tmp config dir with a known rules.yaml file + a
+# provenance entry referencing the file's actual byte and shape
+# checksums. Returns the tmp dir path. By default the rules.yaml file
+# has a single header line "alpha" — `header` controls that line.
+.build_tmp_cfg <- function(header = "alpha") {
   skip_if_no_digest()
   tmp <- withr::local_tempdir(.local_envir = parent.frame())
   rules_path <- file.path(tmp, "rules.yaml")
   dims_path  <- file.path(tmp, "dims.csv")
   params_path <- file.path(tmp, "params.csv")
 
-  writeLines(content, rules_path)
+  writeLines(header, rules_path)
   write.csv(data.frame(a = 1), dims_path, row.names = FALSE)
   write.csv(data.frame(a = 1), params_path, row.names = FALSE)
 
-  rules_sha <- digest::digest(file = rules_path, algo = "sha256")
+  rules_byte <- digest::digest(file = rules_path, algo = "sha256")
+  rules_shape <- link:::.lnk_shape_fingerprint(rules_path)
 
   yaml::write_yaml(
     list(
@@ -31,8 +34,9 @@ skip_if_no_digest <- function() {
       ),
       provenance = list(
         rules.yaml = list(
-          source = "test (hand-authored)",
-          checksum = paste0("sha256:", rules_sha)
+          source         = "test (hand-authored)",
+          checksum       = paste0("sha256:", rules_byte),
+          shape_checksum = rules_shape
         )
       )
     ),
@@ -41,55 +45,110 @@ skip_if_no_digest <- function() {
   tmp
 }
 
+VERIFY_COLS <- c("file",
+                 "byte_expected", "byte_observed", "byte_drift",
+                 "shape_expected", "shape_observed", "shape_drift",
+                 "missing")
+
 test_that("lnk_config_verify returns clean tibble when no drift", {
   skip_if_no_digest()
   tmp <- .build_tmp_cfg()
   cfg <- lnk_config(tmp)
   v <- lnk_config_verify(cfg)
   expect_s3_class(v, "data.frame")
-  expect_named(v, c("file", "expected", "observed", "drift", "missing"))
+  expect_named(v, VERIFY_COLS)
   expect_equal(nrow(v), 1L)
-  expect_false(v$drift)
+  expect_false(v$byte_drift)
+  expect_false(v$shape_drift)
   expect_false(v$missing)
-  expect_equal(v$expected, v$observed)
+  expect_equal(v$byte_expected, v$byte_observed)
+  expect_equal(v$shape_expected, v$shape_observed)
 })
 
-test_that("lnk_config_verify detects drift when file mutates", {
+test_that("byte drift detected when file content changes (header preserved)", {
   skip_if_no_digest()
-  tmp <- .build_tmp_cfg()
-  # Mutate the file after manifest is recorded
-  writeLines("changed\n", file.path(tmp, "rules.yaml"))
+  tmp <- .build_tmp_cfg(header = "alpha")
   cfg <- lnk_config(tmp)
-  expect_warning(v <- lnk_config_verify(cfg), "drifted from recorded")
-  expect_equal(nrow(v), 1L)
-  expect_true(v$drift)
-  expect_false(v$missing)
+  # Append a row but keep the header line — byte changes, shape doesn't
+  cat("alpha\nbeta\n", file = file.path(tmp, "rules.yaml"))
+  expect_warning(v <- lnk_config_verify(cfg), "drifted")
+  expect_true(v$byte_drift)
+  expect_false(v$shape_drift)
 })
 
-test_that("lnk_config_verify strict = TRUE errors on drift", {
+test_that("shape drift detected when header line changes", {
   skip_if_no_digest()
-  tmp <- .build_tmp_cfg()
-  writeLines("changed\n", file.path(tmp, "rules.yaml"))
+  tmp <- .build_tmp_cfg(header = "alpha")
   cfg <- lnk_config(tmp)
-  expect_error(lnk_config_verify(cfg, strict = TRUE),
-               "drifted from recorded")
+  # Change the header — both byte and shape drift
+  writeLines("alpha,beta", file.path(tmp, "rules.yaml"))
+  expect_warning(v <- lnk_config_verify(cfg), "drifted")
+  expect_true(v$byte_drift)
+  expect_true(v$shape_drift)
 })
 
-test_that("lnk_config_verify flags missing files", {
+test_that("strict = TRUE errors on either drift kind", {
+  skip_if_no_digest()
+  tmp <- .build_tmp_cfg(header = "alpha")
+  cfg <- lnk_config(tmp)
+  cat("alpha\nbeta\n", file = file.path(tmp, "rules.yaml"))  # byte only
+  expect_error(lnk_config_verify(cfg, strict = TRUE), "drifted")
+
+  tmp2 <- .build_tmp_cfg(header = "alpha")
+  cfg2 <- lnk_config(tmp2)
+  writeLines("renamed", file.path(tmp2, "rules.yaml"))  # both
+  expect_error(lnk_config_verify(cfg2, strict = TRUE), "drifted")
+})
+
+test_that("missing file flips both drift columns and sets missing = TRUE", {
   skip_if_no_digest()
   tmp <- .build_tmp_cfg()
   cfg <- lnk_config(tmp)
-  # Remove file AFTER lnk_config has loaded — lnk_config requires files
-  # at load time, but lnk_config_verify is called later so files may
-  # have been removed in the meantime.
   file.remove(file.path(tmp, "rules.yaml"))
   expect_warning(v <- lnk_config_verify(cfg))
   expect_true(v$missing)
-  expect_true(v$drift)
-  expect_true(is.na(v$observed))
+  expect_true(v$byte_drift)
+  expect_true(v$shape_drift)
+  expect_true(is.na(v$byte_observed))
+  expect_true(is.na(v$shape_observed))
 })
 
-test_that("lnk_config_verify returns empty tibble when no provenance block", {
+test_that("provenance without shape_checksum: shape_drift stays FALSE", {
+  # Older bundles that have only `checksum:` and no `shape_checksum:`
+  # field stay backward-compatible — verify just doesn't flag shape
+  # drift since there's no recorded shape to compare against.
+  skip_if_no_digest()
+  tmp <- withr::local_tempdir()
+  rules_path <- file.path(tmp, "rules.yaml")
+  writeLines("alpha", rules_path)
+  write.csv(data.frame(a = 1), file.path(tmp, "dims.csv"), row.names = FALSE)
+  write.csv(data.frame(a = 1), file.path(tmp, "params.csv"), row.names = FALSE)
+  rules_byte <- digest::digest(file = rules_path, algo = "sha256")
+  yaml::write_yaml(
+    list(
+      name = "x",
+      files = list(
+        rules_yaml = "rules.yaml",
+        dimensions_csv = "dims.csv",
+        parameters_fresh = "params.csv"
+      ),
+      provenance = list(
+        rules.yaml = list(
+          source = "test (legacy, no shape)",
+          checksum = paste0("sha256:", rules_byte)
+        )
+      )
+    ),
+    file.path(tmp, "config.yaml")
+  )
+  cfg <- lnk_config(tmp)
+  v <- lnk_config_verify(cfg)
+  expect_false(v$byte_drift)
+  expect_true(is.na(v$shape_expected))
+  expect_false(v$shape_drift)
+})
+
+test_that("returns empty tibble when no provenance block", {
   tmp <- withr::local_tempdir()
   file.create(file.path(tmp, "rules.yaml"))
   write.csv(data.frame(a = 1), file.path(tmp, "dims.csv"), row.names = FALSE)
@@ -110,15 +169,15 @@ test_that("lnk_config_verify returns empty tibble when no provenance block", {
   v <- lnk_config_verify(cfg)
   expect_s3_class(v, "data.frame")
   expect_equal(nrow(v), 0L)
-  expect_named(v, c("file", "expected", "observed", "drift", "missing"))
+  expect_named(v, VERIFY_COLS)
 })
 
-test_that("lnk_config_verify rejects non-lnk_config input", {
+test_that("rejects non-lnk_config input", {
   expect_error(lnk_config_verify(list()), "must be an lnk_config")
   expect_error(lnk_config_verify(NULL), "must be an lnk_config")
 })
 
-test_that("lnk_config_verify rejects non-logical strict", {
+test_that("rejects non-logical strict", {
   cfg <- lnk_config("bcfishpass")
   expect_error(lnk_config_verify(cfg, strict = "yes"),
                "single TRUE or FALSE")
@@ -130,7 +189,8 @@ test_that("bundled bcfishpass config has no drift in shipped state", {
   skip_if_no_digest()
   cfg <- lnk_config("bcfishpass")
   v <- lnk_config_verify(cfg)
-  expect_equal(sum(v$drift), 0L)
+  expect_equal(sum(v$byte_drift), 0L)
+  expect_equal(sum(v$shape_drift), 0L)
   expect_equal(sum(v$missing), 0L)
 })
 
@@ -138,6 +198,22 @@ test_that("bundled default config has no drift in shipped state", {
   skip_if_no_digest()
   cfg <- lnk_config("default")
   v <- lnk_config_verify(cfg)
-  expect_equal(sum(v$drift), 0L)
+  expect_equal(sum(v$byte_drift), 0L)
+  expect_equal(sum(v$shape_drift), 0L)
   expect_equal(sum(v$missing), 0L)
+})
+
+test_that(".lnk_shape_fingerprint returns NA for empty file", {
+  tmp <- withr::local_tempfile()
+  file.create(tmp)
+  expect_true(is.na(link:::.lnk_shape_fingerprint(tmp)))
+})
+
+test_that(".lnk_shape_fingerprint normalizes trailing whitespace", {
+  tmp1 <- withr::local_tempfile()
+  tmp2 <- withr::local_tempfile()
+  writeLines("a,b,c", tmp1)
+  writeLines("a,b,c   ", tmp2)  # trailing spaces
+  expect_equal(link:::.lnk_shape_fingerprint(tmp1),
+               link:::.lnk_shape_fingerprint(tmp2))
 })

--- a/tests/testthat/test-lnk_stamp.R
+++ b/tests/testthat/test-lnk_stamp.R
@@ -41,8 +41,12 @@ test_that("lnk_stamp provenance slot is the verify tibble", {
   s <- lnk_stamp(cfg, aoi = "ADMS")
   expect_s3_class(s$provenance, "data.frame")
   expect_named(s$provenance,
-               c("file", "expected", "observed", "drift", "missing"))
-  expect_equal(sum(s$provenance$drift), 0L)
+               c("file",
+                 "byte_expected", "byte_observed", "byte_drift",
+                 "shape_expected", "shape_observed", "shape_drift",
+                 "missing"))
+  expect_equal(sum(s$provenance$byte_drift), 0L)
+  expect_equal(sum(s$provenance$shape_drift), 0L)
 })
 
 test_that("lnk_stamp handles config without provenance block", {


### PR DESCRIPTION
## Summary

Closes [#64](https://github.com/NewGraphEnvironment/link/issues/64).

Adds **shape fingerprint** alongside the existing byte checksum in `provenance:` blocks. The daily bcfishpass CSV sync workflow now classifies each upstream change as byte-only or shape drift, and halts auto-merge on shape drift.

## What changes for each drift kind

| Kind | Action |
|---|---|
| `none` | Exit clean (no PR) — as today |
| `byte` (rows added/edited, header preserved) | Auto-PR + auto-merge — as today |
| `shape` (column rename / add / remove / reshape) | Auto-PR opens with `schema-drift` label, **NOT auto-merged**, workflow exits non-zero (red on Actions tab) |

## Why

bcfishpass's 2026-04-26 long → wide reshape (with column type change) passed straight through the byte-only auto-merge guard and broke link's pipeline downstream. Same path silently corrupts cached HTML report output and ripples into fresh's API. This release closes that gap. Coordinates with crate's adapter pattern (link#65, crate#2) — when shape drift fires, crate's normalize handler is the right place to absorb the change before link's pipeline sees it.

## Files

- `inst/extdata/configs/{bcfishpass,default}/config.yaml` — `shape_checksum: sha256:<hex>` field added to every tracked file's provenance entry (12 files × 2 bundles)
- `R/lnk_config_verify.R` — returns 8-col tibble: `(file, byte_expected, byte_observed, byte_drift, shape_expected, shape_observed, shape_drift, missing)`. Old single `drift` column **renamed** to `byte_drift` (breaking, pre-1.0).
- `R/lnk_stamp.R` — markdown rendering surfaces both drift kinds
- `data-raw/sync_bcfishpass_csvs.R` — computes shape fingerprint at sync time; writes `/tmp/sync_drift_kind` (none / byte / shape)
- `.github/workflows/sync-bcfishpass-csvs.yml` — branches on drift kind; `gh label create schema-drift` (idempotent); `gh pr merge --auto` for future-proof merge queueing
- `tests/testthat/test-lnk_config_verify.R` — extended; `tests/testthat/test-lnk_stamp.R` — column rename
- `NEWS.md` — 0.13.0 entry; `DESCRIPTION` — bump

## Test plan

- [x] `devtools::test()`: 468 PASS, 0 FAIL, 1 pre-existing WARN
- [x] `Rscript data-raw/sync_bcfishpass_csvs.R --dry-run`: detects current state, writes `/tmp/sync_drift_kind = byte` (one CSV byte-drifted upstream since last sync; shape unchanged)
- [x] `lnk_config_verify(lnk_config("bcfishpass"))`: clean (`byte_drift = 0`, `shape_drift = 0`)
- [x] `/code-check` round 1: 3 fragile findings, 2 fixed (`shape_drift` guard + `--auto` flag) + 1 documented (writeBin parity comment)

## Coordination

- Independent of crate#2 — ships standalone today
- crate-Claude scaffolding crate#2 in parallel; link#65 (`lnk_load_overrides()` consuming `crate::crt_ingest()`) lands after crate v0.0.1
- Vignette stays in `dev/` until link#65 ships, then resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
