### PR TITLE
Per-AOI observations filter: wsg_species_presence + observation_key exclusions

### DIFF
--- a/R/lnk_barrier_overrides.R
+++ b/R/lnk_barrier_overrides.R
@@ -26,7 +26,7 @@
 #'   Any confirmed habitat (spawning or rearing flagged) upstream
 #'   of a barrier removes it (threshold = 1).
 #' @param exclusions Character or `NULL`. Schema-qualified table of
-#'   observation exclusions with column `fish_observation_point_id`. Flagged
+#'   observation exclusions with column `observation_key`. Flagged
 #'   observations are removed before counting.
 #' @param control Character or `NULL`. Schema-qualified table of barrier
 #'   controls with columns: `blue_line_key`, `downstream_route_measure`,
@@ -183,7 +183,7 @@ lnk_barrier_overrides <- function(conn,
     if (!is.null(observations) && threshold > 0) {
       excl_where <- if (!is.null(exclusions)) {
         sprintf(
-          "AND o.fish_observation_point_id NOT IN (SELECT fish_observation_point_id FROM %s)",
+          "AND o.observation_key NOT IN (SELECT observation_key FROM %s)",
           exclusions)
       } else {
         ""

--- a/R/lnk_pipeline_break.R
+++ b/R/lnk_pipeline_break.R
@@ -131,48 +131,23 @@ lnk_pipeline_break <- function(conn, aoi, cfg, loaded, schema,
 }
 
 
-#' Build observations_breaks with species filter and data-error exclusions
+#' Build observations_breaks from the per-AOI filtered observations table
+#'
+#' Reads from `<schema>.observations`, materialized by
+#' `.lnk_pipeline_prep_observations()`. That helper already applies the
+#' WSG species-presence filter and the QA exclusions (mirrors bcfp's
+#' `bcfishpass.observations` build), so this step is now a simple
+#' `SELECT DISTINCT blue_line_key, drm` on the pre-filtered table.
 #' @noRd
 .lnk_pipeline_break_obs <- function(conn, aoi, loaded, schema, observations) {
-  obs_species <- .lnk_pipeline_break_obs_species(loaded, aoi)
-  if (length(obs_species) == 0L) {
-    obs_species_sql <- "NULL"
-  } else {
-    obs_species_sql <- paste0(
-      vapply(obs_species, .lnk_quote_literal, character(1)),
-      collapse = ", ")
-  }
-
-  # Observation exclusions: data errors + release excludes
-  excl_filter <- ""
-  excl_df <- loaded$observation_exclusions
-  if (!is.null(excl_df) && nrow(excl_df) > 0) {
-    is_excl <- excl_df$data_error %in% c(TRUE, "t") |
-               excl_df$release_exclude %in% c(TRUE, "t")
-    keys <- excl_df$fish_observation_point_id[is_excl]
-    if (length(keys) > 0) {
-      DBI::dbWriteTable(conn,
-        DBI::Id(schema = schema, table = "obs_exclusions"),
-        data.frame(fish_observation_point_id = keys),
-        overwrite = TRUE)
-      excl_filter <- sprintf(
-        "AND o.fish_observation_point_id NOT IN
-          (SELECT fish_observation_point_id FROM %s.obs_exclusions)",
-        schema)
-    }
-  }
-
   .lnk_db_execute(conn, sprintf(
     "DROP TABLE IF EXISTS %s.observations_breaks", schema))
   .lnk_db_execute(conn, sprintf(
     "CREATE TABLE %s.observations_breaks AS
-     SELECT DISTINCT o.blue_line_key,
-            round(o.downstream_route_measure) AS downstream_route_measure
-     FROM %s o
-     WHERE o.watershed_group_code = %s
-       AND o.species_code IN (%s) %s",
-    schema, observations, .lnk_quote_literal(aoi),
-    obs_species_sql, excl_filter))
+     SELECT DISTINCT blue_line_key,
+            round(downstream_route_measure) AS downstream_route_measure
+     FROM %s.observations",
+    schema, schema))
 
   invisible(NULL)
 }

--- a/R/lnk_pipeline_prepare.R
+++ b/R/lnk_pipeline_prepare.R
@@ -91,9 +91,10 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
   }
 
   .lnk_pipeline_prep_load_aux(conn, aoi, loaded, schema)
+  .lnk_pipeline_prep_observations(conn, aoi, loaded, schema, observations)
   .lnk_pipeline_prep_gradient(conn, aoi, loaded, schema)
   .lnk_pipeline_prep_natural(conn, aoi, cfg, loaded, schema)
-  .lnk_pipeline_prep_overrides(conn, loaded, schema, observations)
+  .lnk_pipeline_prep_overrides(conn, loaded, schema)
   .lnk_pipeline_prep_minimal(conn, aoi, schema)
   .lnk_pipeline_prep_network(conn, aoi, schema)
 
@@ -188,6 +189,81 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
            rearing integer)", schema))
     }
   }
+
+  invisible(NULL)
+}
+
+
+#' Build per-AOI filtered observations table.
+#'
+#' Mirrors bcfishpass `model/01_access/sql/load_observations.sql`:
+#' filters `bcfishobs.observations` by (a) AOI's species set from
+#' `loaded$wsg_species_presence` (only observations of species marked
+#' present in the WSG count) and (b) `loaded$observation_exclusions`
+#' (rows with `data_error = TRUE` or `release_exclude = TRUE` removed,
+#' keyed on `observation_key`). Result: `<schema>.observations`,
+#' consumed by `prep_overrides` and `lnk_pipeline_break`'s observation
+#' break-source step.
+#'
+#' Without this filter, link's barrier-override lift counts QA-flagged
+#' observations and observations of species not present in the WSG —
+#' lifting natural barriers that bcfishpass correctly retains. Surfaced
+#' in TWAC BT over-credit (link#92): a 1987 ST observation upstream of
+#' the outlet falls lifts the fall in link but bcfishpass excludes it
+#' because TWAC has no ST in `wsg_species_presence`.
+#'
+#' bcfishobs records cutthroat as CT/CCT/ACT/CT/RB; when CT is in the
+#' WSG's species set, all four codes are admitted (matches bcfp's
+#' `species_code_remap` CTE).
+#' @noRd
+.lnk_pipeline_prep_observations <- function(conn, aoi, loaded, schema,
+                                            observations = "bcfishobs.observations") {
+  .lnk_validate_identifier(observations, "observations table")
+
+  if (is.null(loaded$wsg_species_presence)) {
+    stop("loaded$wsg_species_presence not present — required for the ",
+         "per-AOI observations filter (mirrors bcfishpass parity)",
+         call. = FALSE)
+  }
+  sp <- .lnk_pipeline_break_obs_species(loaded, aoi)
+
+  .lnk_db_execute(conn, sprintf(
+    "DROP TABLE IF EXISTS %s.observations", schema))
+
+  if (length(sp) == 0) {
+    # No species marked present — empty table mirroring source schema
+    .lnk_db_execute(conn, sprintf(
+      "CREATE TABLE %s.observations AS
+       SELECT * FROM %s WHERE FALSE", schema, observations))
+    return(invisible(NULL))
+  }
+
+  sp_sql <- paste0(
+    vapply(sp, .lnk_quote_literal, character(1)),
+    collapse = ", ")
+
+  excl_filter <- ""
+  excl_df <- loaded$observation_exclusions
+  if (!is.null(excl_df) && nrow(excl_df) > 0) {
+    is_excl <- excl_df$data_error %in% c(TRUE, "t") |
+               excl_df$release_exclude %in% c(TRUE, "t")
+    keys <- excl_df$observation_key[is_excl]
+    if (length(keys) > 0) {
+      keys_sql <- paste0(
+        vapply(keys, .lnk_quote_literal, character(1)),
+        collapse = ", ")
+      excl_filter <- sprintf(
+        "AND o.observation_key NOT IN (%s)", keys_sql)
+    }
+  }
+
+  .lnk_db_execute(conn, sprintf(
+    "CREATE TABLE %s.observations AS
+     SELECT * FROM %s o
+     WHERE o.watershed_group_code = %s
+       AND o.species_code IN (%s)
+       %s",
+    schema, observations, .lnk_quote_literal(aoi), sp_sql, excl_filter))
 
   invisible(NULL)
 }
@@ -353,7 +429,7 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
 
 #' Compute barrier overrides via lnk_barrier_overrides
 #' @noRd
-.lnk_pipeline_prep_overrides <- function(conn, loaded, schema, observations) {
+.lnk_pipeline_prep_overrides <- function(conn, loaded, schema) {
   # Manifest-driven gate. `.lnk_pipeline_prep_load_aux` writes
   # `<schema>.user_habitat_classification` exactly when the manifest
   # declares `user_habitat_classification`, so the loaded entry is the
@@ -375,9 +451,13 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
     NULL
   }
 
+  # Use <schema>.observations (filtered per-AOI by `prep_observations`)
+  # rather than raw bcfishobs.observations. Mirrors bcfishpass's
+  # bcfishpass.observations build (species-presence + exclusions
+  # already applied). See link#92.
   lnk_barrier_overrides(conn,
     barriers = paste0(schema, ".natural_barriers"),
-    observations = observations,
+    observations = paste0(schema, ".observations"),
     habitat = habitat_arg,
     control = control_arg,
     params = loaded$parameters_fresh,

--- a/man/lnk_barrier_overrides.Rd
+++ b/man/lnk_barrier_overrides.Rd
@@ -39,7 +39,7 @@ Any confirmed habitat (spawning or rearing flagged) upstream
 of a barrier removes it (threshold = 1).}
 
 \item{exclusions}{Character or \code{NULL}. Schema-qualified table of
-observation exclusions with column \code{fish_observation_point_id}. Flagged
+observation exclusions with column \code{observation_key}. Flagged
 observations are removed before counting.}
 
 \item{control}{Character or \code{NULL}. Schema-qualified table of barrier

--- a/tests/testthat/test-lnk_pipeline_break.R
+++ b/tests/testthat/test-lnk_pipeline_break.R
@@ -66,18 +66,12 @@ test_that(".lnk_pipeline_break_obs_species expands CT to CT/CCT/ACT/CT\\RB", {
 })
 
 # -- break_obs SQL shape -----------------------------------------------------
+# Post-link#92 simplification: prep_observations builds <schema>.observations
+# with the WSG species-presence + exclusions filters applied. break_obs is now
+# a thin reader from that pre-filtered table — no obs_exclusions temp table
+# write, no inline species/exclusion SQL.
 
-test_that(".lnk_pipeline_break_obs writes AOI-scoped observations_breaks", {
-  loaded_stub <- list(
-    wsg_species_presence = data.frame(
-      watershed_group_code = "BULK",
-      bt = "t", ch = "t", cm = "f", co = "f", ct = "f", dv = "f",
-      pk = "f", rb = "f", sk = "f", st = "f", wct = "f",
-      stringsAsFactors = FALSE
-    ),
-    observation_exclusions = NULL
-  )
-
+test_that(".lnk_pipeline_break_obs reads from <schema>.observations (link#92)", {
   captured <- character(0)
   local_mocked_bindings(
     .lnk_db_execute = function(conn, sql) {
@@ -85,65 +79,23 @@ test_that(".lnk_pipeline_break_obs writes AOI-scoped observations_breaks", {
       invisible(NULL)
     }
   )
-  local_mocked_bindings(
-    dbWriteTable = function(...) invisible(NULL),
-    .package = "DBI"
-  )
 
-  .lnk_pipeline_break_obs("mock", aoi = "BULK", loaded = loaded_stub,
+  .lnk_pipeline_break_obs("mock", aoi = "BULK", loaded = list(),
                            schema = "w_bulk",
                            observations = "bcfishobs.observations")
 
   joined <- paste(captured, collapse = "\n")
+  expect_match(joined, "DROP TABLE IF EXISTS w_bulk.observations_breaks")
   expect_match(joined, "CREATE TABLE w_bulk.observations_breaks")
-  expect_match(joined, "FROM bcfishobs.observations o")
-  expect_match(joined, "o.watershed_group_code = 'BULK'")
-  expect_match(joined, "'BT', 'CH'")
+  # Reads from the pre-filtered <schema>.observations table, NOT raw bcfishobs
+  expect_match(joined, "FROM w_bulk.observations\\b")
+  expect_no_match(joined, "FROM bcfishobs\\.observations")
+  # Species filter, watershed_group filter, and exclusions all moved upstream
+  # to prep_observations — must not appear in this step's SQL.
+  expect_no_match(joined, "watershed_group_code")
+  expect_no_match(joined, "species_code IN")
   expect_no_match(joined, "obs_exclusions")
-})
-
-test_that(".lnk_pipeline_break_obs applies exclusions when present", {
-  loaded_stub <- list(
-    wsg_species_presence = data.frame(
-      watershed_group_code = "BULK",
-      bt = "t", ch = "f", cm = "f", co = "f", ct = "f", dv = "f",
-      pk = "f", rb = "f", sk = "f", st = "f", wct = "f",
-      stringsAsFactors = FALSE
-    ),
-    observation_exclusions = data.frame(
-      fish_observation_point_id = c(1L, 2L, 3L),
-      data_error = c(TRUE, FALSE, FALSE),
-      release_exclude = c(FALSE, TRUE, FALSE),
-      stringsAsFactors = FALSE
-    )
-  )
-
-  captured <- character(0)
-  written <- list()
-  local_mocked_bindings(
-    .lnk_db_execute = function(conn, sql) {
-      captured <<- c(captured, sql)
-      invisible(NULL)
-    }
-  )
-  local_mocked_bindings(
-    dbWriteTable = function(conn, name, value, ...) {
-      written[[length(written) + 1]] <<- list(name = name, value = value)
-      invisible(NULL)
-    },
-    .package = "DBI"
-  )
-
-  .lnk_pipeline_break_obs("mock", aoi = "BULK", loaded = loaded_stub,
-                           schema = "w_bulk",
-                           observations = "bcfishobs.observations")
-
-  expect_length(written, 1L)
-  expect_equal(nrow(written[[1]]$value), 2L)
-  expect_setequal(written[[1]]$value$fish_observation_point_id, c(1L, 2L))
-
-  joined <- paste(captured, collapse = "\n")
-  expect_match(joined, "NOT IN\\s*\\(SELECT fish_observation_point_id FROM w_bulk.obs_exclusions\\)")
+  expect_no_match(joined, "observation_key NOT IN")
 })
 
 # -- habitat endpoints -------------------------------------------------------

--- a/tests/testthat/test-lnk_pipeline_prepare.R
+++ b/tests/testthat/test-lnk_pipeline_prepare.R
@@ -292,7 +292,7 @@ test_that(".lnk_pipeline_prep_overrides passes control when manifest declares it
   )
 
   .lnk_pipeline_prep_overrides("mock-conn", loaded = loaded_stub,
-    schema = "working_bulk", observations = "bcfishobs.observations")
+    schema = "working_bulk")
 
   expect_equal(captured$args$control, "working_bulk.barriers_definite_control")
 })
@@ -318,7 +318,7 @@ test_that(".lnk_pipeline_prep_overrides passes control = NULL when manifest omit
   )
 
   .lnk_pipeline_prep_overrides("mock-conn", loaded = loaded_stub,
-    schema = "working_bulk", observations = "bcfishobs.observations")
+    schema = "working_bulk")
 
   expect_null(captured$args$control)
 })
@@ -351,7 +351,7 @@ test_that(".lnk_pipeline_prep_overrides passes habitat when manifest declares it
   )
 
   .lnk_pipeline_prep_overrides("mock-conn", loaded = loaded_stub,
-    schema = "working_bulk", observations = "bcfishobs.observations")
+    schema = "working_bulk")
 
   expect_equal(captured$args$habitat,
     "working_bulk.user_habitat_classification")
@@ -378,7 +378,147 @@ test_that(".lnk_pipeline_prep_overrides passes habitat = NULL when manifest omit
   )
 
   .lnk_pipeline_prep_overrides("mock-conn", loaded = loaded_stub,
-    schema = "working_bulk", observations = "bcfishobs.observations")
+    schema = "working_bulk")
 
   expect_null(captured$args$habitat)
+})
+
+
+# =====================================================================
+# .lnk_pipeline_prep_observations — link#92 per-AOI filtered observations
+# =====================================================================
+#
+# Mirrors bcfp's `model/01_access/sql/load_observations.sql`:
+#   - INNER filter to WSG's species set (loaded$wsg_species_presence)
+#   - LEFT JOIN observation_exclusions, drop data_error/release_exclude rows
+#     (keyed on observation_key)
+# Result: <schema>.observations, consumed by prep_overrides + break_obs.
+
+test_that(".lnk_pipeline_prep_observations builds species-filtered table", {
+  captured <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured <<- c(captured, sql); invisible(NULL)
+    }
+  )
+
+  loaded <- list(
+    wsg_species_presence = data.frame(
+      watershed_group_code = "BULK",
+      bt = "t", ch = "t", cm = "f", co = "f", ct = "f", dv = "f",
+      pk = "f", rb = "f", sk = "f", st = "f", wct = "f",
+      stringsAsFactors = FALSE
+    ),
+    observation_exclusions = NULL
+  )
+  .lnk_pipeline_prep_observations("mock", aoi = "BULK", loaded = loaded,
+    schema = "w_bulk", observations = "bcfishobs.observations")
+
+  joined <- paste(captured, collapse = "\n")
+  expect_match(joined, "DROP TABLE IF EXISTS w_bulk\\.observations\\b")
+  expect_match(joined, "CREATE TABLE w_bulk\\.observations AS")
+  expect_match(joined, "FROM bcfishobs\\.observations o")
+  expect_match(joined, "o\\.watershed_group_code = 'BULK'")
+  expect_match(joined, "o\\.species_code IN \\('BT', 'CH'\\)")
+  # No exclusions clause when the loaded list has none
+  expect_no_match(joined, "observation_key NOT IN")
+})
+
+test_that(".lnk_pipeline_prep_observations applies QA exclusions on observation_key", {
+  captured <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured <<- c(captured, sql); invisible(NULL)
+    }
+  )
+
+  loaded <- list(
+    wsg_species_presence = data.frame(
+      watershed_group_code = "BULK",
+      bt = "t", ch = "f", cm = "f", co = "f", ct = "f", dv = "f",
+      pk = "f", rb = "f", sk = "f", st = "f", wct = "f",
+      stringsAsFactors = FALSE
+    ),
+    observation_exclusions = data.frame(
+      observation_key  = c("aaa", "bbb", "ccc", "ddd"),
+      data_error       = c(TRUE,  FALSE, FALSE, FALSE),
+      release_exclude  = c(FALSE, TRUE,  FALSE, FALSE),
+      release_include  = c(FALSE, FALSE, FALSE, FALSE),
+      stringsAsFactors = FALSE
+    )
+  )
+  .lnk_pipeline_prep_observations("mock", aoi = "BULK", loaded = loaded,
+    schema = "w_bulk", observations = "bcfishobs.observations")
+
+  joined <- paste(captured, collapse = "\n")
+  # Filter clause keyed on observation_key (NOT fish_observation_point_id) —
+  # this is the link#92 fix. CSV column matches bcfishpass schema exactly.
+  expect_match(joined, "AND o\\.observation_key NOT IN")
+  # Only the 2 truly-excluded keys (data_error TRUE or release_exclude TRUE)
+  # appear; the 2 kept keys do NOT
+  expect_match(joined, "'aaa'")
+  expect_match(joined, "'bbb'")
+  expect_no_match(joined, "'ccc'")
+  expect_no_match(joined, "'ddd'")
+})
+
+test_that(".lnk_pipeline_prep_observations expands CT to CT/CCT/ACT/CT/RB", {
+  captured <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured <<- c(captured, sql); invisible(NULL)
+    }
+  )
+
+  loaded <- list(
+    wsg_species_presence = data.frame(
+      watershed_group_code = "ELKR",
+      bt = "f", ch = "f", cm = "f", co = "f", ct = "t", dv = "f",
+      pk = "f", rb = "f", sk = "f", st = "f", wct = "t",
+      stringsAsFactors = FALSE
+    ),
+    observation_exclusions = NULL
+  )
+  .lnk_pipeline_prep_observations("mock", aoi = "ELKR", loaded = loaded,
+    schema = "w_elkr", observations = "bcfishobs.observations")
+
+  joined <- paste(captured, collapse = "\n")
+  # CT alias remap mirrors bcfishpass species_code_remap (CCT/ACT/CT/RB → CT)
+  for (sp in c("CT", "CCT", "ACT", "CT/RB", "WCT")) {
+    expect_match(joined, sprintf("'%s'", sp))
+  }
+})
+
+test_that(".lnk_pipeline_prep_observations builds empty table when no species present", {
+  captured <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured <<- c(captured, sql); invisible(NULL)
+    }
+  )
+
+  loaded <- list(
+    wsg_species_presence = data.frame(
+      watershed_group_code = "XXXX",
+      bt = "f", ch = "f", cm = "f", co = "f", ct = "f", dv = "f",
+      pk = "f", rb = "f", sk = "f", st = "f", wct = "f",
+      stringsAsFactors = FALSE
+    ),
+    observation_exclusions = NULL
+  )
+  .lnk_pipeline_prep_observations("mock", aoi = "XXXX", loaded = loaded,
+    schema = "w_x", observations = "bcfishobs.observations")
+
+  joined <- paste(captured, collapse = "\n")
+  expect_match(joined, "WHERE FALSE")
+  expect_no_match(joined, "watershed_group_code = 'XXXX'")
+})
+
+test_that(".lnk_pipeline_prep_observations errors when wsg_species_presence missing", {
+  expect_error(
+    .lnk_pipeline_prep_observations("mock", aoi = "BULK",
+      loaded = list(wsg_species_presence = NULL),
+      schema = "w_bulk", observations = "bcfishobs.observations"),
+    "wsg_species_presence not present"
+  )
 })


### PR DESCRIPTION
## Summary

Link's pipeline ignored bcfishpass's per-WSG species-presence filter on fish observations and used the wrong join key for QA exclusions. bcfp's [`load_observations.sql`](https://github.com/smnorris/bcfishpass/blob/main/model/01_access/sql/load_observations.sql) builds `bcfishpass.observations` (224k rows) from `bcfishobs.observations` (372k rows) by:

1. INNER JOIN `wsg_species_presence` — only observations of species marked present in the WSG
2. LEFT JOIN `observation_exclusions` — drop `data_error = TRUE` or `release_exclude = TRUE` rows, keyed on `observation_key`

Link consumed raw `bcfishobs.observations` directly with neither filter applied. The exclusions join referenced `fish_observation_point_id` — a column never in the CSV — so all 1,182 QA exclusions were silently dropped.

Surfaced via the provincial parity run (`research/provincial_parity_2026_05_01.md` — Class D over-credits on TWAC, STHM, BULL, BBAR, COWN). Traced to TWAC: a 1987 ST observation upstream of the outlet falls (blkey 356351200 DRM 524) lifts the fall on link side because TWAC has BT=t/CH=t/DV=t/RB=t but ST=NA in `wsg_species_presence` — bcfp filters the obs out, link counts it.

## Change

Adds `.lnk_pipeline_prep_observations()` in `R/lnk_pipeline_prepare.R` mirroring bcfp's `load_observations.sql`. Builds `<schema>.observations` per AOI with both filters applied. Downstream consumers updated:

- `prep_overrides` reads `<schema>.observations` (no longer takes `observations` parameter)
- `lnk_pipeline_break_obs` simplified to a thin reader from `<schema>.observations` — no inline species/exclusions logic
- `lnk_barrier_overrides` docstring + SQL updated to use `observation_key` column (matches CSV schema)

## Verification

**TWAC pre-flight** (the canonical Class D outlier):
| metric | post-#90 | post-#92 |
|---|---:|---:|
| BT spawning | +21.4% | **0.0%** |
| BT rearing | +24.9% | **0.0%** |
| BT rearing_stream | +30.2% | **0.0%** |

**15-WSG `tar_make`** (52 min):

13 rows tightened toward parity (all HARR + LFRA BT):

| WSG / metric | post-#90 | post-#92 |
|---|---:|---:|
| LFRA BT rearing | -2.62% | **-0.54%** |
| LFRA BT rearing_stream | -3.75% | **-0.93%** |
| LFRA BT spawning | -1.29% | **+0.10%** |
| HARR BT rearing_stream | -4.19% | **-1.29%** |
| HARR BT rearing | -1.84% | **-0.69%** |
| HARR BT spawning | -1.58% | **-0.15%** |

Other 13 of 15 WSGs unchanged — they had no QA-flagged or species-not-in-WSG observations affecting their lifts. **HORS BT stays -7.68%** (fresh#158 stream-order bypass, different mechanism, deferred per design).

**Default bundle** also changes (6 rows on HARR/LFRA BT) — same fix applies to default config too. **Methodology correctness improvement aligned with bcfp's pattern, not a regression.** Default-bundle's persistent BT divergence (HARR -29%, LFRA -12%) is unrelated SK/lake methodology.

## Test plan

- [x] `devtools::test(filter = "lnk_pipeline_prepare|lnk_pipeline_break")` 92/92 PASS
- [x] `/code-check` 3 rounds clean
- [x] TWAC pre-flight: +30% → 0%
- [x] HARR pre-flight: no regression (-1.29% post-#92)
- [x] 15-WSG `tar_make`: 13 rows tightened toward parity, no regression
- [x] Default bundle: change documented as correctness improvement

## Architecture note

`.lnk_pipeline_break_obs` was the natural home for the observation-side filtering until link#92's diagnosis showed it was missing the `wsg_species_presence` filter entirely. Folding into a dedicated `prep_observations` step (mirroring bcfp's `load_observations.sql` 1:1) makes the filter logic explicit and shared across both the break-source step and the barrier-overrides lift. Single source of truth for "what observations does link count for this WSG."

## Follow-ups (out of scope)

- Class D over-credits in WSGs not in the 15-WSG suite (STHM, BULL, BBAR, COWN, MFRA, KNIG) — provincial re-run after merge will confirm closure
- HORS / COLR / KHOR / CLRH WCT under-credits — fresh#158 (stream-order bypass), distinct mechanism
- `lnk_pipeline_break.R`'s `observations` parameter is now unused — leave for one release cycle for back-compat, drop in a follow-up

Fixes #92
Relates to NewGraphEnvironment/sred-2025-2026#24
