### PR TITLE
NOTICE + LICENSE-bcfishpass + Title/Description refresh (#78)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,18 +1,20 @@
 Package: link
-Title: Crossing Connectivity Interpretation
+Title: Habitat and Connectivity Interpretation for Stream Networks
 Version: 0.18.0
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),
            comment = c(ORCID = "0009-0003-7697-6064")),
     person("Simon", "Norris", role = "ctb"))
-Description: Connectivity-system-agnostic crossing interpretation layer.
-    Scores, overrides, and prioritizes crossings for fish passage using
-    configurable severity thresholds and multi-source data integration.
-    Produces scored crossing tables and break source specs for network
-    segmentation engines. Crossings are features on the network — some
-    break geometry (confirmed barriers), others index for downstream
-    relationship queries (unassessed crossings, observations).
+Description: Domain interpretation layer over stream network models.
+    Connects point features — crossings, observations, barriers,
+    habitat confirmations — to the network and interprets what they
+    mean for habitat: intrinsic potential, accessibility under network
+    connectivity, per-feature rollups. Pairs with 'fresh', the network
+    modelling engine; 'fresh' answers what the habitat is, 'link'
+    answers what the features mean for the network. Pipelines are
+    driven by manifest config bundles so methodology choices are data,
+    not code, and reproducible across runs.
 License: MIT + file LICENSE
 URL: https://github.com/NewGraphEnvironment/link,
     https://newgraphenvironment.github.io/link/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,11 @@
 Package: link
 Title: Crossing Connectivity Interpretation
 Version: 0.18.0
-Authors@R:
+Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),
-           comment = c(ORCID = "0009-0003-7697-6064"))
+           comment = c(ORCID = "0009-0003-7697-6064")),
+    person("Simon", "Norris", role = "ctb"))
 Description: Connectivity-system-agnostic crossing interpretation layer.
     Scores, overrides, and prioritizes crossings for fish passage using
     configurable severity thresholds and multi-source data integration.

--- a/LICENSE-bcfishpass
+++ b/LICENSE-bcfishpass
@@ -1,0 +1,816 @@
+=========================
+SOFTWARE
+=========================
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Simon Norris, Canadian Wildlife Federation,
+                  Province of British Columbia, New Graph Environment,
+                  bcfishpass contributers
+
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+============================
+DATABASE
+============================
+
+## ODC Open Database License (ODbL)
+
+### Preamble
+
+The Open Database License (ODbL) is a license agreement intended to
+allow users to freely share, modify, and use this Database while
+maintaining this same freedom for others. Many databases are covered by
+copyright, and therefore this document licenses these rights. Some
+jurisdictions, mainly in the European Union, have specific rights that
+cover databases, and so the ODbL addresses these rights, too. Finally,
+the ODbL is also an agreement in contract for users of this Database to
+act in certain ways in return for accessing this Database.
+
+Databases can contain a wide variety of types of content (images,
+audiovisual material, and sounds all in the same database, for example),
+and so the ODbL only governs the rights over the Database, and not the
+contents of the Database individually. Licensors should use the ODbL
+together with another license for the contents, if the contents have a
+single set of rights that uniformly covers all of the contents. If the
+contents have multiple sets of different rights, Licensors should
+describe what rights govern what contents together in the individual
+record or in some other way that clarifies what rights apply.
+
+Sometimes the contents of a database, or the database itself, can be
+covered by other rights not addressed here (such as private contracts,
+trade mark over the name, or privacy rights / data protection rights
+over information in the contents), and so you are advised that you may
+have to consult other documents or clear other rights before doing
+activities not covered by this License.
+
+------
+
+The Licensor (as defined below)
+
+and
+
+You (as defined below)
+
+agree as follows:
+
+### 1.0 Definitions of Capitalised Words
+
+"Collective Database" - Means this Database in unmodified form as part
+of a collection of independent databases in themselves that together are
+assembled into a collective whole. A work that constitutes a Collective
+Database will not be considered a Derivative Database.
+
+"Convey" - As a verb, means Using the Database, a Derivative Database,
+or the Database as part of a Collective Database in any way that enables
+a Person to make or receive copies of the Database or a Derivative
+Database.  Conveying does not include interaction with a user through a
+computer network, or creating and Using a Produced Work, where no
+transfer of a copy of the Database or a Derivative Database occurs.
+"Contents" - The contents of this Database, which includes the
+information, independent works, or other material collected into the
+Database. For example, the contents of the Database could be factual
+data or works such as images, audiovisual material, text, or sounds.
+
+"Database" - A collection of material (the Contents) arranged in a
+systematic or methodical way and individually accessible by electronic
+or other means offered under the terms of this License.
+
+"Database Directive" - Means Directive 96/9/EC of the European
+Parliament and of the Council of 11 March 1996 on the legal protection
+of databases, as amended or succeeded.
+
+"Database Right" - Means rights resulting from the Chapter III ("sui
+generis") rights in the Database Directive (as amended and as transposed
+by member states), which includes the Extraction and Re-utilisation of
+the whole or a Substantial part of the Contents, as well as any similar
+rights available in the relevant jurisdiction under Section 10.4.
+
+"Derivative Database" - Means a database based upon the Database, and
+includes any translation, adaptation, arrangement, modification, or any
+other alteration of the Database or of a Substantial part of the
+Contents. This includes, but is not limited to, Extracting or
+Re-utilising the whole or a Substantial part of the Contents in a new
+Database.
+
+"Extraction" - Means the permanent or temporary transfer of all or a
+Substantial part of the Contents to another medium by any means or in
+any form.
+
+"License" - Means this license agreement and is both a license of rights
+such as copyright and Database Rights and an agreement in contract.
+
+"Licensor" - Means the Person that offers the Database under the terms
+of this License.
+
+"Person" - Means a natural or legal person or a body of persons
+corporate or incorporate.
+
+"Produced Work" -  a work (such as an image, audiovisual material, text,
+or sounds) resulting from using the whole or a Substantial part of the
+Contents (via a search or other query) from this Database, a Derivative
+Database, or this Database as part of a Collective Database.
+
+"Publicly" - means to Persons other than You or under Your control by
+either more than 50% ownership or by the power to direct their
+activities (such as contracting with an independent consultant).
+
+"Re-utilisation" - means any form of making available to the public all
+or a Substantial part of the Contents by the distribution of copies, by
+renting, by online or other forms of transmission.
+
+"Substantial" - Means substantial in terms of quantity or quality or a
+combination of both. The repeated and systematic Extraction or
+Re-utilisation of insubstantial parts of the Contents may amount to the
+Extraction or Re-utilisation of a Substantial part of the Contents.
+
+"Use" - As a verb, means doing any act that is restricted by copyright
+or Database Rights whether in the original medium or any other; and
+includes without limitation distributing, copying, publicly performing,
+publicly displaying, and preparing derivative works of the Database, as
+well as modifying the Database as may be technically necessary to use it
+in a different mode or format.
+
+"You" - Means a Person exercising rights under this License who has not
+previously violated the terms of this License with respect to the
+Database, or who has received express permission from the Licensor to
+exercise rights under this License despite a previous violation.
+
+Words in the singular include the plural and vice versa.
+
+### 2.0 What this License covers
+
+2.1. Legal effect of this document. This License is:
+
+  a. A license of applicable copyright and neighbouring rights;
+
+  b. A license of the Database Right; and
+
+  c. An agreement in contract between You and the Licensor.
+
+2.2 Legal rights covered. This License covers the legal rights in the
+Database, including:
+
+  a. Copyright. Any copyright or neighbouring rights in the Database.
+  The copyright licensed includes any individual elements of the
+  Database, but does not cover the copyright over the Contents
+  independent of this Database. See Section 2.4 for details. Copyright
+  law varies between jurisdictions, but is likely to cover: the Database
+  model or schema, which is the structure, arrangement, and organisation
+  of the Database, and can also include the Database tables and table
+  indexes; the data entry and output sheets; and the Field names of
+  Contents stored in the Database;
+
+  b. Database Rights. Database Rights only extend to the Extraction and
+  Re-utilisation of the whole or a Substantial part of the Contents.
+  Database Rights can apply even when there is no copyright over the
+  Database. Database Rights can also apply when the Contents are removed
+  from the Database and are selected and arranged in a way that would
+  not infringe any applicable copyright; and
+
+  c. Contract. This is an agreement between You and the Licensor for
+  access to the Database. In return you agree to certain conditions of
+  use on this access as outlined in this License.
+
+2.3 Rights not covered.
+
+  a. This License does not apply to computer programs used in the making
+  or operation of the Database;
+
+  b. This License does not cover any patents over the Contents or the
+  Database; and
+
+  c. This License does not cover any trademarks associated with the
+  Database.
+
+2.4 Relationship to Contents in the Database. The individual items of
+the Contents contained in this Database may be covered by other rights,
+including copyright, patent, data protection, privacy, or personality
+rights, and this License does not cover any rights (other than Database
+Rights or in contract) in individual Contents contained in the Database.
+For example, if used on a Database of images (the Contents), this
+License would not apply to copyright over individual images, which could
+have their own separate licenses, or one single license covering all of
+the rights over the images.
+
+### 3.0 Rights granted
+
+3.1 Subject to the terms and conditions of this License, the Licensor
+grants to You a worldwide, royalty-free, non-exclusive, terminable (but
+only under Section 9) license to Use the Database for the duration of
+any applicable copyright and Database Rights. These rights explicitly
+include commercial use, and do not exclude any field of endeavour. To
+the extent possible in the relevant jurisdiction, these rights may be
+exercised in all media and formats whether now known or created in the
+future.
+
+The rights granted cover, for example:
+
+  a. Extraction and Re-utilisation of the whole or a Substantial part of
+  the Contents;
+
+  b. Creation of Derivative Databases;
+
+  c. Creation of Collective Databases;
+
+  d. Creation of temporary or permanent reproductions by any means and
+  in any form, in whole or in part, including of any Derivative
+  Databases or as a part of Collective Databases; and
+
+  e. Distribution, communication, display, lending, making available, or
+  performance to the public by any means and in any form, in whole or in
+  part, including of any Derivative Database or as a part of Collective
+  Databases.
+
+3.2 Compulsory license schemes. For the avoidance of doubt:
+
+  a. Non-waivable compulsory license schemes. In those jurisdictions in
+  which the right to collect royalties through any statutory or
+  compulsory licensing scheme cannot be waived, the Licensor reserves
+  the exclusive right to collect such royalties for any exercise by You
+  of the rights granted under this License;
+
+  b. Waivable compulsory license schemes. In those jurisdictions in
+  which the right to collect royalties through any statutory or
+  compulsory licensing scheme can be waived, the Licensor waives the
+  exclusive right to collect such royalties for any exercise by You of
+  the rights granted under this License; and,
+
+  c. Voluntary license schemes. The Licensor waives the right to collect
+  royalties, whether individually or, in the event that the Licensor is
+  a member of a collecting society that administers voluntary licensing
+  schemes, via that society, from any exercise by You of the rights
+  granted under this License.
+
+3.3 The right to release the Database under different terms, or to stop
+distributing or making available the Database, is reserved. Note that
+this Database may be multiple-licensed, and so You may have the choice
+of using alternative licenses for this Database. Subject to Section
+10.4, all other rights not expressly granted by Licensor are reserved.
+
+### 4.0 Conditions of Use
+
+4.1 The rights granted in Section 3 above are expressly made subject to
+Your complying with the following conditions of use. These are important
+conditions of this License, and if You fail to follow them, You will be
+in material breach of its terms.
+
+4.2 Notices. If You Publicly Convey this Database, any Derivative
+Database, or the Database as part of a Collective Database, then You
+must:
+
+  a. Do so only under the terms of this License or another license
+  permitted under Section 4.4;
+
+  b. Include a copy of this License (or, as applicable, a license
+  permitted under Section 4.4) or its Uniform Resource Identifier (URI)
+  with the Database or Derivative Database, including both in the
+  Database or Derivative Database and in any relevant documentation; and
+
+  c. Keep intact any copyright or Database Right notices and notices
+  that refer to this License.
+
+  d. If it is not possible to put the required notices in a particular
+  file due to its structure, then You must include the notices in a
+  location (such as a relevant directory) where users would be likely to
+  look for it.
+
+4.3 Notice for using output (Contents). Creating and Using a Produced
+Work does not require the notice in Section 4.2. However, if you
+Publicly Use a Produced Work, You must include a notice associated with
+the Produced Work reasonably calculated to make any Person that uses,
+views, accesses, interacts with, or is otherwise exposed to the Produced
+Work aware that Content was obtained from the Database, Derivative
+Database, or the Database as part of a Collective Database, and that it
+is available under this License.
+
+  a. Example notice. The following text will satisfy notice under
+  Section 4.3:
+
+        Contains information from BCFISHPASS, which is made available
+        here under the Open Database License (ODbL).
+
+DATABASE NAME should be replaced with the name of the Database and a
+hyperlink to the URI of the Database. "Open Database License" should
+contain a hyperlink to the URI of the text of this License. If
+hyperlinks are not possible, You should include the plain text of the
+required URI's with the above notice.
+
+4.4 Share alike.
+
+  a. Any Derivative Database that You Publicly Use must be only under
+  the terms of:
+
+    i. This License;
+
+    ii. A later version of this License similar in spirit to this
+      License; or
+
+    iii. A compatible license.
+
+  If You license the Derivative Database under one of the licenses
+  mentioned in (iii), You must comply with the terms of that license.
+
+  b. For the avoidance of doubt, Extraction or Re-utilisation of the
+  whole or a Substantial part of the Contents into a new database is a
+  Derivative Database and must comply with Section 4.4.
+
+  c. Derivative Databases and Produced Works.  A Derivative Database is
+  Publicly Used and so must comply with Section 4.4. if a Produced Work
+  created from the Derivative Database is Publicly Used.
+
+  d. Share Alike and additional Contents. For the avoidance of doubt,
+  You must not add Contents to Derivative Databases under Section 4.4 a
+  that are incompatible with the rights granted under this License.
+
+  e. Compatible licenses. Licensors may authorise a proxy to determine
+  compatible licenses under Section 4.4 a iii. If they do so, the
+  authorised proxy's public statement of acceptance of a compatible
+  license grants You permission to use the compatible license.
+
+
+4.5 Limits of Share Alike.  The requirements of Section 4.4 do not apply
+in the following:
+
+  a. For the avoidance of doubt, You are not required to license
+  Collective Databases under this License if You incorporate this
+  Database or a Derivative Database in the collection, but this License
+  still applies to this Database or a Derivative Database as a part of
+  the Collective Database;
+
+  b. Using this Database, a Derivative Database, or this Database as
+  part of a Collective Database to create a Produced Work does not
+  create a Derivative Database for purposes of  Section 4.4; and
+
+  c. Use of a Derivative Database internally within an organisation is
+  not to the public and therefore does not fall under the requirements
+  of Section 4.4.
+
+4.6 Access to Derivative Databases. If You Publicly Use a Derivative
+Database or a Produced Work from a Derivative Database, You must also
+offer to recipients of the Derivative Database or Produced Work a copy
+in a machine readable form of:
+
+  a. The entire Derivative Database; or
+
+  b. A file containing all of the alterations made to the Database or
+  the method of making the alterations to the Database (such as an
+  algorithm), including any additional Contents, that make up all the
+  differences between the Database and the Derivative Database.
+
+The Derivative Database (under a.) or alteration file (under b.) must be
+available at no more than a reasonable production cost for physical
+distributions and free of charge if distributed over the internet.
+
+4.7 Technological measures and additional terms
+
+  a. This License does not allow You to impose (except subject to
+  Section 4.7 b.)  any terms or any technological measures on the
+  Database, a Derivative Database, or the whole or a Substantial part of
+  the Contents that alter or restrict the terms of this License, or any
+  rights granted under it, or have the effect or intent of restricting
+  the ability of any person to exercise those rights.
+
+  b. Parallel distribution. You may impose terms or technological
+  measures on the Database, a Derivative Database, or the whole or a
+  Substantial part of the Contents (a "Restricted Database") in
+  contravention of Section 4.74 a. only if You also make a copy of the
+  Database or a Derivative Database available to the recipient of the
+  Restricted Database:
+
+    i. That is available without additional fee;
+
+    ii. That is available in a medium that does not alter or restrict
+    the terms of this License, or any rights granted under it, or have
+    the effect or intent of restricting the ability of any person to
+    exercise those rights (an "Unrestricted Database"); and
+
+    iii. The Unrestricted Database is at least as accessible to the
+    recipient as a practical matter as the Restricted Database.
+
+  c. For the avoidance of doubt, You may place this Database or a
+  Derivative Database in an authenticated environment, behind a
+  password, or within a similar access control scheme provided that You
+  do not alter or restrict the terms of this License or any rights
+  granted under it or have the effect or intent of restricting the
+  ability of any person to exercise those rights.
+
+4.8 Licensing of others. You may not sublicense the Database. Each time
+You communicate the Database, the whole or Substantial part of the
+Contents, or any Derivative Database to anyone else in any way, the
+Licensor offers to the recipient a license to the Database on the same
+terms and conditions as this License. You are not responsible for
+enforcing compliance by third parties with this License, but You may
+enforce any rights that You have over a Derivative Database. You are
+solely responsible for any modifications of a Derivative Database made
+by You or another Person at Your direction. You may not impose any
+further restrictions on the exercise of the rights granted or affirmed
+under this License.
+
+### 5.0 Moral rights
+
+5.1 Moral rights. This section covers moral rights, including any rights
+to be identified as the author of the Database or to object to treatment
+that would otherwise prejudice the author's honour and reputation, or
+any other derogatory treatment:
+
+  a. For jurisdictions allowing waiver of moral rights, Licensor waives
+  all moral rights that Licensor may have in the Database to the fullest
+  extent possible by the law of the relevant jurisdiction under Section
+  10.4;
+
+  b. If waiver of moral rights under Section 5.1 a in the relevant
+  jurisdiction is not possible, Licensor agrees not to assert any moral
+  rights over the Database and waives all claims in moral rights to the
+  fullest extent possible by the law of the relevant jurisdiction under
+  Section 10.4; and
+
+  c. For jurisdictions not allowing waiver or an agreement not to assert
+  moral rights under Section 5.1 a and b, the author may retain their
+  moral rights over certain aspects of the Database.
+
+Please note that some jurisdictions do not allow for the waiver of moral
+rights, and so moral rights may still subsist over the Database in some
+jurisdictions.
+
+### 6.0 Fair dealing, Database exceptions, and other rights not affected
+
+6.1 This License does not affect any rights that You or anyone else may
+independently have under any applicable law to make any use of this
+Database, including without limitation:
+
+  a. Exceptions to the Database Right including: Extraction of Contents
+  from non-electronic Databases for private purposes, Extraction for
+  purposes of illustration for teaching or scientific research, and
+  Extraction or Re-utilisation for public security or an administrative
+  or judicial procedure.
+
+  b. Fair dealing, fair use, or any other legally recognised limitation
+  or exception to infringement of copyright or other applicable laws.
+
+6.2 This License does not affect any rights of lawful users to Extract
+and Re-utilise insubstantial parts of the Contents, evaluated
+quantitatively or qualitatively, for any purposes whatsoever, including
+creating a Derivative Database (subject to other rights over the
+Contents, see Section 2.4). The repeated and systematic Extraction or
+Re-utilisation of insubstantial parts of the Contents may however amount
+to the Extraction or Re-utilisation of a Substantial part of the
+Contents.
+
+### 7.0 Warranties and Disclaimer
+
+7.1 The Database is licensed by the Licensor "as is" and without any
+warranty of any kind, either express, implied, or arising by statute,
+custom, course of dealing, or trade usage. Licensor specifically
+disclaims any and all implied warranties or conditions of title,
+non-infringement, accuracy or completeness, the presence or absence of
+errors, fitness for a particular purpose, merchantability, or otherwise.
+Some jurisdictions do not allow the exclusion of implied warranties, so
+this exclusion may not apply to You.
+
+### 8.0 Limitation of liability
+
+8.1 Subject to any liability that may not be excluded or limited by law,
+the Licensor is not liable for, and expressly excludes, all liability
+for loss or damage however and whenever caused to anyone by any use
+under this License, whether by You or by anyone else, and whether caused
+by any fault on the part of the Licensor or not. This exclusion of
+liability includes, but is not limited to, any special, incidental,
+consequential, punitive, or exemplary damages such as loss of revenue,
+data, anticipated profits, and lost business. This exclusion applies
+even if the Licensor has been advised of the possibility of such
+damages.
+
+8.2 If liability may not be excluded by law, it is limited to actual and
+direct financial loss to the extent it is caused by proved negligence on
+the part of the Licensor.
+
+### 9.0 Termination of Your rights under this License
+
+9.1 Any breach by You of the terms and conditions of this License
+automatically terminates this License with immediate effect and without
+notice to You. For the avoidance of doubt, Persons who have received the
+Database, the whole or a Substantial part of the Contents, Derivative
+Databases, or the Database as part of a Collective Database from You
+under this License will not have their licenses terminated provided
+their use is in full compliance with this License or a license granted
+under Section 4.8 of this License.  Sections 1, 2, 7, 8, 9 and 10 will
+survive any termination of this License.
+
+9.2 If You are not in breach of the terms of this License, the Licensor
+will not terminate Your rights under it.
+
+9.3 Unless terminated under Section 9.1, this License is granted to You
+for the duration of applicable rights in the Database.
+
+9.4 Reinstatement of rights. If you cease any breach of the terms and
+conditions of this License, then your full rights under this License
+will be reinstated:
+
+  a. Provisionally and subject to permanent termination until the 60th
+  day after cessation of breach;
+
+  b. Permanently on the 60th day after cessation of breach unless
+  otherwise reasonably notified by the Licensor; or
+
+  c.  Permanently if reasonably notified by the Licensor of the
+  violation, this is the first time You have received notice of
+  violation of this License from  the Licensor, and You cure the
+  violation prior to 30 days after your receipt of the notice.
+
+Persons subject to permanent termination of rights are not eligible to
+be a recipient and receive a license under Section 4.8.
+
+9.5 Notwithstanding the above, Licensor reserves the right to release
+the Database under different license terms or to stop distributing or
+making available the Database. Releasing the Database under different
+license terms or stopping the distribution of the Database will not
+withdraw this License (or any other license that has been, or is
+required to be, granted under the terms of this License), and this
+License will continue in full force and effect unless terminated as
+stated above.
+
+### 10.0 General
+
+10.1 If any provision of this License is held to be invalid or
+unenforceable, that must not affect the validity or enforceability of
+the remainder of the terms and conditions of this License and each
+remaining provision of this License shall be valid and enforced to the
+fullest extent permitted by law.
+
+10.2 This License is the entire agreement between the parties with
+respect to the rights granted here over the Database. It replaces any
+earlier understandings, agreements or representations with respect to
+the Database.
+
+10.3 If You are in breach of the terms of this License, You will not be
+entitled to rely on the terms of this License or to complain of any
+breach by the Licensor.
+
+10.4 Choice of law. This License takes effect in and will be governed by
+the laws of the relevant jurisdiction in which the License terms are
+sought to be enforced. If the standard suite of rights granted under
+applicable copyright law and Database Rights in the relevant
+jurisdiction includes additional rights not granted under this License,
+these additional rights are granted in this License in order to meet the
+terms of this License.
+
+Copyright 2025 Simon Norris, Canadian Wildlife Federation, Province of British Columbia, bcfishpass contributors
+
+
+
+=========================
+DATABASE CONTENTS
+=========================
+
+Database Contents License (DbCL)
+
+The Licensor and You agree as follows:
+
+1.0 Definitions of Capitalised Words
+
+The definitions of the Open Database License (ODbL) 1.0 are incorporated by reference into the Database Contents License.
+
+2.0 Rights granted and Conditions of Use<
+
+2.1 Rights granted. The Licensor grants to You a worldwide,
+royalty-free, non-exclusive, perpetual, irrevocable copyright license to
+do any act that is restricted by copyright over anything within the
+Contents, whether in the original medium or any other. These rights
+explicitly include commercial use, and do not exclude any field of
+endeavour. These rights include, without limitation, the right to
+sublicense the work.
+
+2.2 Conditions of Use. You must comply with the ODbL.
+
+2.3 Relationship to Databases and ODbL. This license does not cover any
+Database Rights, Database copyright, or contract over the Contents as
+part of the Database. Please see the ODbL covering the Database for more
+details about Your rights and obligations.
+
+2.4 Non-assertion of copyright over facts. The Licensor takes the
+position that factual information is not covered by copyright. The DbCL
+grants you permission for any information having copyright contained in
+the Contents.
+
+3.0 Warranties, disclaimer, and limitation of liability
+
+3.1 The Contents are licensed by the Licensor “as is” and without any
+warranty of any kind, either express or implied, whether of title, of
+accuracy, of the presence of absence of errors, of fitness for purpose,
+or otherwise. Some jurisdictions do not allow the exclusion of implied
+warranties, so this exclusion may not apply to You.
+
+3.2 Subject to any liability that may not be excluded or limited by law,
+the Licensor is not liable for, and expressly excludes, all liability
+for loss or damage however and whenever caused to anyone by any use
+under this License, whether by You or by anyone else, and whether caused
+by any fault on the part of the Licensor or not. This exclusion of
+liability includes, but is not limited to, any special, incidental,
+consequential, punitive, or exemplary damages. This exclusion applies
+even if the Licensor has been advised of the possibility of such
+damages.
+
+3.3 If liability may not be excluded by law, it is limited to actual and
+direct financial loss to the extent it is caused by proved negligence on
+the part of the Licensor.
+
+Copyright 2025 Simon Norris, Canadian Wildlife Federation, Province of British Columbia, bcfishpass contributors

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,39 @@
+# NOTICE
+
+`link` builds on upstream data and software from
+[smnorris](https://github.com/smnorris) and is grateful to those projects.
+
+## Upstream sources
+
+| Source | License | How `link` uses it |
+|---|---|---|
+| [smnorris/fwapg](https://github.com/smnorris/fwapg) | MIT | Runtime SQL access to BC's Freshwater Atlas. Not redistributed. |
+| [smnorris/bcfishobs](https://github.com/smnorris/bcfishobs) | Apache 2.0 | Runtime read of fish observation data (via tunnel DB). Not redistributed. |
+| [smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) (software) | Apache 2.0 | Reference for habitat-classification parity. Not redistributed. |
+| [smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) (data) | ODbL + DATABASE CONTENTS | **Redistributed** — the override CSVs in `inst/extdata/configs/*/overrides/`. |
+
+## Redistributed data
+
+`link` redistributes the following files from
+[smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) under the terms
+of `LICENSE-bcfishpass` (a verbatim copy at this repository's root):
+
+- `inst/extdata/configs/bcfishpass/overrides/user_habitat_classification.csv`
+- `inst/extdata/configs/bcfishpass/overrides/user_modelled_crossing_fixes.csv`
+- `inst/extdata/configs/bcfishpass/overrides/user_pscis_barrier_status.csv`
+- `inst/extdata/configs/bcfishpass/overrides/pscis_modelledcrossings_streams_xref.csv`
+- `inst/extdata/configs/bcfishpass/overrides/user_barriers_definite.csv`
+- `inst/extdata/configs/bcfishpass/overrides/user_barriers_definite_control.csv`
+- `inst/extdata/configs/bcfishpass/overrides/user_crossings_misc.csv`
+
+The same files are mirrored under `inst/extdata/configs/default/overrides/`.
+Provenance metadata (upstream commit SHA, sync date, byte + shape checksums)
+for each file is recorded in the corresponding `config.yaml` under the
+`provenance:` block.
+
+## `link`'s own license
+
+`link` itself is MIT-licensed; see `LICENSE` for `link`'s code license.
+This `NOTICE` file documents attribution for upstream redistributions and
+runtime dependencies; it does not modify the terms under which `link`'s
+own code is distributed.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ fresh models habitat on the network. link connects features to the
 network and interprets them. They change for different reasons and can
 each be used independently.
 
+## Acknowledgements
+
+`link` builds on upstream work by [smnorris](https://github.com/smnorris):
+
+| Source | License | How `link` uses it |
+|---|---|---|
+| [smnorris/fwapg](https://github.com/smnorris/fwapg) | MIT | Runtime SQL access to BC's Freshwater Atlas |
+| [smnorris/bcfishobs](https://github.com/smnorris/bcfishobs) | Apache 2.0 | Runtime read of fish observation data |
+| [smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) (software) | Apache 2.0 | Reference for habitat-classification parity |
+| [smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) (data) | ODbL | Redistributed override CSVs in `inst/extdata/configs/*/overrides/` |
+
+See [`NOTICE.md`](NOTICE.md) for the full attribution and
+[`LICENSE-bcfishpass`](LICENSE-bcfishpass) for the verbatim upstream license
+governing the redistributed data.
+
 ## License
 
-MIT
+MIT (see [`LICENSE`](LICENSE)). Applies to `link`'s own code; redistributed
+data carries its own license — see Acknowledgements above and `NOTICE.md`.

--- a/inst/extdata/configs/bcfishpass/overrides/README.md
+++ b/inst/extdata/configs/bcfishpass/overrides/README.md
@@ -1,0 +1,13 @@
+# bcfishpass overrides
+
+The CSVs in this directory are sourced from
+[smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) and
+redistributed under the terms of `LICENSE-bcfishpass` at the root of
+the `link` repository.
+
+Provenance (upstream commit SHA, sync date, byte + shape checksums)
+for each file is recorded in `../config.yaml` under the `provenance:`
+block.
+
+See [`NOTICE.md`](https://github.com/NewGraphEnvironment/link/blob/main/NOTICE.md)
+at the root of `link`'s repository for the full attribution table.

--- a/inst/extdata/configs/default/overrides/README.md
+++ b/inst/extdata/configs/default/overrides/README.md
@@ -1,0 +1,13 @@
+# default overrides
+
+The CSVs in this directory are sourced from
+[smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) and
+redistributed under the terms of `LICENSE-bcfishpass` at the root of
+the `link` repository.
+
+Provenance (upstream commit SHA, sync date, byte + shape checksums)
+for each file is recorded in `../config.yaml` under the `provenance:`
+block.
+
+See [`NOTICE.md`](https://github.com/NewGraphEnvironment/link/blob/main/NOTICE.md)
+at the root of `link`'s repository for the full attribution table.

--- a/man/link-package.Rd
+++ b/man/link-package.Rd
@@ -22,5 +22,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Allan Irvine \email{airvine@newgraphenvironment.com} (\href{https://orcid.org/0009-0003-7697-6064}{ORCID})
 
+Other contributors:
+\itemize{
+  \item Simon Norris [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/link-package.Rd
+++ b/man/link-package.Rd
@@ -4,11 +4,11 @@
 \name{link-package}
 \alias{link}
 \alias{link-package}
-\title{link: Crossing Connectivity Interpretation}
+\title{link: Habitat and Connectivity Interpretation for Stream Networks}
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Connectivity-system-agnostic crossing interpretation layer. Scores, overrides, and prioritizes crossings for fish passage using configurable severity thresholds and multi-source data integration. Produces scored crossing tables and break source specs for network segmentation engines. Crossings are features on the network — some break geometry (confirmed barriers), others index for downstream relationship queries (unassessed crossings, observations).
+Domain interpretation layer over stream network models. Connects point features — crossings, observations, barriers, habitat confirmations — to the network and interprets what they mean for habitat: intrinsic potential, accessibility under network connectivity, per-feature rollups. Pairs with 'fresh', the network modelling engine; 'fresh' answers what the habitat is, 'link' answers what the features mean for the network. Pipelines are driven by manifest config bundles so methodology choices are data, not code, and reproducible across runs.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
## Summary

Two related concerns landing together:

### Attribution (closes #78)

`link` redistributes override CSVs sourced from
[smnorris/bcfishpass](https://github.com/smnorris/bcfishpass) under
`inst/extdata/configs/*/overrides/` and reads
[`fwapg`](https://github.com/smnorris/fwapg) +
[`bcfishobs`](https://github.com/smnorris/bcfishobs) at runtime. The
licenses (MIT, Apache 2.0, ODbL) all expect attribution. This PR adds it.

- `LICENSE-bcfishpass` at root — verbatim copy of upstream LICENSE
- `NOTICE.md` at root — source/license table + names redistributed files + pointer to `LICENSE-bcfishpass`
- `inst/extdata/configs/{bcfishpass,default}/overrides/README.md` — pointer files reachable via `system.file()` after install
- `README.md` — new "Acknowledgements" section above License
- `DESCRIPTION` `Authors@R` — Simon Norris added as `[ctb]` (name + role only)

### Title / Description refresh

Old DESCRIPTION still framed link as "Crossing Connectivity Interpretation" from the v0.6 era. Updated to reflect what link is at v0.18.0:

```
Title: Habitat and Connectivity Interpretation for Stream Networks
Description: Domain interpretation layer over stream network models.
    Connects point features — crossings, observations, barriers,
    habitat confirmations — to the network and interprets what they
    mean for habitat: intrinsic potential, accessibility under network
    connectivity, per-feature rollups. Pairs with 'fresh', the network
    modelling engine; 'fresh' answers what the habitat is, 'link'
    answers what the features mean for the network. Pipelines are
    driven by manifest config bundles so methodology choices are data,
    not code, and reproducible across runs.
```

Mirrors the README's "fresh answers / link answers" framing. Names the three habitat axes (intrinsic potential, accessibility under connectivity, per-feature rollups). Drops fish-passage-specific narrowing — the code already supports any species via configurable parameters.

## Test plan

- [x] `R CMD INSTALL` succeeds — `Authors@R` parses cleanly
- [x] `LICENSE-bcfishpass` is byte-identical to upstream `main` HEAD
- [x] `NOTICE.md` lists every CSV in `inst/extdata/configs/bcfishpass/overrides/` that comes from upstream
- [x] Per-bundle `overrides/README.md` reachable via `system.file()` after install
- [x] `devtools::document()` regenerates `man/link-package.Rd` cleanly from new Title + Description

## Out of scope (deferred)

- `CITATION` file
- Mirror to `NewGraphEnvironment/crate` — separate effort, comms-thread-first

Fixes #78
Relates to NewGraphEnvironment/sred-2025-2026#28
