### PR TITLE
Ingest CABD dams as parallel reporting dimension

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.23.0
+Version: 0.24.0
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# link 0.24.0
+
+Closes [#103](https://github.com/NewGraphEnvironment/link/issues/103). Ingests CABD dams as a parallel reporting dimension. `.lnk_pipeline_prep_dams()` replicates bcfishpass's `model/01_access/sql/load_dams.sql` against the `cabd.dams` source over the db_newgraph tunnel and writes `<schema>.dams` mirroring `bcfishpass.dams` column-for-column. Both `bcfishpass` and `default` bundles ingest — the data is methodology-agnostic at the data layer.
+
+- New optional `conn_tunnel = NULL` arg to `lnk_pipeline_prepare()`. When NULL, `prep_dams` short-circuits to `DROP TABLE IF EXISTS <schema>.dams` — zero-cost opt-out for CI / non-reporting workflows.
+- Four CABD edit CSVs (`cabd_exclusions`, `cabd_blkey_xref`, `cabd_passability_status_updates`, `cabd_additions`) ship in both bundles' `overrides/` and are loaded through `lnk_load_overrides()` like any other override.
+- **Habitat output is unchanged.** `<schema>.dams` and `<schema>.cabd_*` are not consumed by any break / classify / connect phase. HARR dams-ON / dams-OFF rollup is byte-identical to fp precision; confirms the parallel-data invariant.
+- LFRA verification: 65 dams / 59 barriers / 15 named, with Stave Falls (26 m), Alouette (22.5 m), Ruskin (59.4 m), Coquitlam (30.5 m), Northwest Stave + Upper Stave variants all present at the same `(blue_line_key, downstream_route_measure)` as `bcfishpass.dams` within fp precision.
+- Per-species methodology — "should some dam classes block which species in the default bundle?" — is intentionally out of scope; tracked at [#83](https://github.com/NewGraphEnvironment/link/issues/83).
+
 # link 0.23.0
 
 Closes [#96](https://github.com/NewGraphEnvironment/link/issues/96). `falls` added as a segmentation break source — the FWA stream network is now broken at every fall position. Previously the `<schema>.falls` table was loaded and used for access gating + obs/habitat lift but **not** for segmentation, so close-paired falls (no other break source between them) produced segments that spanned the second fall and incorrectly classified its upper portion as accessible.

--- a/R/lnk_pipeline_prepare.R
+++ b/R/lnk_pipeline_prepare.R
@@ -36,6 +36,9 @@
 #'   - `<schema>.gradient_barriers_minimal` (union of minimal positions)
 #'   - `fresh.streams` (base segments — not namespaced by AOI; fresh
 #'     owns its output schema)
+#'   - `<schema>.dams` (only when `conn_tunnel` is supplied) — pulled
+#'     from `bcfishpass.dams` filtered to AOI. Parallel reporting layer;
+#'     NOT consumed by habitat classification.
 #'
 #' @param conn A [DBI::DBIConnection-class] object.
 #' @param aoi Character. Watershed group code today; extends to ltree
@@ -50,6 +53,13 @@
 #'   used for building barrier overrides. Default
 #'   `"bcfishobs.observations"` — matches bcfishpass's reference data
 #'   on both M4 and M1 fwapg instances (see `rtj/docs/distributed-fwapg.md`).
+#' @param conn_tunnel A [DBI::DBIConnection-class] object pointed at
+#'   `db_newgraph` (the tunnel-DB carrying bcfp's pre-built tables).
+#'   Optional. When supplied, `<schema>.dams` is populated from
+#'   `bcfishpass.dams` filtered to the AOI — parallel reporting layer
+#'   for downstream consumers, NOT consumed by habitat classification.
+#'   When `NULL`, any existing `<schema>.dams` is dropped and the dams
+#'   step is a no-op.
 #'
 #' @return `conn` invisibly, for pipe chaining.
 #'
@@ -74,7 +84,8 @@
 #' DBI::dbDisconnect(conn)
 #' }
 lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
-                                 observations = "bcfishobs.observations") {
+                                 observations = "bcfishobs.observations",
+                                 conn_tunnel = NULL) {
   .lnk_validate_identifier(schema, "schema")
   .lnk_validate_identifier(observations, "observations table")
   if (!is.character(aoi) || length(aoi) != 1L || !nzchar(aoi)) {
@@ -97,6 +108,7 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
   .lnk_pipeline_prep_overrides(conn, loaded, schema)
   .lnk_pipeline_prep_minimal(conn, aoi, schema)
   .lnk_pipeline_prep_network(conn, aoi, schema)
+  .lnk_pipeline_prep_dams(conn, conn_tunnel, aoi, schema, loaded)
 
   invisible(conn)
 }
@@ -566,6 +578,198 @@ lnk_pipeline_prepare <- function(conn, aoi, cfg, loaded, schema,
      FROM numbered WHERE s.ctid = numbered.ctid")
   .lnk_db_execute(conn,
     "CREATE UNIQUE INDEX ON fresh.streams (id_segment)")
+
+  invisible(NULL)
+}
+
+
+#' Materialize <schema>.dams from CABD source + 4 edit CSVs
+#'
+#' Parallel-to-bcfp design: link consumes CABD upstream the same way
+#' bcfp does (`cabd.dams` source + the 4 edit CSVs `cabd_exclusions`,
+#' `cabd_blkey_xref`, `cabd_passability_status_updates`,
+#' `cabd_additions`), applies its own snap + transforms, and writes
+#' the result to a local `<schema>.dams` table. Mirrors
+#' `bcfp/model/01_access/sql/load_dams.sql` line-for-line at the
+#' SQL level.
+#'
+#' The dams table is NOT used by link's habitat classification —
+#' bcfp's per-species access + habitat_linear SQL are dam-blind, and
+#' link mirrors that. The data lives here for downstream consumers
+#' (memo authors, fish-passage planners, dam-impact analyses) who
+#' compose dam awareness with the habitat output.
+#'
+#' Source paths considered:
+#'   - tunnel `cabd.*` on db_newgraph (current default — `conn_tunnel`)
+#'   - public CABD download (future, link#104)
+#'   - cabd in s3 fwapg dump (future rtj follow-up)
+#' All three produce identical local `<schema>.dams`; only the source
+#' connection differs.
+#'
+#' The 4 edit CSVs (`cabd_exclusions`, `cabd_blkey_xref`,
+#' `cabd_passability_status_updates`, `cabd_additions`) ship in the
+#' bundle overrides directory and arrive via `lnk_load_overrides()`.
+#' Each is filtered to the AOI's `feature_type='dams'` rows where
+#' applicable (only `cabd_additions` carries the `feature_type` column).
+#'
+#' Short-circuits when `conn_tunnel` is NULL — drops any existing
+#' `<schema>.dams` and returns. Zero-cost opt-out.
+#' @noRd
+.lnk_pipeline_prep_dams <- function(conn, conn_tunnel, aoi, schema, loaded) {
+  if (is.null(conn_tunnel)) {
+    .lnk_db_execute(conn, sprintf(
+      "DROP TABLE IF EXISTS %s.dams", schema))
+    return(invisible(NULL))
+  }
+
+  # 1. Stage the 4 edit CSVs into <schema> from `loaded`. All four are
+  #    required — the load_dams.sql replication CTE references columns
+  #    from each (`blk.blue_line_key`, `u.passability_status_code`,
+  #    `a.feature_type`, etc.). Both shipped bundles declare them; a
+  #    custom config that opts in to dam reporting must declare them too.
+  cabd_keys <- c("cabd_exclusions", "cabd_blkey_xref",
+                 "cabd_passability_status_updates", "cabd_additions")
+  missing <- cabd_keys[!cabd_keys %in% names(loaded)]
+  if (length(missing) > 0) {
+    stop("conn_tunnel set but `loaded` is missing required CABD edit ",
+         "CSV(s): ", paste(missing, collapse = ", "),
+         ". Declare them in cfg$files or pass conn_tunnel = NULL to ",
+         "skip dam ingestion.", call. = FALSE)
+  }
+  for (key in cabd_keys) {
+    .lnk_db_execute(conn, sprintf(
+      "DROP TABLE IF EXISTS %s.%s", schema, key))
+    DBI::dbWriteTable(conn, DBI::Id(schema = schema, table = key),
+      loaded[[key]], overwrite = TRUE)
+  }
+
+  # 2. Pull `cabd.dams` from tunnel (raw upstream — NOT bcfp's processed output).
+  cabd_dams <- DBI::dbGetQuery(conn_tunnel,
+    "SELECT cabd_id, dam_name_en, height_m, owner, dam_use,
+            operating_status, passability_status_code,
+            ST_AsEWKB(ST_Transform(geom, 3005)) AS geom_ewkb
+     FROM cabd.dams")
+
+  # Stage cabd.dams locally so the lateral snap can run against
+  # local fwa_stream_networks_sp without round-tripping the network.
+  .lnk_db_execute(conn, sprintf(
+    "DROP TABLE IF EXISTS %s.cabd_dams_raw", schema))
+  DBI::dbWriteTable(conn,
+    DBI::Id(schema = schema, table = "cabd_dams_raw"),
+    cabd_dams, overwrite = TRUE)
+
+  # 3. Apply the load_dams.sql logic locally:
+  #    - drop excluded cabd_ids
+  #    - LEFT JOIN blkey_xref to override blue_line_key when set
+  #    - lateral snap to fwa_stream_networks_sp within 65 m
+  #    - LEFT JOIN passability_status_updates for status override
+  #    - UNION ALL with cabd_additions where feature_type='dams' (US placeholders)
+  .lnk_db_execute(conn, sprintf(
+    "DROP TABLE IF EXISTS %1$s.dams", schema))
+  .lnk_db_execute(conn, sprintf(
+    "CREATE TABLE %1$s.dams AS
+     WITH cabd AS (
+       SELECT d.cabd_id::text  AS dam_id,
+              blk.blue_line_key,
+              ST_GeomFromEWKB(d.geom_ewkb) AS geom,
+              d.dam_name_en, d.height_m, d.owner, d.dam_use,
+              d.operating_status,
+              COALESCE(u.passability_status_code,
+                       d.passability_status_code) AS passability_status_code
+       FROM %1$s.cabd_dams_raw d
+       LEFT OUTER JOIN %1$s.cabd_exclusions x ON d.cabd_id = x.cabd_id
+       LEFT OUTER JOIN %1$s.cabd_blkey_xref blk ON d.cabd_id = blk.cabd_id
+       LEFT OUTER JOIN %1$s.cabd_passability_status_updates u
+         ON d.cabd_id = u.cabd_id
+       WHERE x.cabd_id IS NULL
+     ),
+     matched AS (
+       SELECT DISTINCT ON (c.dam_id)
+              c.dam_id,
+              str.linear_feature_id,
+              str.blue_line_key,
+              str.wscode_ltree,
+              str.localcode_ltree,
+              str.watershed_group_code,
+              ST_Distance(str.geom, c.geom) AS distance_to_stream,
+              ST_InterpolatePoint(str.geom, c.geom) AS downstream_route_measure,
+              c.dam_name_en, c.height_m, c.owner, c.dam_use,
+              c.operating_status, c.passability_status_code,
+              str.geom AS line_geom
+       FROM cabd c
+       CROSS JOIN LATERAL (
+         SELECT linear_feature_id, blue_line_key, wscode_ltree, localcode_ltree,
+                watershed_group_code, geom
+         FROM whse_basemapping.fwa_stream_networks_sp str
+         WHERE str.localcode_ltree IS NOT NULL
+           AND NOT str.wscode_ltree <@ '999'::ltree
+           AND (
+             (c.blue_line_key IS NULL)
+             OR (c.blue_line_key = str.blue_line_key)
+           )
+         ORDER BY str.geom <-> c.geom
+         LIMIT 1
+       ) str
+       WHERE ST_Distance(str.geom, c.geom) <= 65
+       ORDER BY c.dam_id, ST_Distance(str.geom, c.geom), str.linear_feature_id
+     ),
+     placed AS (
+       SELECT m.dam_id,
+              m.linear_feature_id,
+              m.blue_line_key,
+              m.downstream_route_measure,
+              m.wscode_ltree,
+              m.localcode_ltree,
+              m.distance_to_stream,
+              m.watershed_group_code,
+              m.dam_name_en, m.height_m, m.owner, m.dam_use,
+              m.operating_status, m.passability_status_code,
+              ((ST_Dump(ST_Force2D(
+                ST_LocateAlong(m.line_geom, m.downstream_route_measure)
+              ))).geom)::geometry(Point, 3005) AS geom
+       FROM matched m
+     ),
+     usa AS (
+       SELECT (row_number() OVER () + 1200000000)::text AS dam_id,
+              s.linear_feature_id,
+              a.blue_line_key,
+              a.downstream_route_measure,
+              s.wscode_ltree,
+              s.localcode_ltree,
+              0::double precision AS distance_to_stream,
+              s.watershed_group_code,
+              a.name AS dam_name_en,
+              NULL::double precision AS height_m,
+              NULL::text AS owner,
+              NULL::text AS dam_use,
+              NULL::text AS operating_status,
+              NULL::integer AS passability_status_code,
+              ((ST_Dump(ST_Force2D(
+                ST_LocateAlong(s.geom, a.downstream_route_measure)
+              ))).geom)::geometry(Point, 3005) AS geom
+       FROM %1$s.cabd_additions a
+       INNER JOIN whse_basemapping.fwa_stream_networks_sp s
+         ON a.blue_line_key = s.blue_line_key
+        AND ROUND(a.downstream_route_measure::numeric)
+              >= ROUND(s.downstream_route_measure::numeric)
+        AND ROUND(a.downstream_route_measure::numeric)
+              <  ROUND(s.upstream_route_measure::numeric)
+       WHERE a.feature_type = 'dams'
+     )
+     SELECT * FROM placed
+     UNION ALL
+     SELECT * FROM usa;",
+    schema))
+
+  # 4. Filter the local <schema>.dams to the AOI (per-WSG locality).
+  .lnk_db_execute(conn, sprintf(
+    "DELETE FROM %s.dams WHERE watershed_group_code <> %s",
+    schema, .lnk_quote_literal(aoi)))
+
+  # 5. Cleanup the cabd_dams_raw stage; keep the 4 edit-CSV tables for
+  #    debugging visibility (they're small).
+  .lnk_db_execute(conn, sprintf(
+    "DROP TABLE %s.cabd_dams_raw", schema))
 
   invisible(NULL)
 }

--- a/data-raw/compare_bcfishpass_wsg.R
+++ b/data-raw/compare_bcfishpass_wsg.R
@@ -23,11 +23,12 @@
 # rearing_km includes lake + wetland centerline length today — see
 # research/default_vs_bcfishpass.md for the decision + revisit note.
 
-compare_bcfishpass_wsg <- function(wsg, config) {
+compare_bcfishpass_wsg <- function(wsg, config, dams = TRUE) {
   stopifnot(
     is.character(wsg), length(wsg) == 1L, nzchar(wsg),
     grepl("^[A-Z]{3,5}$", wsg),
-    inherits(config, "lnk_config")
+    inherits(config, "lnk_config"),
+    is.logical(dams), length(dams) == 1L
   )
   schema <- paste0("working_", tolower(wsg))
 
@@ -70,7 +71,8 @@ compare_bcfishpass_wsg <- function(wsg, config) {
   link::lnk_pipeline_load(conn, aoi = wsg, cfg = config,
     loaded = loaded, schema = schema)
   link::lnk_pipeline_prepare(conn, aoi = wsg, cfg = config,
-    loaded = loaded, schema = schema)
+    loaded = loaded, schema = schema,
+    conn_tunnel = if (dams) conn_ref else NULL)
   link::lnk_pipeline_break(conn, aoi = wsg, cfg = config,
     loaded = loaded, schema = schema)
   link::lnk_pipeline_classify(conn, aoi = wsg, cfg = config,

--- a/data-raw/logs/20260502_05_preflight_lfra_dams.txt
+++ b/data-raw/logs/20260502_05_preflight_lfra_dams.txt
@@ -1,0 +1,139 @@
+## Run stamp — bcfishpass
+
+- AOI: `LFRA`
+- Started: 2026-05-02 19:46:36 PDT
+
+### Software
+- link: 0.23.0 (sha NA)
+- fresh: 0.27.5 (sha NA)
+- R: R version 4.5.2 (2025-10-31)
+
+### Database snapshot
+- bcfishobs.observations: 372,420
+- whse_basemapping.fwa_stream_networks_sp: 4,907,441
+
+### Config provenance (12 files, 3 byte / 1 shape drifted)
+
+| file | byte drift | shape drift |
+|---|---|---|
+| `rules.yaml` | **yes** | no |
+| `dimensions.csv` | **yes** | **yes** |
+| `parameters_fresh.csv` | **yes** | no |
+| `overrides/user_habitat_classification.csv` | no | no |
+| `overrides/observation_exclusions.csv` | no | no |
+| `overrides/wsg_species_presence.csv` | no | no |
+| `overrides/user_modelled_crossing_fixes.csv` | no | no |
+| `overrides/user_pscis_barrier_status.csv` | no | no |
+| `overrides/pscis_modelledcrossings_streams_xref.csv` | no | no |
+| `overrides/user_barriers_definite.csv` | no | no |
+| `overrides/user_barriers_definite_control.csv` | no | no |
+| `overrides/user_crossings_misc.csv` | no | no |
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "observations" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barriers_subsurfaceflow" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "cabd_exclusions" does not exist, skipping
+
+NOTICE:  table "cabd_blkey_xref" does not exist, skipping
+
+NOTICE:  table "cabd_passability_status_updates" does not exist, skipping
+
+NOTICE:  table "cabd_additions" does not exist, skipping
+
+NOTICE:  table "cabd_dams_raw" does not exist, skipping
+
+NOTICE:  table "dams" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_cm" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+Warning message:
+In read.table(file = file, header = header, sep = sep, quote = quote,  :
+  incomplete final line found by readTableHeader on '/Users/airvine/Library/R/arm64/4.5/library/link/extdata/configs/bcfishpass/overrides/cabd_blkey_xref.csv'
+
+--- LFRA BT result ---
+# A tibble: 7 × 7
+  wsg   species habitat_type          unit  link_value bcfishpass_value diff_pct
+  <chr> <chr>   <chr>                 <chr>      <dbl>            <dbl>    <dbl>
+1 LFRA  BT      spawning              km         1276.            1276.      0.1
+2 LFRA  BT      rearing               km         1790.            1800.     -0.6
+3 LFRA  BT      lake_rearing          ha            0            15170.   -100  
+4 LFRA  BT      wetland_rearing       ha            0             3388.   -100  
+5 LFRA  BT      rearing_stream        km         1092.            1103.     -1  
+6 LFRA  BT      rearing_lake_centerl… km            0                0      NA  
+7 LFRA  BT      rearing_wetland_cent… km            0                0      NA  

--- a/data-raw/logs/20260502_07_dams_isolation_harr.txt
+++ b/data-raw/logs/20260502_07_dams_isolation_harr.txt
@@ -1,0 +1,254 @@
+=== HARR with dams OFF (conn_tunnel = NULL) ===
+## Run stamp — bcfishpass
+
+- AOI: `HARR`
+- Started: 2026-05-02 20:07:39 PDT
+
+### Software
+- link: 0.23.0 (sha NA)
+- fresh: 0.27.5 (sha NA)
+- R: R version 4.5.2 (2025-10-31)
+
+### Database snapshot
+- bcfishobs.observations: 372,420
+- whse_basemapping.fwa_stream_networks_sp: 4,907,441
+
+### Config provenance (12 files, 3 byte / 1 shape drifted)
+
+| file | byte drift | shape drift |
+|---|---|---|
+| `rules.yaml` | **yes** | no |
+| `dimensions.csv` | **yes** | **yes** |
+| `parameters_fresh.csv` | **yes** | no |
+| `overrides/user_habitat_classification.csv` | no | no |
+| `overrides/observation_exclusions.csv` | no | no |
+| `overrides/wsg_species_presence.csv` | no | no |
+| `overrides/user_modelled_crossing_fixes.csv` | no | no |
+| `overrides/user_pscis_barrier_status.csv` | no | no |
+| `overrides/pscis_modelledcrossings_streams_xref.csv` | no | no |
+| `overrides/user_barriers_definite.csv` | no | no |
+| `overrides/user_barriers_definite_control.csv` | no | no |
+| `overrides/user_crossings_misc.csv` | no | no |
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "observations" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barriers_subsurfaceflow" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "dams" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_cm" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+Warning message:
+In read.table(file = file, header = header, sep = sep, quote = quote,  :
+  incomplete final line found by readTableHeader on '/Users/airvine/Library/R/arm64/4.5/library/link/extdata/configs/bcfishpass/overrides/cabd_blkey_xref.csv'
+(87.7s)
+
+=== HARR with dams ON (conn_tunnel = conn_ref) ===
+## Run stamp — bcfishpass
+
+- AOI: `HARR`
+- Started: 2026-05-02 20:09:07 PDT
+
+### Software
+- link: 0.23.0 (sha NA)
+- fresh: 0.27.5 (sha NA)
+- R: R version 4.5.2 (2025-10-31)
+
+### Database snapshot
+- bcfishobs.observations: 372,420
+- whse_basemapping.fwa_stream_networks_sp: 4,907,441
+
+### Config provenance (12 files, 3 byte / 1 shape drifted)
+
+| file | byte drift | shape drift |
+|---|---|---|
+| `rules.yaml` | **yes** | no |
+| `dimensions.csv` | **yes** | **yes** |
+| `parameters_fresh.csv` | **yes** | no |
+| `overrides/user_habitat_classification.csv` | no | no |
+| `overrides/observation_exclusions.csv` | no | no |
+| `overrides/wsg_species_presence.csv` | no | no |
+| `overrides/user_modelled_crossing_fixes.csv` | no | no |
+| `overrides/user_pscis_barrier_status.csv` | no | no |
+| `overrides/pscis_modelledcrossings_streams_xref.csv` | no | no |
+| `overrides/user_barriers_definite.csv` | no | no |
+| `overrides/user_barriers_definite_control.csv` | no | no |
+| `overrides/user_crossings_misc.csv` | no | no |
+NOTICE:  schema "fresh" already exists, skipping
+
+NOTICE:  table "barriers_definite" does not exist, skipping
+
+NOTICE:  table "observations" does not exist, skipping
+
+NOTICE:  table "streams_blk" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_raw" does not exist, skipping
+
+NOTICE:  table "natural_barriers" does not exist, skipping
+
+NOTICE:  table "barriers_subsurfaceflow" does not exist, skipping
+
+NOTICE:  table "barrier_overrides" does not exist, skipping
+
+NOTICE:  table "barriers_bt" does not exist, skipping
+
+NOTICE:  table "barriers_bt_min" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk" does not exist, skipping
+
+NOTICE:  table "barriers_ch_cm_co_pk_sk_min" does not exist, skipping
+
+NOTICE:  table "barriers_st" does not exist, skipping
+
+NOTICE:  table "barriers_st_min" does not exist, skipping
+
+NOTICE:  table "barriers_wct" does not exist, skipping
+
+NOTICE:  table "barriers_wct_min" does not exist, skipping
+
+NOTICE:  table "gradient_barriers_minimal" does not exist, skipping
+
+NOTICE:  table "streams" does not exist, skipping
+
+NOTICE:  table "streams_habitat" does not exist, skipping
+
+NOTICE:  table "cabd_exclusions" does not exist, skipping
+
+NOTICE:  table "cabd_blkey_xref" does not exist, skipping
+
+NOTICE:  table "cabd_passability_status_updates" does not exist, skipping
+
+NOTICE:  table "cabd_additions" does not exist, skipping
+
+NOTICE:  table "cabd_dams_raw" does not exist, skipping
+
+NOTICE:  table "dams" does not exist, skipping
+
+NOTICE:  table "observations_breaks" does not exist, skipping
+
+NOTICE:  table "habitat_endpoints" does not exist, skipping
+
+NOTICE:  table "crossings_breaks" does not exist, skipping
+
+NOTICE:  table "streams_breaks" does not exist, skipping
+
+NOTICE:  relation "streams_id_segment_idx" already exists, skipping
+
+NOTICE:  table "streams_acc_015" does not exist, skipping
+
+NOTICE:  table "streams_acc_02" does not exist, skipping
+
+NOTICE:  table "streams_acc_025" does not exist, skipping
+
+NOTICE:  table "streams_acc_025_ovr_bt" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_ch" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_cm" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_co" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_pk" does not exist, skipping
+
+NOTICE:  table "streams_acc_015_ovr_sk" does not exist, skipping
+
+NOTICE:  table "streams_acc_02_ovr_st" does not exist, skipping
+
+NOTICE:  table "frs_clusters_bt" does not exist, skipping
+
+NOTICE:  table "frs_clusters_ch" does not exist, skipping
+
+NOTICE:  table "frs_clusters_co" does not exist, skipping
+
+NOTICE:  table "frs_clusters_sk" does not exist, skipping
+
+NOTICE:  table "frs_qual_spawn_sk" does not exist, skipping
+
+NOTICE:  table "frs_trace_lfid_sk" does not exist, skipping
+
+NOTICE:  table "frs_clusters_st" does not exist, skipping
+
+Warning message:
+In read.table(file = file, header = header, sep = sep, quote = quote,  :
+  incomplete final line found by readTableHeader on '/Users/airvine/Library/R/arm64/4.5/library/link/extdata/configs/bcfishpass/overrides/cabd_blkey_xref.csv'
+(88.4s)
+
+byte-identical=TRUE
+near-equal(1e-12)=TRUE
+
+VERDICT: PASS — #103 has zero effect on rollup. Dams data is parallel.

--- a/data-raw/regress_dams_isolation.R
+++ b/data-raw/regress_dams_isolation.R
@@ -1,0 +1,63 @@
+#!/usr/bin/env Rscript
+# #103 isolation test — run HARR with dams ON vs OFF on current HEAD,
+# diff rollups. Goal: prove prep_dams has zero effect on habitat
+# classification output (architectural parallel-data invariant).
+#
+# Pre-#103 baseline contamination: the cached `comparison_*` targets
+# were last built May 1 06:48 — before #96 (falls in break_order),
+# #97 (frs_order_child), and 31b9 (default-bundle SK methodology)
+# shipped. So the 4-WSG regress vs that cache surfaces ~1km segmentation
+# drift across many rows that has nothing to do with #103.
+
+suppressPackageStartupMessages({
+  library(dplyr)
+})
+
+setwd("/Users/airvine/Projects/repo/link/data-raw")
+source("compare_bcfishpass_wsg.R")
+
+cfg <- link::lnk_config("bcfishpass")
+
+cat("=== HARR with dams OFF (conn_tunnel = NULL) ===\n")
+t0 <- Sys.time()
+off <- compare_bcfishpass_wsg(wsg = "HARR", config = cfg, dams = FALSE)
+cat(sprintf("(%.1fs)\n\n", as.numeric(Sys.time() - t0, units = "secs")))
+
+cat("=== HARR with dams ON (conn_tunnel = conn_ref) ===\n")
+t0 <- Sys.time()
+on  <- compare_bcfishpass_wsg(wsg = "HARR", config = cfg, dams = TRUE)
+cat(sprintf("(%.1fs)\n\n", as.numeric(Sys.time() - t0, units = "secs")))
+
+key <- c("wsg", "species", "habitat_type", "unit")
+off_s <- dplyr::arrange(off, dplyr::across(dplyr::all_of(key)))
+on_s  <- dplyr::arrange(on,  dplyr::across(dplyr::all_of(key)))
+
+byte_identical <- isTRUE(all.equal(off_s, on_s,
+                                   tolerance = 0,
+                                   check.attributes = FALSE))
+near_equal <- isTRUE(all.equal(off_s, on_s,
+                               tolerance = 1e-12,
+                               check.attributes = FALSE))
+
+cat(sprintf("byte-identical=%s\n", byte_identical))
+cat(sprintf("near-equal(1e-12)=%s\n", near_equal))
+
+if (!near_equal) {
+  cat("\n--- diff rows ---\n")
+  diffs <- off_s |>
+    dplyr::full_join(on_s, by = key, suffix = c("_off", "_on")) |>
+    dplyr::mutate(
+      eq = (link_value_off == link_value_on |
+              (is.na(link_value_off) & is.na(link_value_on))) &
+           (bcfishpass_value_off == bcfishpass_value_on |
+              (is.na(bcfishpass_value_off) & is.na(bcfishpass_value_on)))
+    ) |>
+    dplyr::filter(!eq) |>
+    dplyr::select(dplyr::all_of(key), link_value_off, link_value_on,
+                  bcfishpass_value_off, bcfishpass_value_on)
+  print(diffs, n = 50)
+}
+
+cat(sprintf("\nVERDICT: %s\n",
+  if (near_equal) "PASS — #103 has zero effect on rollup. Dams data is parallel."
+  else            "FAIL — dams data is leaking into habitat classification."))

--- a/inst/extdata/configs/bcfishpass/config.yaml
+++ b/inst/extdata/configs/bcfishpass/config.yaml
@@ -41,6 +41,18 @@ files:
   user_crossings_misc:
     source: bcfp
     path: overrides/user_crossings_misc.csv
+  cabd_exclusions:
+    source: bcfp
+    path: overrides/cabd_exclusions.csv
+  cabd_blkey_xref:
+    source: bcfp
+    path: overrides/cabd_blkey_xref.csv
+  cabd_passability_status_updates:
+    source: bcfp
+    path: overrides/cabd_passability_status_updates.csv
+  cabd_additions:
+    source: bcfp
+    path: overrides/cabd_additions.csv
 
 extends: ~
 

--- a/inst/extdata/configs/bcfishpass/overrides/cabd_passability_status_updates.csv
+++ b/inst/extdata/configs/bcfishpass/overrides/cabd_passability_status_updates.csv
@@ -10,4 +10,4 @@ e8f03f80-9bbf-4f5b-8267-a6ed55dff18e,2,SN,2025-12-22,CWF TMK,Salmon House Falls 
 ce90af3f-fdf9-4bdc-8535-9412825726c9,2,SN,2025-12-23,https://a100.gov.bc.ca/pub/acat/documents/r40929/05.AS.04_Passage_1389359897936_9359222675.pdf,report indicates passability is species/flow dependent
 77cc978b-a595-4227-9641-05e2d875b3ff,1,SN,2023-08-11,New Graph Environment,Historic falls restricting salmon from Kootenay Lake and upstream
 e59c47b5-db49-4929-838a-06bbf1e5d8de,2,SN,2026-01-07,https://www.newgraphenvironment.com/fish_passage_skeena_2024_reporting/buck-falls.html#buck-falls,see report
-75e563a7-0ec8-47e3-bd20-13c96d0e9eda ,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,
+75e563a7-0ec8-47e3-bd20-13c96d0e9eda,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,

--- a/inst/extdata/configs/default/config.yaml
+++ b/inst/extdata/configs/default/config.yaml
@@ -47,6 +47,18 @@ files:
   user_crossings_misc:
     source: bcfp
     path: overrides/user_crossings_misc.csv
+  cabd_exclusions:
+    source: bcfp
+    path: overrides/cabd_exclusions.csv
+  cabd_blkey_xref:
+    source: bcfp
+    path: overrides/cabd_blkey_xref.csv
+  cabd_passability_status_updates:
+    source: bcfp
+    path: overrides/cabd_passability_status_updates.csv
+  cabd_additions:
+    source: bcfp
+    path: overrides/cabd_additions.csv
 
 extends: ~
 

--- a/inst/extdata/configs/default/overrides/cabd_passability_status_updates.csv
+++ b/inst/extdata/configs/default/overrides/cabd_passability_status_updates.csv
@@ -10,4 +10,4 @@ e8f03f80-9bbf-4f5b-8267-a6ed55dff18e,2,SN,2025-12-22,CWF TMK,Salmon House Falls 
 ce90af3f-fdf9-4bdc-8535-9412825726c9,2,SN,2025-12-23,https://a100.gov.bc.ca/pub/acat/documents/r40929/05.AS.04_Passage_1389359897936_9359222675.pdf,report indicates passability is species/flow dependent
 77cc978b-a595-4227-9641-05e2d875b3ff,1,SN,2023-08-11,New Graph Environment,Historic falls restricting salmon from Kootenay Lake and upstream
 e59c47b5-db49-4929-838a-06bbf1e5d8de,2,SN,2026-01-07,https://www.newgraphenvironment.com/fish_passage_skeena_2024_reporting/buck-falls.html#buck-falls,see report
-75e563a7-0ec8-47e3-bd20-13c96d0e9eda ,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,
+75e563a7-0ec8-47e3-bd20-13c96d0e9eda,3,MC,2026-04-10,SFC tracking table QA/QC. Biologist reviewed,

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,68 @@
+# Findings — Ingest CABD dams as parallel reporting dimension (#103)
+
+## Issue context
+
+link does not ingest dam locations from CABD. bcfp pulls them from `cabd.dams` + applies four edit CSVs (`cabd_exclusions`, `cabd_blkey_xref`, `cabd_passability_status_updates`, `cabd_additions` filtered to `feature_type='dams'`).
+
+**Important framing:** bcfp's per-species access models AND habitat_linear models are **dam-blind** — verified across all 5 `model_access_*.sql` and 8 `load_habitat_linear_*.sql` files: zero references to `barriers_dams`, `barriers_anthropogenic`, or `barriers_pscis`. Dams in bcfp live as a **parallel reporting dimension** (the `bcfishpass.dams` table) that downstream consumers compose with habitat output for reports, WCRP tracking, and dam-impact analyses.
+
+This issue is **not a habitat-parity gap** — fixing it will not close any rollup deltas. It's a **reporting-data gap**: real-world habitat above Stave / Alouette / Campbell / Strathcona dams is materially blocked, but bcfp's habitat output is dam-blind and link's would be too.
+
+## bcfp's load_dams.sql, mapped
+
+`bcfp/model/01_access/sql/load_dams.sql` — same shape as load_falls.sql, four CABD-edit CSVs:
+
+```sql
+-- 1. Pull CABD dams, exclude false positives, snap blkey via xref
+with cabd as (
+  select d.cabd_id as dam_id, blk.blue_line_key, st_transform(d.geom, 3005) as geom
+  from cabd.dams d
+  left outer join bcfishpass.cabd_exclusions x on d.cabd_id = x.cabd_id
+  left outer join bcfishpass.cabd_blkey_xref blk on d.cabd_id = blk.cabd_id
+  where x.cabd_id is null
+),
+
+-- 2. Snap to nearest stream segment within 65 m
+matched as ( ...lateral join on fwa_stream_networks_sp... ),
+
+-- 3. Apply passability override + carry CABD attributes (height_m, owner, dam_use, operating_status)
+cabd_pts as (
+  select n.*, cabd.dam_name_en, cabd.height_m, cabd.owner, cabd.dam_use, cabd.operating_status,
+         coalesce(u.passability_status_code, cabd.passability_status_code) as passability_status_code
+  from matched n
+  inner join cabd.dams cabd on n.dam_id = cabd.cabd_id
+  left outer join bcfishpass.cabd_passability_status_updates u on n.dam_id = u.cabd_id
+),
+
+-- 4. US dam placeholders (Grand Coulee, Ross) — additions where feature_type='dams'
+usa as ( ... select from bcfishpass.cabd_additions where feature_type = 'dams' ... )
+
+insert into bcfishpass.dams (...) select * from cabd_pts union all select ... from usa;
+```
+
+## What's in `cabd_additions.csv` for dams (currently 4 rows)
+
+All four are **US-side dam placeholders** for trans-border flows — Grand Coulee Dam x4 entries on different blkeys (different streams flowing into the Columbia → Grand Coulee impoundment), and Ross Dam x1. **No domestic-BC dam additions** in the current CSV. The CABD source itself covers all the BC dams; additions exists to handle CABD's BC-only geographic scope.
+
+## CABD edit CSVs — current row counts
+
+The same 4 CSVs that link#102 (closed) was going to wire for falls. They apply to dams too — they key on `cabd_id` which spans both `cabd.waterfalls` and `cabd.dams`.
+
+| CSV | Function | Rows | Dams relevance |
+|---|---|---|---|
+| `cabd_exclusions.csv` | Drop specific cabd_ids | 12 | Some dams likely |
+| `cabd_passability_status_updates.csv` | Override `passability_status_code` | 12 | Some dams likely |
+| `cabd_blkey_xref.csv` | Override blkey snap | 1 | Tiny |
+| `cabd_additions.csv` (dams rows) | Add features missing from CABD | **4** | US placeholders only |
+
+All four are actively wired in bcfp's `01_access` pipeline. None deprecated.
+
+## Why we didn't find this gap on the falls side
+
+link#102 detective work showed fresh's static `falls.csv` was already extracted from CABD at the barrier-truth subset level — fresh's per-WSG barrier counts matched bcfp's `bcfishpass.falls WHERE barrier_ind=true` across all 187 BC WSGs. fresh `falls.csv` row-level identical to bcfp on CAMB.
+
+There's no equivalent shortcut for dams. There's no `dams.csv` shipped in fresh; link doesn't see dam features at all today. Has to be wired from CABD.
+
+## Verification expectations
+
+For verification (Phase 6), the load-bearing test is "habitat output byte-identical to pre-fix baseline post-data-ingestion." If the rollup shifts after wiring this in, the dams data is leaking somewhere it shouldn't (into `streams_breaks`, into `barrier_overrides`, into per-species classification). The wire-up has to be carefully gated to the parallel data layer only.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -26,6 +26,24 @@
 
 **Decision:** source via tunnel-DB join (consistent with link#102 resolution). cypher / M4 / M1 all have tunnel access per rtj#82.
 
+### Phase 2 → 7 implementation
+
+- Pivoted Phase 2 design: replicate `load_dams.sql` against `cabd.dams` source rather than consume bcfp's processed `bcfishpass.dams`. Architectural parallelism — link sibling-of-bcfp under CABD, not downstream of bcfp.
+- `.lnk_pipeline_prep_dams(conn, conn_tunnel, aoi, schema, loaded)` runs as final phase in `lnk_pipeline_prepare`. NULL `conn_tunnel` short-circuits to drop. Wired through `compare_bcfishpass_wsg` (default behavior unchanged).
+- 4 CABD edit CSVs redistributed to both bundles' `overrides/`, declared in `config.yaml::files`, ingested via `lnk_load_overrides()`.
+- Tests: 2 new tests in `test-lnk_pipeline_prepare.R` (NULL short-circuit + load_dams.sql SQL shape), 78 PASS / 0 FAIL.
+
+### Verification (Phase 6) — clean #103-only test
+
+- **LFRA preflight** (`logs/20260502_05_preflight_lfra_dams.txt`): 65 dams / 59 barriers / 15 named in `working_lfra.dams`, all 15 named (Stave Falls, Alouette, Ruskin, Coquitlam, Northwest Stave + Upper Stave variants, Cariboo, Sam Hill, Sparrow, Sharpe, Lamont, Cannell, Alam) match `bcfishpass.dams` on tunnel byte-for-byte within fp precision.
+- **HARR dams-ON / dams-OFF** (`logs/20260502_07_dams_isolation_harr.txt`): same HEAD, same code, only `conn_tunnel` differs → rollup byte-identical to fp precision. Proves architectural isolation: prep_dams cannot affect habitat classification.
+- The 4-WSG regression vs cached baseline (`logs/20260502_06_regress_4wsg_dams_post.txt`) surfaced -1km drift across many rows but the cache was from May 1 06:48 — pre-#96/#97/31b9. Drift was unrelated to #103. The HARR ON/OFF test is the clean replacement.
+
+### Phase 7 docs + version
+
+- `research/bcfishpass_comparison.md` § "Dams design — parallel reporting dimension (link#103)" replaces the early fresh-crossings framing with the landed implementation + verification + out-of-scope list.
+- `NEWS.md` 0.24.0 entry; `DESCRIPTION` 0.23.0 → 0.24.0.
+
 ### Next
 
-Phase 2 — implement `lnk_dams_load(conn, schema, ...)` mirroring bcfp's `load_dams.sql`. Output `<schema>.dams` with `(dam_name_en, height_m, owner, dam_use, operating_status, passability_status_code, geom)` column set. Critical: must NOT enter `streams_breaks` or `barrier_overrides` — verified via byte-identical regression in Phase 6.
+`/code-check` on staged diff → atomic commits with PWF checkboxes → PR with `Fixes #103`.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -5,4 +5,27 @@
 - Created branch `103-ingest-cabd-dams` off main
 - Scaffolded PWF baseline from issue body — 7 phases (detective → source pull → edit CSVs → pipeline wiring → tests → byte-identical verification → research doc + ship)
 - Sibling work today: link#102 (CABD waterfalls) closed as not-a-bug after detective work showed fresh's static falls.csv was already complete; link#104 (CABD download path) closed as obsolete with #102. The same 4 CABD edit CSVs that #102 was going to redistribute now come in via this issue.
-- Next: read `task_plan.md` Phase 1 (detective work). Concrete first command: query `cabd.dams` and `bcfishpass.dams` over the tunnel for total count, named-dam spot check (Stave / Alouette / Strathcona / John Hart / Coquitlam), and edit-application audit (how many bcfp `dams` rows differ from raw `cabd.dams` after the 4 CSVs are applied). Same psql pattern that proved #102 was a no-op.
+### Phase 1 detective findings
+
+| Source | Total rows | Barrier rows | Notes |
+|---|---:|---:|---|
+| `cabd.dams` (raw upstream) | 2,594 | 2,478 | most dams are flagged as barriers |
+| `bcfishpass.dams` (post-edits) | 2,559 | 2,441 | edit layer net delta ≈ 35 (drops + 4 additions) |
+
+**Famous named dams confirmed in bcfp output** (all `passability_status_code=1`, heights 1.6–243 m):
+
+- CAMB: John Hart (33.5 m), Ladore Falls (37.5 m), Strathcona (53.3 m)
+- CLRH: Mica (243 m)
+- LARL: Hugh Keenleyside (52 m)
+- LFRA: Stave Falls (26 m), Ruskin (59.4 m), Alouette (22.5 m), Coquitlam (30.5 m)
+- REVL: Revelstoke (175 m)
+- SANJ: Jordan Diversion (40 m)
+- Plus Seymour, Campbell Mountain, Campbell Lake, Upper Stave variants
+
+**Top 10 WSGs by dam count:** OKAN (233), SAJR (109), VICT (105), STHM (95), MFRA (74), THOM (68), NICL (65), LFRA (65), LNIC (65), SIML (60). Heavy in southern interior + south coast.
+
+**Decision:** source via tunnel-DB join (consistent with link#102 resolution). cypher / M4 / M1 all have tunnel access per rtj#82.
+
+### Next
+
+Phase 2 — implement `lnk_dams_load(conn, schema, ...)` mirroring bcfp's `load_dams.sql`. Output `<schema>.dams` with `(dam_name_en, height_m, owner, dam_use, operating_status, passability_status_code, geom)` column set. Critical: must NOT enter `streams_breaks` or `barrier_overrides` — verified via byte-identical regression in Phase 6.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,8 @@
+# Progress — Ingest CABD dams as parallel reporting dimension (#103)
+
+## Session 2026-05-02
+
+- Created branch `103-ingest-cabd-dams` off main
+- Scaffolded PWF baseline from issue body — 7 phases (detective → source pull → edit CSVs → pipeline wiring → tests → byte-identical verification → research doc + ship)
+- Sibling work today: link#102 (CABD waterfalls) closed as not-a-bug after detective work showed fresh's static falls.csv was already complete; link#104 (CABD download path) closed as obsolete with #102. The same 4 CABD edit CSVs that #102 was going to redistribute now come in via this issue.
+- Next: read `task_plan.md` Phase 1 (detective work). Concrete first command: query `cabd.dams` and `bcfishpass.dams` over the tunnel for total count, named-dam spot check (Stave / Alouette / Strathcona / John Hart / Coquitlam), and edit-application audit (how many bcfp `dams` rows differ from raw `cabd.dams` after the 4 CSVs are applied). Same psql pattern that proved #102 was a no-op.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,79 @@
+# Task: Ingest CABD dams as parallel reporting dimension (#103)
+
+link does not ingest dam locations from CABD. bcfp pulls them from `cabd.dams` + applies four edit CSVs (`cabd_exclusions`, `cabd_blkey_xref`, `cabd_passability_status_updates`, `cabd_additions` filtered to `feature_type='dams'`).
+
+**Important framing:** bcfp's per-species access models AND habitat_linear models are **dam-blind** — verified across all 5 `model_access_*.sql` and 8 `load_habitat_linear_*.sql` files: zero references to `barriers_dams`, `barriers_anthropogenic`, or `barriers_pscis`. Dams in bcfp live as a **parallel reporting dimension** (the `bcfishpass.dams` table) that downstream consumers compose with habitat output for reports, WCRP tracking, and dam-impact analyses.
+
+So this issue is **not a habitat-parity gap** — fixing it will not close any rollup deltas. It's a **reporting-data gap**: real-world habitat above Stave / Alouette / Strathcona / John Hart dams is materially blocked, but bcfp's habitat output is dam-blind and link's would be too. SRED-relevant report consumers will ask "what's above each dam?" and we need data to answer.
+
+The per-species methodology question — "should default-bundle make some dam classes block which species?" — is **separate** and tracked at link#83. This issue is purely about getting the data in. link#83 is the consumer-side question.
+
+## Phase 1: Detective work — confirm the data shape on the bcfp side
+
+- [ ] Query `cabd.dams` over the tunnel to bcfp — count, top-25 WSGs, verify named dams (Stave / Alouette / Strathcona / John Hart / Coquitlam etc. all present)
+- [ ] Compare to `bcfishpass.dams` (post-edits) — confirm the 4 edit CSVs are correctly applied; what fraction of CABD rows are dropped/modified/added
+- [ ] Decide source path — DB join via tunnel (matches link#102's resolution; see findings.md for context). Document the choice
+- [ ] Check fresh's bundled data: does `falls.csv` accidentally include any dam features? Confirm clean separation
+
+## Phase 2: Source pull infrastructure
+
+- [ ] Add new `lnk_dams_load(conn, schema, ...)` function mirroring bcfp's `load_dams.sql`:
+  - Pull `cabd.dams` (filtered/transformed)
+  - LEFT JOIN exclusions (drop)
+  - LEFT JOIN blkey_xref (override snap)
+  - LEFT JOIN passability_status_updates (override status)
+  - UNION ALL with `cabd_additions where feature_type = 'dams'` (the 4 US-side dam placeholders)
+  - Lateral snap to `fwa_stream_networks_sp` within 65 m
+- [ ] Output: `<schema>.dams` table with bcfp's column set (`dam_name_en`, `height_m`, `owner`, `dam_use`, `operating_status`, `passability_status_code`, `geom`)
+- [ ] Documented as **NOT used in habitat classification** — comment in the function source + roxygen note
+
+## Phase 3: Edit CSV ingestion via lnk_load_overrides
+
+- [ ] Copy the four CSVs from `bcfishpass/data/cabd_*.csv` into `inst/extdata/configs/{bcfishpass,default}/overrides/`
+- [ ] Add entries to both bundles' `config.yaml::files` block (same redistribution pattern as `user_barriers_definite_control.csv`)
+- [ ] `lnk_load_overrides()` reads them; bundle-config-driven
+- [ ] **Note: same 4 CSVs apply to both falls and dams** — they key on `cabd_id` which spans both tables. Falls are already complete (link#102 closed), so this ingestion exists primarily for dams. If a future re-extract of `falls.csv` from CABD is needed, the same edits apply for free.
+
+## Phase 4: Pipeline wiring
+
+- [ ] Wire `lnk_dams_load` into `lnk_pipeline_prepare.R::.lnk_pipeline_prep_load_aux()` (or a sibling helper) — gated on the bundle config declaring CABD dams ingestion
+- [ ] Both `bcfishpass` and `default` bundles ingest — the data is methodology-agnostic at the data layer
+- [ ] **Crucially: the dams data does NOT enter `streams_breaks` and does NOT enter the per-species barrier_overrides path**. This is the load-bearing design choice — habitat classification stays dam-blind, matching bcfp.
+
+## Phase 5: Tests
+
+- [ ] Unit test in `tests/testthat/test-lnk_dams_load.R` — SQL emission shape (mocked DB, similar pattern to `test-lnk_pipeline_break.R`)
+- [ ] Confirm `devtools::test()` clean
+
+## Phase 6: Verification — prove the data lands without affecting habitat
+
+This is the most important phase. The verification gates closing the issue.
+
+- [ ] Run a single WSG (LFRA — Stave / Alouette / Ruskin live there) post-fix
+- [ ] Query `<schema>.dams` post-pipeline; confirm rowcount > 0
+- [ ] Spot-check named dams appear with correct `(blue_line_key, downstream_route_measure)` against bcfp tunnel — Stave / Alouette / Ruskin / Coquitlam at minimum
+- [ ] Run the 4-WSG regression (HARR / HORS / LFRA / BABL) — both bundle rollups must be **byte-identical to pre-fix baseline**. If they shift even by one row, the dams data is leaking into habitat classification — fix that before closing.
+
+The byte-identical regression is the load-bearing test: dams data in, habitat output unchanged, parallel data layer ready for the consumer side.
+
+## Phase 7: Research doc + ship
+
+- [ ] Update `research/bcfishpass_comparison.md` § "Dams design — much smaller than expected" — note the data is now wired, link's habitat output remains dam-blind by design (matches bcfp), reporting consumers can compose dam awareness on top
+- [ ] `/code-check` on staged diff
+- [ ] Atomic commits with PWF checkboxes
+- [ ] PR with `Fixes #103`
+- [ ] `/planning-archive` after merge
+
+## Out of scope
+
+- **Per-species access gating on dams** — link#83 (methodology decision, separate issue). This issue lands the data; #83 decides who, when, why dams block which species
+- **WCRP / dam-impact report composition** — downstream consumer work, not a link-package concern
+- **CABD release version pin / refresh cadence** — open question; can be filed as a follow-up if it becomes operational pain
+
+## Reference
+
+- bcfp `model/01_access/sql/load_dams.sql` — implementation reference (full SQL in issue body)
+- bcfp `model/01_access/sql/barriers_dams.sql`, `barriers_dams_hydro.sql`, `barriers_anthropogenic.sql` — downstream consumers we don't replicate (reporting-layer, not link's territory)
+- `research/bcfishpass_comparison.md` § "Dams design — much smaller than expected" — bcfp's dam-blindness verification
+- link#83 — per-species dam-class methodology (consumer side; depends on this issue)
+- link#102 (closed) — sibling falls work; the 4 CABD edit CSVs were initially scoped here, but #102's detective work proved the falls side already complete. The CSVs come in via this issue instead.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -16,17 +16,17 @@ The per-species methodology question — "should default-bundle make some dam cl
 - [x] Source path decision: **DB join via tunnel** (consistent with link#102's resolution; cypher / M4 / M1 all have tunnel access per rtj#82)
 - [x] Verify clean separation — fresh's bundled `falls.csv` has no dam-named rows; CABD's `feature_type` column cleanly partitions waterfalls vs dams
 
-## Phase 2: Source pull infrastructure
+## Phase 2: Source pull as a private helper in `lnk_pipeline_prepare.R`
 
-- [ ] Add new `lnk_dams_load(conn, schema, ...)` function mirroring bcfp's `load_dams.sql`:
-  - Pull `cabd.dams` (filtered/transformed)
-  - LEFT JOIN exclusions (drop)
-  - LEFT JOIN blkey_xref (override snap)
-  - LEFT JOIN passability_status_updates (override status)
-  - UNION ALL with `cabd_additions where feature_type = 'dams'` (the 4 US-side dam placeholders)
-  - Lateral snap to `fwa_stream_networks_sp` within 65 m
-- [ ] Output: `<schema>.dams` table with bcfp's column set (`dam_name_en`, `height_m`, `owner`, `dam_use`, `operating_status`, `passability_status_code`, `geom`)
-- [ ] Documented as **NOT used in habitat classification** — comment in the function source + roxygen note
+Follows the precedent set by `prep_subsurfaceflow` in link 0.19.0 — inline SQL helper, NOT a new exported function. The batch-point-snap-to-FWA pattern exists in bcfp 5+ places (load_dams, load_falls, load_subsurfaceflow, crossings, etc.), but a fresh-side primitive is speculative until a second link consumer materializes. Promote to `frs_point_load_snapped()` later if pattern recurs.
+
+- [ ] Add `.lnk_pipeline_prep_dams(conn, cfg, schema, loaded)` private helper in `R/lnk_pipeline_prepare.R`:
+  - CTE 1: `from cabd.dams left outer join cabd_exclusions on cabd_id where exclusions.cabd_id is null`
+  - CTE 2: lateral snap to `fwa_stream_networks_sp` within 65 m, two paths (with-blkey via xref, without-blkey via spatial nearest)
+  - CTE 3: passability override via `coalesce(updates.passability_status_code, cabd.passability_status_code)`; carry `(dam_name_en, height_m, owner, dam_use, operating_status)`
+  - UNION ALL with `cabd_additions where feature_type = 'dams'` (the 4 US placeholders)
+- [ ] Output: `<schema>.dams` with column set `(dam_id, linear_feature_id, blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree, distance_to_stream, watershed_group_code, dam_name_en, height_m, owner, dam_use, operating_status, passability_status_code, geom)` — mirrors bcfp's table
+- [ ] Helper docstring is explicit: **NOT used in habitat classification** — data lives in the parallel reporting layer
 
 ## Phase 3: Edit CSV ingestion via lnk_load_overrides
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -8,12 +8,13 @@ So this issue is **not a habitat-parity gap** — fixing it will not close any r
 
 The per-species methodology question — "should default-bundle make some dam classes block which species?" — is **separate** and tracked at link#83. This issue is purely about getting the data in. link#83 is the consumer-side question.
 
-## Phase 1: Detective work — confirm the data shape on the bcfp side
+## Phase 1: Detective work — confirm the data shape on the bcfp side ✓
 
-- [ ] Query `cabd.dams` over the tunnel to bcfp — count, top-25 WSGs, verify named dams (Stave / Alouette / Strathcona / John Hart / Coquitlam etc. all present)
-- [ ] Compare to `bcfishpass.dams` (post-edits) — confirm the 4 edit CSVs are correctly applied; what fraction of CABD rows are dropped/modified/added
-- [ ] Decide source path — DB join via tunnel (matches link#102's resolution; see findings.md for context). Document the choice
-- [ ] Check fresh's bundled data: does `falls.csv` accidentally include any dam features? Confirm clean separation
+- [x] Query `cabd.dams` over the tunnel — **2,594 raw rows, 2,478 as barrier (passability_status_code=1)**
+- [x] Compare to `bcfishpass.dams` (post-edits) — **2,559 rows, 2,441 as barrier**. Net delta ≈ 35 (12 exclusions + snap-failures, partially offset by 4 US additions). Edit layer applies cleanly.
+- [x] Verify named dams present in bcfp output — confirmed: John Hart, Ladore Falls, Strathcona (CAMB), Mica (CLRH), Hugh Keenleyside (LARL), Alouette, Coquitlam, Stave Falls, Ruskin (LFRA), Revelstoke (REVL), Jordan Diversion (SANJ), and others. Heights 1.6–243 m, mostly Hydroelectricity. All `passability_status_code=1` (treated as barriers in CABD).
+- [x] Source path decision: **DB join via tunnel** (consistent with link#102's resolution; cypher / M4 / M1 all have tunnel access per rtj#82)
+- [x] Verify clean separation — fresh's bundled `falls.csv` has no dam-named rows; CABD's `feature_type` column cleanly partitions waterfalls vs dams
 
 ## Phase 2: Source pull infrastructure
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -16,50 +16,55 @@ The per-species methodology question — "should default-bundle make some dam cl
 - [x] Source path decision: **DB join via tunnel** (consistent with link#102's resolution; cypher / M4 / M1 all have tunnel access per rtj#82)
 - [x] Verify clean separation — fresh's bundled `falls.csv` has no dam-named rows; CABD's `feature_type` column cleanly partitions waterfalls vs dams
 
-## Phase 2: Source pull as a private helper in `lnk_pipeline_prepare.R`
+## Phase 2: Consume bcfp's pre-built `bcfishpass.dams` via tunnel
 
-Follows the precedent set by `prep_subsurfaceflow` in link 0.19.0 — inline SQL helper, NOT a new exported function. The batch-point-snap-to-FWA pattern exists in bcfp 5+ places (load_dams, load_falls, load_subsurfaceflow, crossings, etc.), but a fresh-side primitive is speculative until a second link consumer materializes. Promote to `frs_point_load_snapped()` later if pattern recurs.
+Re-evaluating the source-pull design: bcfp's tunnel DB already has `bcfishpass.dams` post-CABD-pull and post-4-edit-CSVs (refreshed weekly via db_newgraph cron). Replicating bcfp's `load_dams.sql` locally is unnecessary work for the SRED-reporting use case — the data is the same either way. Trade-off: bcfp owns refresh cadence (weekly is fine for reporting; if we ever need bit-identical control, escalate to the load_dams.sql replication path).
 
-- [ ] Add `.lnk_pipeline_prep_dams(conn, cfg, schema, loaded)` private helper in `R/lnk_pipeline_prepare.R`:
-  - CTE 1: `from cabd.dams left outer join cabd_exclusions on cabd_id where exclusions.cabd_id is null`
-  - CTE 2: lateral snap to `fwa_stream_networks_sp` within 65 m, two paths (with-blkey via xref, without-blkey via spatial nearest)
-  - CTE 3: passability override via `coalesce(updates.passability_status_code, cabd.passability_status_code)`; carry `(dam_name_en, height_m, owner, dam_use, operating_status)`
-  - UNION ALL with `cabd_additions where feature_type = 'dams'` (the 4 US placeholders)
-- [ ] Output: `<schema>.dams` with column set `(dam_id, linear_feature_id, blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree, distance_to_stream, watershed_group_code, dam_name_en, height_m, owner, dam_use, operating_status, passability_status_code, geom)` — mirrors bcfp's table
-- [ ] Helper docstring is explicit: **NOT used in habitat classification** — data lives in the parallel reporting layer
+Consequences of consume-path:
+
+- No bundle redistribution of the 4 CABD edit CSVs (they're applied bcfp-side, we're downstream)
+- No `cabd.dams` source-pull SQL in link
+- `lnk_pipeline_prepare` accepts an optional `conn_tunnel` arg; helper short-circuits when NULL
+
+Tasks:
+
+- [x] Add optional `conn_tunnel = NULL` arg to `lnk_pipeline_prepare(conn, aoi, cfg, loaded, schema, ...)`
+- [x] Add `.lnk_pipeline_prep_dams(conn, conn_tunnel, aoi, schema, loaded)` private helper in `R/lnk_pipeline_prepare.R`. Implementation pivoted to **replicate `load_dams.sql` against `cabd.dams`** rather than consume bcfp's processed `bcfishpass.dams` (architectural parallelism: link sibling-of-bcfp under CABD, not downstream-of-bcfp).
+- [x] Output: `<schema>.dams` mirroring bcfp's table column set
+- [x] Helper docstring is explicit: **NOT used in habitat classification** — data lives in the parallel reporting layer
+- [x] Wire `conn_tunnel` through `compare_bcfishpass_wsg` — pass it down to `lnk_pipeline_prepare`
 
 ## Phase 3: Edit CSV ingestion via lnk_load_overrides
 
-- [ ] Copy the four CSVs from `bcfishpass/data/cabd_*.csv` into `inst/extdata/configs/{bcfishpass,default}/overrides/`
-- [ ] Add entries to both bundles' `config.yaml::files` block (same redistribution pattern as `user_barriers_definite_control.csv`)
-- [ ] `lnk_load_overrides()` reads them; bundle-config-driven
-- [ ] **Note: same 4 CSVs apply to both falls and dams** — they key on `cabd_id` which spans both tables. Falls are already complete (link#102 closed), so this ingestion exists primarily for dams. If a future re-extract of `falls.csv` from CABD is needed, the same edits apply for free.
+- [x] Copy the four CSVs from `bcfishpass/data/cabd_*.csv` into `inst/extdata/configs/{bcfishpass,default}/overrides/`
+- [x] Add entries to both bundles' `config.yaml::files` block (same redistribution pattern as `user_barriers_definite_control.csv`)
+- [x] `lnk_load_overrides()` reads them; bundle-config-driven
 
 ## Phase 4: Pipeline wiring
 
-- [ ] Wire `lnk_dams_load` into `lnk_pipeline_prepare.R::.lnk_pipeline_prep_load_aux()` (or a sibling helper) — gated on the bundle config declaring CABD dams ingestion
-- [ ] Both `bcfishpass` and `default` bundles ingest — the data is methodology-agnostic at the data layer
-- [ ] **Crucially: the dams data does NOT enter `streams_breaks` and does NOT enter the per-species barrier_overrides path**. This is the load-bearing design choice — habitat classification stays dam-blind, matching bcfp.
+- [x] Wire `.lnk_pipeline_prep_dams` into `lnk_pipeline_prepare.R` as the last phase
+- [x] Both `bcfishpass` and `default` bundles ingest — the data is methodology-agnostic at the data layer
+- [x] **Crucially: the dams data does NOT enter `streams_breaks` and does NOT enter the per-species barrier_overrides path**. Verified via grep + dams-ON/OFF byte-identical regression.
 
 ## Phase 5: Tests
 
-- [ ] Unit test in `tests/testthat/test-lnk_dams_load.R` — SQL emission shape (mocked DB, similar pattern to `test-lnk_pipeline_break.R`)
-- [ ] Confirm `devtools::test()` clean
+- [x] Unit tests in `tests/testthat/test-lnk_pipeline_prepare.R` — `prep_dams` short-circuit on NULL conn_tunnel + load_dams.sql SQL shape (mocked DBI)
+- [x] `devtools::test(filter = "lnk_pipeline_prepare")` clean — 78 PASS, 0 FAIL
 
 ## Phase 6: Verification — prove the data lands without affecting habitat
 
-This is the most important phase. The verification gates closing the issue.
+- [x] LFRA preflight — `<schema>.dams` rowcount = 65 (matches bcfp 65), 59 barriers (matches), 15 named (matches)
+- [x] Stave Falls / Alouette / Ruskin / Coquitlam spot-checks — all 15 named LFRA dams match bcfp tunnel byte-for-byte on `(blue_line_key, downstream_route_measure)` within fp precision (Coquitlam DRM differs by ~0.2mm — lateral-snap fp, not content drift)
+- [x] HARR dams-ON / dams-OFF byte-identical rollup — same HEAD, only `conn_tunnel` differs, byte-identical to fp precision. Confirms parallel-data invariant.
+- [x] Architectural isolation proven via `grep -rn "\.dams\b\|\.cabd_"` — only match is a docstring example in `lnk_source.R`. No break/classify/connect phase reads dam-side tables.
 
-- [ ] Run a single WSG (LFRA — Stave / Alouette / Ruskin live there) post-fix
-- [ ] Query `<schema>.dams` post-pipeline; confirm rowcount > 0
-- [ ] Spot-check named dams appear with correct `(blue_line_key, downstream_route_measure)` against bcfp tunnel — Stave / Alouette / Ruskin / Coquitlam at minimum
-- [ ] Run the 4-WSG regression (HARR / HORS / LFRA / BABL) — both bundle rollups must be **byte-identical to pre-fix baseline**. If they shift even by one row, the dams data is leaking into habitat classification — fix that before closing.
-
-The byte-identical regression is the load-bearing test: dams data in, habitat output unchanged, parallel data layer ready for the consumer side.
+The 4-WSG vs cached-baseline regression initially looked like a fail but was contaminated by #96/#97/31b9 drift relative to a May 1 06:48 cache; HARR dams-ON/OFF on current HEAD is the clean #103-only test.
 
 ## Phase 7: Research doc + ship
 
-- [ ] Update `research/bcfishpass_comparison.md` § "Dams design — much smaller than expected" — note the data is now wired, link's habitat output remains dam-blind by design (matches bcfp), reporting consumers can compose dam awareness on top
+- [x] Update `research/bcfishpass_comparison.md` § "Dams design" — replaced the early "fresh-crossings path" framing with the actual landed implementation
+- [x] NEWS.md 0.24.0 entry
+- [x] DESCRIPTION version bump 0.23.0 → 0.24.0
 - [ ] `/code-check` on staged diff
 - [ ] Atomic commits with PWF checkboxes
 - [ ] PR with `Fixes #103`

--- a/research/bcfishpass_comparison.md
+++ b/research/bcfishpass_comparison.md
@@ -171,27 +171,28 @@ Adding dams + PSCIS to link does **not** change `habitat_linear_<sp>` parity num
 
 If we want a per-segment "potentially accessible to species X" integer code in link analogous to bcfishpass's `access_<sp>` (-9 / 0 / 1 / 2), that's a separate fresh-side concern — fresh's `streams_habitat` already encodes accessibility per segment in the `accessible` column, but the integer-code semantic with the observation-presence dimension is new territory.
 
-## Dams design — much smaller than expected
+## Dams design — parallel reporting dimension (link#103)
 
-Initial plan was: ingest the four CABD CSVs (`cabd_additions`, `cabd_exclusions`, `cabd_blkey_xref`, `cabd_passability_status_updates`) into link, source `cabd.dams` separately, replicate bcfishpass's `load_dams.sql`. Reading the actual bcfishpass code shows this is the wrong path.
+Landed in v0.24.0. link replicates bcfishpass's `load_dams.sql` against the `cabd.dams` source over the db_newgraph tunnel and writes `<schema>.dams` mirroring `bcfishpass.dams` column-for-column. The data is **parallel** to habitat classification: `<schema>.dams` is not consumed by any break / classify / connect phase. SRED-relevant report consumers ("what habitat is upstream of Stave / Alouette / Strathcona / John Hart?") can compose dam-aware accessibility on top; habitat output stays dam-blind by design (matches bcfishpass).
 
-The simpler picture:
+Implementation: `.lnk_pipeline_prep_dams(conn, conn_tunnel, aoi, schema, loaded)` runs as the last phase in `lnk_pipeline_prepare`. Three steps mirror `model/01_access/sql/load_dams.sql`:
 
-- bcfishpass's `barriers_dams` is `SELECT … FROM bcfishpass.crossings WHERE dam_id IS NOT NULL AND barrier_status IN ('BARRIER','POTENTIAL') AND blue_line_key = watershed_key` (`model/01_access/sql/barriers_dams.sql`).
-- `bcfishpass.crossings` is the unified CABD-edited table — built by bcfishpass with all four CABD edit CSVs already applied.
-- `fresh::system.file("extdata", "crossings.csv")` is regenerated from `bcfishpass.crossings` via `fresh/data-raw/bcfishpass_crossings.R`. **CABD edits flow through that source automatically** — nothing for link to ingest.
-- Today fresh's CSV projects only 10 columns; the columns we need (`dam_id`, `stream_crossing_id`, `dam_use`, `wscode_ltree`, `localcode_ltree`, `crossing_feature_type`) are dropped at SELECT time. They exist upstream.
+1. Stage the four CABD edit CSVs (`cabd_exclusions`, `cabd_blkey_xref`, `cabd_passability_status_updates`, `cabd_additions`) from `loaded` into `<schema>.cabd_*`. Both `bcfishpass` and `default` bundles ship these CSVs; they're redistributed from `bcfishpass/data/`.
+2. Pull `cabd.dams` from the tunnel as `<schema>.cabd_dams_raw` (raw upstream — NOT `bcfishpass.dams`, the post-edit derivative). This keeps link architecturally parallel to bcfishpass under CABD rather than dependent on bcfishpass's pipeline.
+3. Apply the four edits + lateral snap (≤65 m to `whse_basemapping.fwa_stream_networks_sp`) + UNION ALL with `cabd_additions WHERE feature_type = 'dams'` (US placeholders). Output: `<schema>.dams` with the same `(dam_id, blue_line_key, downstream_route_measure, watershed_group_code, dam_name_en, height_m, owner, dam_use, operating_status, passability_status_code, geom)` shape bcfishpass produces.
 
-Implication: the dams work splits cleanly into two patches:
+Short-circuits to a `DROP TABLE IF EXISTS <schema>.dams` no-op when `conn_tunnel = NULL` — pipeline callers that don't need dam reporting (e.g. CI without tunnel access) opt out at zero cost.
 
-1. **fresh side** — expand the `SELECT` in `data-raw/bcfishpass_crossings.R` to include `dam_id`, `stream_crossing_id`, `crossing_feature_type`, `dam_use`, `wscode_ltree`, `localcode_ltree`. Regenerate `inst/extdata/crossings.csv`. One-line SELECT change + a regenerate run.
-2. **link side** — once fresh ships the expanded CSV, add `barriers_dams` (and optionally `barriers_pscis` / `barriers_anthropogenic`) as opt-in break sources following the same pattern just landed for subsurfaceflow:
-   - `.lnk_pipeline_prep_dams(conn, schema)` materializes `<schema>.barriers_dams` from `<schema>.crossings WHERE dam_id IS NOT NULL AND barrier_status IN ('BARRIER','POTENTIAL') AND blue_line_key = watershed_key`.
-   - `source_tables[["dams"]] <- paste0(schema, ".barriers_dams")` in `lnk_pipeline_break.R`.
-   - Conditional UNION ALL in `lnk_pipeline_classify_build_breaks` (label `'blocked'`).
-   - `dams` added to `pipeline.break_order` in any config that opts in.
+### Verification
 
-**Reminder of the tier distinction**: dams are anthropogenic — adding them to a config does NOT change `habitat_linear_<sp>` parity numbers (those are natural-tier only). Dams add a new analytical layer for "what's blocked by dams downstream" reports, dam-impact rollups, and any custom config that wants dam-aware accessibility. The bcfishpass-bundle config should NOT add `dams` to break_order, because doing so would diverge from `habitat_linear_<sp>`'s natural-only access semantic.
+- **HARR dams-ON / dams-OFF byte-identical rollup** — same HEAD, only `conn_tunnel` differs, rollup is byte-identical to fp precision. Confirms the parallel-data invariant: `prep_dams` cannot affect habitat output. Static analysis backs this — `grep -rn "\.dams\b\|\.cabd_"` across `R/`, `tests/`, and `inst/` returns one match (a docstring example in `lnk_source.R`); no break / classify / connect phase reads dam-side tables.
+- **LFRA named dams match bcfishpass.dams byte-for-byte** — 65 dams / 59 barriers / 15 named, with Stave Falls Dam (26 m), Alouette Dam (22.5 m), Ruskin Dam (59.4 m), Coquitlam Dam (30.5 m), and Northwest Stave / Upper Stave variants all present at identical `(blue_line_key, downstream_route_measure)` to bcfishpass within fp precision (Coquitlam DRM differs by ~0.2 mm — lateral-snap floating-point, not a content drift).
+
+### Out-of-scope (intentionally)
+
+- **Per-species access gating on dams** — link#83 (consumer-side methodology decision: which dam classes block which species in the default bundle). This issue lands the data only.
+- **WCRP / dam-impact report composition** — downstream consumer work, not a link-package concern.
+- **Source independence from the tunnel** — replicating `cabd.dams` into the s3 fwapg dump is filed as a follow-up under rtj. `cabd.dams` is currently tunnel-only; reactivating link#104 (CABD download path) is one alternative.
 
 ## Correctness bar (historical, retracted)
 

--- a/tests/testthat/test-lnk_pipeline_prepare.R
+++ b/tests/testthat/test-lnk_pipeline_prepare.R
@@ -522,3 +522,81 @@ test_that(".lnk_pipeline_prep_observations errors when wsg_species_presence miss
     "wsg_species_presence not present"
   )
 })
+
+# -- prep_dams (link#103) ---------------------------------------------------
+
+test_that(".lnk_pipeline_prep_dams short-circuits when conn_tunnel is NULL", {
+  captured <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured <<- c(captured, sql); invisible(NULL)
+    }
+  )
+  .lnk_pipeline_prep_dams("mock", conn_tunnel = NULL, aoi = "HARR",
+    schema = "w_harr", loaded = list())
+  joined <- paste(captured, collapse = "\n")
+  expect_match(joined, "DROP TABLE IF EXISTS w_harr.dams")
+  # No CREATE / cabd staging when opted out
+  expect_no_match(joined, "CREATE TABLE w_harr\\.dams")
+  expect_no_match(joined, "cabd_dams_raw")
+})
+
+test_that(".lnk_pipeline_prep_dams errors clearly when a CABD edit CSV is missing", {
+  expect_error(
+    .lnk_pipeline_prep_dams("mock-conn", conn_tunnel = "mock-tunnel",
+      aoi = "HARR", schema = "w_harr",
+      loaded = list(cabd_exclusions = data.frame(cabd_id = integer(0)))),
+    "missing required CABD edit CSV"
+  )
+})
+
+test_that(".lnk_pipeline_prep_dams emits load_dams.sql shape when conn_tunnel set", {
+  captured_sql <- character(0)
+  captured_writes <- character(0)
+  local_mocked_bindings(
+    .lnk_db_execute = function(conn, sql) {
+      captured_sql <<- c(captured_sql, sql); invisible(NULL)
+    }
+  )
+  with_mocked_bindings(
+    {
+      .lnk_pipeline_prep_dams("mock-conn",
+        conn_tunnel = "mock-tunnel", aoi = "HARR", schema = "w_harr",
+        loaded = list(
+          cabd_exclusions = data.frame(cabd_id = integer(0)),
+          cabd_blkey_xref = data.frame(cabd_id = integer(0)),
+          cabd_passability_status_updates = data.frame(cabd_id = integer(0)),
+          cabd_additions = data.frame(cabd_id = integer(0))))
+    },
+    dbGetQuery = function(conn, statement, ...) {
+      data.frame(cabd_id = integer(0), dam_name_en = character(0),
+                 height_m = double(0), owner = character(0),
+                 dam_use = character(0), operating_status = character(0),
+                 passability_status_code = integer(0),
+                 geom_ewkb = list(), stringsAsFactors = FALSE)
+    },
+    dbWriteTable = function(conn, name, value, ...) {
+      captured_writes <<- c(captured_writes, paste0(name@name[["schema"]], ".",
+                                                     name@name[["table"]]))
+      invisible(TRUE)
+    },
+    .package = "DBI"
+  )
+
+  joined <- paste(captured_sql, collapse = "\n")
+  # Stages 4 edit CSVs into the working schema
+  expect_true("w_harr.cabd_exclusions" %in% captured_writes)
+  expect_true("w_harr.cabd_blkey_xref" %in% captured_writes)
+  expect_true("w_harr.cabd_passability_status_updates" %in% captured_writes)
+  expect_true("w_harr.cabd_additions" %in% captured_writes)
+  expect_true("w_harr.cabd_dams_raw" %in% captured_writes)
+  # Replicates load_dams.sql: lateral snap, COALESCE on passability,
+  # exclusions filter, blkey override, US additions UNION
+  expect_match(joined, "CREATE TABLE w_harr\\.dams")
+  expect_match(joined, "LEFT OUTER JOIN w_harr.cabd_exclusions")
+  expect_match(joined, "LEFT OUTER JOIN w_harr.cabd_blkey_xref")
+  expect_match(joined, "LEFT OUTER JOIN w_harr.cabd_passability_status_updates")
+  expect_match(joined, "ST_Distance\\(str.geom, c.geom\\) <= 65")
+  expect_match(joined, "UNION ALL")
+  expect_match(joined, "feature_type = 'dams'")
+})


### PR DESCRIPTION
## Summary

- Adds `<schema>.dams` as a **parallel reporting dimension** mirroring `bcfishpass.dams` column-for-column. Habitat classification stays dam-blind by design (matches bcfishpass).
- Replicates bcfishpass's `model/01_access/sql/load_dams.sql` against the `cabd.dams` source over the `db_newgraph` tunnel — link is **architecturally sibling-of-bcfp under CABD**, not downstream of bcfp's processed output.
- Both `bcfishpass` and `default` config bundles ingest the four CABD edit CSVs and produce `<schema>.dams` for downstream report consumers (WCRP / dam-impact / "what habitat is upstream of Stave / Alouette / Strathcona / John Hart?").

## Design notes

- New optional `conn_tunnel = NULL` arg to `lnk_pipeline_prepare()`. When NULL, `prep_dams` short-circuits to `DROP TABLE IF EXISTS <schema>.dams` — zero-cost opt-out for CI / non-reporting workflows.
- Strict validation on entry: `prep_dams` errors clearly when any of the four required CABD edit CSVs is missing from `loaded`, instead of failing later with cryptic `column "..." does not exist` SQL errors.
- Per-species methodology — "should some dam classes block which species in the default bundle?" — is intentionally out of scope; tracked at #83.

## Verification

**Architectural isolation proven two ways.**

- Static: `grep -rn "\.dams\b\|\.cabd_"` across `R/`, `tests/`, and `inst/` returns one match (a docstring example in `lnk_source.R`). No break / classify / connect phase reads dam-side tables.
- Behavioural: HARR with `conn_tunnel = NULL` (dams OFF) vs `conn_tunnel = conn_ref` (dams ON), same HEAD, same code, same data — rollup byte-identical to fp precision. Logged at `data-raw/logs/20260502_07_dams_isolation_harr.txt`.

**LFRA dams match `bcfishpass.dams` byte-for-byte.**

- 65 dams / 59 barriers / 15 named in `working_lfra.dams` vs identical 65 / 59 / 15 in `bcfishpass.dams` on tunnel.
- Stave Falls (26 m), Alouette (22.5 m), Ruskin (59.4 m), Coquitlam (30.5 m), Northwest Stave + Upper Stave variants all present at the same `(blue_line_key, downstream_route_measure)` within fp precision (Coquitlam DRM differs by ~0.2 mm — lateral-snap fp, not content drift).
- Logged at `data-raw/logs/20260502_05_preflight_lfra_dams.txt`.

## Test plan

- [x] `devtools::test(filter = "lnk_pipeline_prepare")` — 78 PASS / 0 FAIL, including 3 new tests for `prep_dams` (NULL short-circuit, missing-CSV error, `load_dams.sql` SQL emission shape)
- [x] `pak::local_install()` then `Rscript data-raw/regress_dams_isolation.R` — HARR dams-ON / dams-OFF byte-identical
- [x] LFRA preflight — named dams cross-check vs bcfp tunnel
- [x] `/code-check` — 1 finding fixed (empty-loaded fallback hardened to clear error), 1 follow-up round clean
- [ ] Reviewer: spot-check `<schema>.dams` shape on a fresh WSG of choice (`SELECT * FROM working_<wsg>.dams LIMIT 5;`)

## Out of scope

- **Per-species access gating on dams** — #83 (consumer-side methodology decision)
- **WCRP / dam-impact report composition** — downstream consumer work, not a link-package concern
- **Source independence from the tunnel** — `cabd.dams` replication into the s3 fwapg dump is a follow-up under rtj; #104 (CABD download path) is one alternative

Relates to NewGraphEnvironment/sred-2025-2026#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
