### PR TITLE
DB hygiene: drop working schemas after persist; drop worker schemas after consolidation (v0.29.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.28.0
+Version: 0.29.0
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# link 0.29.0
+
+Closes [#118](https://github.com/NewGraphEnvironment/link/issues/118). DB hygiene to prevent the disk-full incident that crashed cypher's `fresh-db` container during the 2026-05-04 `default_extrabreaks` provincial trifecta. Two-tier orchestrator-level cleanup; no in-package API changes.
+
+- `compare_bcfishpass_wsg()` gains `cleanup_working = TRUE` parameter — drops `working_<aoi>` schema after the rollup tibble is built. Default-on; pass `FALSE` for interactive debug. Saves ~10–15 GB per provincial run on every host (60+ working schemas accumulated otherwise).
+- `consolidate_schema()` gains `keep_source = FALSE` parameter — drops source schema on each remote host after a successful pg_restore. Default-on; rc-guarded (failed restore leaves source for retry); warn-but-don't-fail on drop rc != 0. Saves ~25–30 GB per consolidated bundle on M1 + cypher.
+- `data-raw/README.md` documents per-worker disk capacity: rough footprints (~30 GB single-bundle persistent + 10–15 GB per-WSG scratch + 30–40 GB fwapg base), 60 GB minimum free recommendation, 2026-05-04 cypher incident as cautionary tale.
+- Bit-identical bcfp parity by default. ADMS rollup tibble post-cleanup `identical()` to pre-cleanup baseline (RDS file metadata differs but deserialized object is identical).
+- Approach: orchestrator-level cleanup, NOT in-package — `lnk_pipeline_persist` stays scoped to one job; the rollup query reads working schema in long-form AFTER persist returns, so the natural lifecycle owner is the orchestrator script.
+
 # link 0.28.0
 
 Orphan-class break source — fed-vector experiments now Just Work without a separate knob. When `cfg$pipeline$gradient_classes` (or the caller's `classes` arg) contains thresholds below every modelled species's `access_gradient_max`, those positions enter `gradient_barriers_minimal` as a `barriers_orphan` table — no per-species filter, no minimal reduction (every detected position splits the network for segmentation precision). Access semantics are unaffected: fresh's per-species access label filter at classify time rejects any `gradient_NNNN` label below the species's threshold, so orphan classes never block any species.

--- a/data-raw/README.md
+++ b/data-raw/README.md
@@ -90,3 +90,28 @@ Run artifacts land in subdirectories of `data-raw/logs/` keyed by topic:
 
 Reusable helper scripts read from these directories without hardcoded
 filenames where possible (newest-by-mtime wins).
+
+## Disk capacity per worker host
+
+Trifecta workers (M1, cypher) hold short-lived per-WSG scratch + a
+single bundle's persistent schema. Rough footprints on a 232-WSG run:
+
+| Working state | Disk on a worker |
+|---------------|------------------|
+| `working_<wsg>` × 60 (per-WSG scratch) | ~10–15 GB |
+| Single bundle persistent schema (no extras) | ~25 GB |
+| Single bundle persistent schema (extras — 2.8× row count) | ~30 GB |
+| fwapg base data (whse_basemapping, bcfishobs, etc.) | ~30–40 GB |
+| **Recommended free disk per worker (single bundle in flight)** | **60 GB minimum** |
+
+The 2026-05-04 cypher disk-full incident filled a 96 GB droplet with
+3 accumulated bundles + 60 working schemas at once. After the v0.29.0
+hygiene fixes (`compare_bcfishpass_wsg(cleanup_working = TRUE)` drops
+working schemas on completion; `consolidate_schema(keep_source = FALSE)`
+drops source persistent schema after successful pg_restore), a
+single-bundle-in-flight worker holds ~60 GB total — comfortable on the
+existing 96 GB cypher tier.
+
+Per-run footprint is recorded in `data-raw/logs/bcfp_baselines.csv`
+(bcfp build + run label) — cross-reference with `du -sh` on
+`/var/lib/docker/volumes/<vol>/_data` to track actual disk over time.

--- a/data-raw/compare_bcfishpass_wsg.R
+++ b/data-raw/compare_bcfishpass_wsg.R
@@ -24,13 +24,15 @@
 # research/default_vs_bcfishpass.md for the decision + revisit note.
 
 compare_bcfishpass_wsg <- function(wsg, config, dams = TRUE,
-                                   species = NULL) {
+                                   species = NULL,
+                                   cleanup_working = TRUE) {
   stopifnot(
     is.character(wsg), length(wsg) == 1L, nzchar(wsg),
     grepl("^[A-Z]{3,5}$", wsg),
     inherits(config, "lnk_config"),
     is.logical(dams), length(dams) == 1L,
-    is.null(species) || is.character(species)
+    is.null(species) || is.character(species),
+    is.logical(cleanup_working), length(cleanup_working) == 1L
   )
   schema <- paste0("working_", tolower(wsg))
 
@@ -410,6 +412,16 @@ compare_bcfishpass_wsg <- function(wsg, config, dams = TRUE,
     NA_real_,
     round(100 * (out$link_value - out$bcfishpass_value) /
           out$bcfishpass_value, 1))
+
+  # Working schema lifecycle ends here. The rollup tibble + persistent-
+  # schema rows (written by lnk_pipeline_persist) are the durable
+  # artifacts. Dropping <schema> CASCADE on a worker host saves ~10–15 GB
+  # per provincial run (60+ working_<wsg> schemas accumulate otherwise).
+  # Pass cleanup_working = FALSE for interactive debug / manual inspection
+  # of the working schema tables.
+  if (isTRUE(cleanup_working)) {
+    DBI::dbExecute(conn, sprintf("DROP SCHEMA %s CASCADE", schema))
+  }
 
   out
 }

--- a/data-raw/consolidate_schema.R
+++ b/data-raw/consolidate_schema.R
@@ -47,13 +47,20 @@
 #' @param dest_conn DBI connection for verification queries + (optional)
 #'   for invoking lnk_db_conn-style auth. Default `link::lnk_db_conn()`.
 #' @param verbose Logical.
+#' @param keep_source Logical. When FALSE (default), drop the source
+#'   schema on each remote host after a successful pg_restore — workers
+#'   are one-shot ETL and the source copy is dead weight once consolidated.
+#'   Pass TRUE to preserve the source for debugging or re-restore. Drop
+#'   is rc-guarded: failed pg_restore leaves source schema in place for
+#'   retry.
 #'
 #' @return Invisibly: list of per-source pg_dump + restore outcomes.
 consolidate_schema <- function(schema,
                                 sources,
                                 backup = TRUE,
                                 dest_conn = link::lnk_db_conn(),
-                                verbose = TRUE) {
+                                verbose = TRUE,
+                                keep_source = FALSE) {
   stopifnot(
     is.character(schema), length(schema) == 1L, nzchar(schema),
     is.list(sources), length(sources) > 0L
@@ -117,6 +124,27 @@ consolidate_schema <- function(schema,
       results[[src$host]] <- list(ok = FALSE, stage = "pg_restore", rc = rc,
                                    local_dump = local_dump)
       next
+    }
+
+    # 5. Drop source schema (rc-guarded — only on successful restore).
+    # Worker hosts are one-shot ETL; once data lives on the destination
+    # it's dead weight on the source. Saves ~25–30 GB per consolidated
+    # bundle on M1 / cypher. Pass keep_source = TRUE to opt out (e.g.
+    # debug, manual re-restore).
+    if (!isTRUE(keep_source)) {
+      drop_cmd <- if (via == "docker") {
+        sprintf("docker exec %s psql -U %s -d %s -c \"DROP SCHEMA %s CASCADE\"",
+          container, pg_user, pg_db, schema)
+      } else {
+        sprintf("PGHOST=localhost PGPORT=5432 PGDATABASE=%s PGUSER=%s PGPASSWORD=postgres psql -c \"DROP SCHEMA %s CASCADE\"",
+          pg_db, pg_user, schema)
+      }
+      log(src$host, " -> DROP SCHEMA ", schema, " CASCADE (post-restore cleanup)")
+      drop_rc <- system(sprintf("ssh '%s' '%s'", src$host, drop_cmd))
+      if (drop_rc != 0L) {
+        log(src$host, " -> WARN: DROP SCHEMA returned rc=", drop_rc,
+            " — restore succeeded, source not cleaned, recoverable")
+      }
     }
 
     results[[src$host]] <- list(ok = TRUE, stage = "complete",

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,52 @@
+# Findings — DB hygiene: drop working schemas after persist; drop worker schemas after consolidation (#118)
+
+## Surface area mapping (Plan-mode exploration, 2026-05-04)
+
+### `R/lnk_pipeline_persist.R` — function shape
+
+Signature: `lnk_pipeline_persist(conn, aoi, cfg, species, schema = paste0("working_", tolower(aoi)))`. Final operation = per-species INSERT loop, then `invisible(conn)`. The natural place to drop the working schema would be at the end of this function — but doing so breaks the compare script's rollup query (see below).
+
+### `data-raw/compare_bcfishpass_wsg.R` — orchestrator flow
+
+Sequence:
+1. `lnk_pipeline_setup → load → prepare → break → classify → connect`
+2. `lnk_persist_init` + `lnk_pipeline_persist` (writes persistent schema rows)
+3. **Rollup query** — `SELECT … FROM <schema>.streams s JOIN <schema>.streams_habitat h …`
+4. Return rollup tibble
+
+The rollup query reads from the WORKING schema (`<schema>.streams_habitat` is long-format with a `species_code` column). The persistent schema is wide-per-species (`streams_habitat_<sp>` without `species_code`), so the rollup query can't trivially port to the persistent tables. Conclusion: drop the working schema AFTER the rollup query, not in `lnk_pipeline_persist`.
+
+### `data-raw/consolidate_schema.R` — current state
+
+Function signature: `consolidate_schema(schema, sources, backup, dest_conn, verbose)`. Per-source loop:
+1. pg_dump on source via `via = "docker"` SSH-exec (or `via = "psql"`).
+2. scp dump local.
+3. pg_restore --data-only --no-owner onto destination.
+4. Verification queries on destination tables.
+
+No cleanup of source after restore today. Adding source-drop is straightforward — same `via = "docker"` SSH pattern used for pg_dump can run `DROP SCHEMA … CASCADE` on the source.
+
+### `tests/testthat/test-lnk_pipeline_persist.R`
+
+4 tests with `local_mocked_bindings` for `.lnk_db_execute`. None reference the working schema lifecycle — all focus on persist's DELETE+INSERT patterns. Phase 1's change is in `compare_bcfishpass_wsg.R`, not in `lnk_pipeline_persist`, so these tests stay unchanged.
+
+## Approach choice — orchestrator level vs in-package
+
+| Option | Cost | Trade-off |
+|--------|------|-----------|
+| Drop in `lnk_pipeline_persist` | Function gains a side-effect | Breaks compare's rollup; would force rollup into persist (large rewrite to wide-per-species query) |
+| Drop in `compare_bcfishpass_wsg` after rollup | One param + one block | Keeps persist scoped; orchestrator owns lifecycle |
+
+Issue body explicitly allows orchestrator path: "(or as the final step of `compare_bcfishpass_wsg`)". Going that way.
+
+## Risks identified
+
+- **Interactive debug** — default-on cleanup means a developer running `compare_bcfishpass_wsg("ADMS", config = …)` interactively loses the working schema after. Mitigation: `cleanup_working = FALSE` opt-out documented in roxygen.
+- **Source-drop timing** — must guard on `pg_restore` rc == 0L, not just "ssh succeeded". Otherwise we lose the source schema for a partial restore.
+- **SSH flake** — Phase 2 source-drop adds SSH calls per source. If SSH fails after a successful restore, the M4-side data is fine but source isn't cleaned. Net: partial cleanup is acceptable, partial restore would not be.
+
+## Issue context
+
+(full body of #118 reproduced here for archival)
+
+`<see issue body in PR body / GitHub UI for the canonical text — same text as scaffolded in task_plan.md "Context" section above>`

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress — DB hygiene: drop working schemas after persist; drop worker schemas after consolidation (#118)
+
+## Session 2026-05-04
+
+- Plan-mode exploration of `R/lnk_pipeline_persist.R`, `data-raw/compare_bcfishpass_wsg.R`, `data-raw/consolidate_schema.R`, and existing persist tests. Phases approved by user.
+- Decision: orchestrator-level cleanup (compare_bcfishpass_wsg + consolidate_schema), not in-package. Keeps `lnk_pipeline_persist` scoped to one job; rollup query continues to read working schema in long-form.
+- Created branch `118-db-hygiene-drop-working-schemas-after-pe` off main (post v0.28.0).
+- Scaffolded PWF baseline.
+- Next: Phase 1 — add `cleanup_working = TRUE` parameter to `compare_bcfishpass_wsg()`, drop schema after rollup, ADMS smoke.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -6,4 +6,8 @@
 - Decision: orchestrator-level cleanup (compare_bcfishpass_wsg + consolidate_schema), not in-package. Keeps `lnk_pipeline_persist` scoped to one job; rollup query continues to read working schema in long-form.
 - Created branch `118-db-hygiene-drop-working-schemas-after-pe` off main (post v0.28.0).
 - Scaffolded PWF baseline.
-- Next: Phase 1 — add `cleanup_working = TRUE` parameter to `compare_bcfishpass_wsg()`, drop schema after rollup, ADMS smoke.
+- Phase 1 done — `cleanup_working = TRUE` param added to `compare_bcfishpass_wsg()`; drops `working_<aoi>` after rollup. ADMS smoke: rollup `identical()` to pre-cleanup baseline, working_adms confirmed dropped.
+- Phase 2 done — `keep_source = FALSE` param added to `consolidate_schema()`; drops source schema on each remote host after successful pg_restore (rc-guarded; warn-but-don't-fail on drop failure).
+- Phase 3 done — `data-raw/README.md` "Disk capacity per worker host" section: per-bundle footprint, extras 2.8× multiplier, 60 GB safe floor, cypher incident reference.
+- Phase 4: smoke verification done (Phase 1 byte-identical). Multi-WSG + cross-host rehearsal deferred to next real provincial (cypher's fwapg needs reload first). Suite 736 PASS / 0 FAIL.
+- Phase 5 ready — NEWS.md + DESCRIPTION bumped to 0.29.0. PR open + SRED cross-ref next.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -11,39 +11,38 @@ Workers are dispatched as one-shot ETL — once `pg_dump → scp → pg_restore`
 
 ## Phase 1: working_<aoi> cleanup in `compare_bcfishpass_wsg.R`
 
-- [ ] Add `cleanup_working = TRUE` parameter to `compare_bcfishpass_wsg()` signature.
-- [ ] After the rollup tibble is built and `stamp` is captured, before `return(out)`, add a `DROP SCHEMA <working> CASCADE` block guarded by `if (isTRUE(cleanup_working))`.
-- [ ] Brief comment explaining the cleanup contract: working schema's job done once rollup is computed and persistent rows are written.
-- [ ] Verify nothing else after the rollup query needs the working schema.
-- [ ] ADMS smoke. Confirm rollup byte-identical to v0.28.0 baseline, and `\dn working_adms` returns 0 rows post-run.
-- [ ] `/code-check` on staged diff.
+- [x] Add `cleanup_working = TRUE` parameter to `compare_bcfishpass_wsg()` signature.
+- [x] After the rollup tibble is built and `stamp` is captured, before `return(out)`, add a `DROP SCHEMA <working> CASCADE` block guarded by `if (isTRUE(cleanup_working))`.
+- [x] Brief comment explaining the cleanup contract: working schema's job done once rollup is computed and persistent rows are written.
+- [x] Verify nothing else after the rollup query needs the working schema.
+- [x] ADMS smoke. Rollup `identical()` TRUE vs pre-cleanup baseline; `working_adms` confirmed dropped post-run.
+- [ ] `/code-check` on staged diff (after Phase 2 since both touch `data-raw/`).
 
 ## Phase 2: source schema drop in `consolidate_schema.R`
 
-- [ ] Add `keep_source = FALSE` parameter to `consolidate_schema()`.
-- [ ] After successful per-source `pg_restore` (rc == 0L), run `DROP SCHEMA <schema> CASCADE` against the SOURCE host via the same SSH/docker-exec pattern used for `pg_dump`.
-- [ ] Failure path: leave source schema in place if `pg_restore` failed.
-- [ ] Document the new default in roxygen + the data-raw README inventory entry.
-- [ ] Manual smoke: run with a small synthetic schema on one host, verify source dropped.
-- [ ] `/code-check` on staged diff.
+- [x] Add `keep_source = FALSE` parameter to `consolidate_schema()`.
+- [x] After successful per-source `pg_restore` (rc == 0L), run `DROP SCHEMA <schema> CASCADE` against the SOURCE host via the same SSH/docker-exec pattern used for `pg_dump`.
+- [x] Failure path: leave source schema in place if `pg_restore` failed (rc-guarded inside `if (!isTRUE(keep_source))`; warn-but-don't-fail on drop rc != 0).
+- [x] Document the new default in roxygen.
+- [ ] Manual smoke: deferred to next real consolidation (cypher needs fwapg reload first; defer with M1 only when doing a small test).
+- [ ] `/code-check` on staged diff (with Phase 1).
 
 ## Phase 3: capacity planning note in `data-raw/README.md`
 
-- [ ] Add "Disk capacity per host" section: per-bundle footprint, extras 3× multiplier, recommended minimum free disk per worker (60 GB safe floor), today's cypher incident as cautionary tale.
-- [ ] Cross-link from `data-raw/logs/README.md`.
+- [x] Add "Disk capacity per worker host" section: per-bundle footprint, extras 2.8× multiplier, 60 GB safe floor, cypher incident reference.
+- [ ] Cross-link from `data-raw/logs/README.md` (combine with Phase 5 release commit).
 
 ## Phase 4: end-to-end regression
 
-- [ ] M4-only single-host provincial run on `default` bundle (no trifecta needed) — verifies Phase 1 cleanup. Acceptance: zero `working_*` schemas post-run; rollup RDS byte-identical on a small WSG sample (ADMS, BABL, BULK).
-- [ ] Manual consolidation rehearsal on M1: pg_dump small schema → restore on M4 → verify M1's source schema dropped. Verifies Phase 2.
-- [ ] Defer full 3-host trifecta verification until next planned provincial run (cypher needs fwapg reload anyway).
-- [ ] Stamped log under `data-raw/logs/<TS>_link118_regression.txt`.
+- [x] ADMS smoke (Phase 1): rollup `identical()` to pre-cleanup baseline, working_adms confirmed dropped.
+- [ ] Multi-WSG single-host run + manual consolidation rehearsal — deferred to next real provincial run (cypher's fwapg needs reload first; 4-WSG smoke would be ~6 min wall but doesn't exercise consolidation since M4 is single-host).
+- [x] Suite: 736 PASS / 0 FAIL.
 
 ## Phase 5: release
 
-- [ ] `NEWS.md` 0.29.0 entry (DB hygiene + cleanup contracts).
-- [ ] `DESCRIPTION` 0.28.0 → 0.29.0.
-- [ ] PR body references #118 + SRED cross-ref (`Relates to NewGraphEnvironment/sred-2025-2026#24`).
+- [x] `NEWS.md` 0.29.0 entry (DB hygiene + cleanup contracts).
+- [x] `DESCRIPTION` 0.28.0 → 0.29.0.
+- [ ] PR body references #118 + SRED cross-ref.
 
 ## Validation
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,53 @@
+# Task: DB hygiene — drop working schemas after persist; drop worker schemas after consolidation (#118)
+
+Today's `default_extrabreaks` provincial trifecta filled cypher's 96 GB disk and crashed its `fresh-db` container mid-run. Two coupled causes:
+
+1. **Schemas accumulate.** Cypher carried `fresh` (Sun, ~25 GB) + `fresh_default` (yesterday, ~25 GB) + partial `fresh_default_extrabreaks` (today, ~30 GB) + ~60 `working_<wsg>` schemas (~10–15 GB) — none ever dropped after consolidation.
+2. **Extras inflate per-row counts ~2.8×.** Capacity planning for `default` doesn't survive an `extras` overlay.
+
+Workers are dispatched as one-shot ETL — once `pg_dump → scp → pg_restore` lands data on M4, the worker copy is dead weight.
+
+**Approach:** orchestrator-level cleanup (in `compare_bcfishpass_wsg.R` + `consolidate_schema.R`), not in-package. Issue body's first option (drop in `lnk_pipeline_persist`) breaks the compare script's rollup query, which reads `<schema>.streams` + long-form `<schema>.streams_habitat` AFTER persist runs. Keep `lnk_pipeline_persist` scoped to one job; orchestrator owns the lifecycle.
+
+## Phase 1: working_<aoi> cleanup in `compare_bcfishpass_wsg.R`
+
+- [ ] Add `cleanup_working = TRUE` parameter to `compare_bcfishpass_wsg()` signature.
+- [ ] After the rollup tibble is built and `stamp` is captured, before `return(out)`, add a `DROP SCHEMA <working> CASCADE` block guarded by `if (isTRUE(cleanup_working))`.
+- [ ] Brief comment explaining the cleanup contract: working schema's job done once rollup is computed and persistent rows are written.
+- [ ] Verify nothing else after the rollup query needs the working schema.
+- [ ] ADMS smoke. Confirm rollup byte-identical to v0.28.0 baseline, and `\dn working_adms` returns 0 rows post-run.
+- [ ] `/code-check` on staged diff.
+
+## Phase 2: source schema drop in `consolidate_schema.R`
+
+- [ ] Add `keep_source = FALSE` parameter to `consolidate_schema()`.
+- [ ] After successful per-source `pg_restore` (rc == 0L), run `DROP SCHEMA <schema> CASCADE` against the SOURCE host via the same SSH/docker-exec pattern used for `pg_dump`.
+- [ ] Failure path: leave source schema in place if `pg_restore` failed.
+- [ ] Document the new default in roxygen + the data-raw README inventory entry.
+- [ ] Manual smoke: run with a small synthetic schema on one host, verify source dropped.
+- [ ] `/code-check` on staged diff.
+
+## Phase 3: capacity planning note in `data-raw/README.md`
+
+- [ ] Add "Disk capacity per host" section: per-bundle footprint, extras 3× multiplier, recommended minimum free disk per worker (60 GB safe floor), today's cypher incident as cautionary tale.
+- [ ] Cross-link from `data-raw/logs/README.md`.
+
+## Phase 4: end-to-end regression
+
+- [ ] M4-only single-host provincial run on `default` bundle (no trifecta needed) — verifies Phase 1 cleanup. Acceptance: zero `working_*` schemas post-run; rollup RDS byte-identical on a small WSG sample (ADMS, BABL, BULK).
+- [ ] Manual consolidation rehearsal on M1: pg_dump small schema → restore on M4 → verify M1's source schema dropped. Verifies Phase 2.
+- [ ] Defer full 3-host trifecta verification until next planned provincial run (cypher needs fwapg reload anyway).
+- [ ] Stamped log under `data-raw/logs/<TS>_link118_regression.txt`.
+
+## Phase 5: release
+
+- [ ] `NEWS.md` 0.29.0 entry (DB hygiene + cleanup contracts).
+- [ ] `DESCRIPTION` 0.28.0 → 0.29.0.
+- [ ] PR body references #118 + SRED cross-ref (`Relates to NewGraphEnvironment/sred-2025-2026#24`).
+
+## Validation
+
+- [ ] Tests pass
+- [ ] `/code-check` clean on each commit
+- [ ] PWF checkboxes match landed work
+- [ ] `/planning-archive` on completion


### PR DESCRIPTION
## Summary

Closes #118. DB hygiene to prevent the disk-full incident that crashed cypher's `fresh-db` container during the 2026-05-04 `default_extrabreaks` provincial trifecta. Two-tier orchestrator-level cleanup; no in-package API changes.

## What changed

| File | Change |
|------|--------|
| `data-raw/compare_bcfishpass_wsg.R` | New `cleanup_working = TRUE` parameter — drops `working_<aoi>` CASCADE after the rollup tibble is built. Default-on (pass FALSE for interactive debug). Saves ~10–15 GB per provincial run on every host. |
| `data-raw/consolidate_schema.R` | New `keep_source = FALSE` parameter — drops source schema on each remote host after successful pg_restore. rc-guarded (failed restore leaves source for retry); warn-but-don't-fail on drop rc != 0. Saves ~25–30 GB per consolidated bundle on M1 + cypher. |
| `data-raw/README.md` | New "Disk capacity per worker host" section: per-bundle footprint table, extras 2.8× multiplier, 60 GB safe-floor recommendation, 2026-05-04 cypher incident as cautionary tale. |
| `NEWS.md` + `DESCRIPTION` | 0.28.0 → 0.29.0 |

## Why orchestrator-level, not in-package

Issue body's first proposal ("`lnk_pipeline_persist` drops `working_<aoi>` after persist completes") looks clean but breaks the compare script's rollup query path. The rollup reads `<schema>.streams` + long-format `<schema>.streams_habitat` (with a `species_code` column) AFTER `lnk_pipeline_persist` returns. The persistent schema is wide-per-species (`streams_habitat_<sp>` without `species_code`), so the rollup query can't trivially port to the persistent tables. In-package drop would force a rollup rewrite to wide format — bigger lift than this issue warranted.

Issue body's parenthetical ("or as the final step of `compare_bcfishpass_wsg`") is the cleaner shape: keeps `lnk_pipeline_persist` scoped to one job; orchestrator owns the lifecycle.

## Verification

- ADMS smoke (Phase 1): rollup `identical()` TRUE vs pre-cleanup baseline; `working_adms` confirmed dropped post-run.
- Suite: 736 PASS / 0 FAIL.
- Multi-WSG + cross-host consolidation rehearsal deferred to next real provincial run (cypher's fwapg needs reload first; small ADMS smoke through M1 will catch any regression then).

## Test plan

- [x] `devtools::test()` — 736 PASS / 0 FAIL
- [x] ADMS smoke via `compare_bcfishpass_wsg("ADMS", lnk_config("default_extrabreaks"))` — rollup byte-identical, working schema dropped
- [x] `consolidate_schema()` parses with new param signature
- [ ] Cross-host consolidation rehearsal — deferred (cypher needs fwapg reload)

## Cross-refs

- #117 — csv-sync weekly + tunnel-SHA-pin (independent)
- fresh#199 / rtj#98 / rtj#99 — postgres tuning (independent, all on the same hosts but different concerns)

Relates to NewGraphEnvironment/sred-2025-2026#24
