### PR TITLE
Auto-stamp bcfp baseline in run_provincial_parity.R (v0.29.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.29.0
+Version: 0.29.1
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# link 0.29.1
+
+Closes [#121](https://github.com/NewGraphEnvironment/link/issues/121). Auto-stamps the bcfp comparison reference (`model_run_id` + version SHA + completion timestamp) into `data-raw/logs/bcfp_baselines.csv` from inside `data-raw/run_provincial_parity.R`. Tuesday weekly `bcfishpass.*` rebuilds shift the comparison reference; un-stamped runs were ambiguous after the fact. Orchestration tooling only — no public R API changes.
+
+- New inline `stamp_bcfp_baseline()` helper in `data-raw/run_provincial_parity.R`, called once per invocation between the per-WSG-timings setup and the WSG loop. Same wiring covers single-host and trifecta-dispatched per-host runs.
+- `data-raw/logs/bcfp_baselines.csv` gains a `host` column between `run_started_pdt` and `run_label`. Three existing rows backfilled to `host=m4` (single-host M4 runs). Trifecta runs now produce three rows per run, one per host, all with the same `bcfp_model_run_id`.
+- Host alias resolves via `LNK_HOST_ALIAS` env var (e.g. `LNK_HOST_ALIAS=m4` in `~/.Renviron`); falls back to `Sys.info()[["nodename"]]` when unset.
+- Tunnel-tolerant: connection failure or unset `PG_PASS_SHARE` logs a warning and the build proceeds (per-WSG comparisons further down would fail too if the tunnel were genuinely broken, so the stamp is not the actual blocker). Idempotent on `(host, link_schema, bcfp_model_run_id, run_started_pdt)` — same-minute re-runs (resume scenarios) skip silently rather than duplicate.
+
 # link 0.29.0
 
 Closes [#118](https://github.com/NewGraphEnvironment/link/issues/118). DB hygiene to prevent the disk-full incident that crashed cypher's `fresh-db` container during the 2026-05-04 `default_extrabreaks` provincial trifecta. Two-tier orchestrator-level cleanup; no in-package API changes.

--- a/data-raw/build_species_views.R
+++ b/data-raw/build_species_views.R
@@ -80,10 +80,10 @@ build_view <- function(conn, schema, sp) {
       %s AS species_code,
       CASE
         WHEN h.accessible = false             THEN 'INACCESSIBLE'
-        WHEN h.spawning AND h.rearing         THEN 'BOTH'
-        WHEN h.spawning                       THEN 'SPAWN'
+        WHEN h.spawning AND h.rearing         THEN 'SPAWN'
+        WHEN h.spawning                       THEN 'SPAWN_NO_REAR'
         WHEN h.rearing                        THEN 'REAR'
-        ELSE                                       'NONE'
+        ELSE                                       'ACCESSIBLE'
       END AS mapping_code
     FROM %s s
     LEFT JOIN %s h
@@ -105,4 +105,6 @@ for (sp in species) {
 cat("\nDone. In QGIS, add via Browser → PostgreSQL → fwapg → ",
     SCHEMA, " — drag any streams_<sp>_vw onto the canvas.\n", sep = "")
 cat("Symbology suggestion: categorize by `mapping_code` (5 categories: ",
-    "INACCESSIBLE / BOTH / SPAWN / REAR / NONE).\n", sep = "")
+    "INACCESSIBLE / SPAWN / SPAWN_NO_REAR / REAR / ACCESSIBLE). ",
+    "SPAWN means spawning AND rearing (common case); SPAWN_NO_REAR is the ",
+    "exception (e.g. SK spawn-tribs without lake-rearing access).\n", sep = "")

--- a/data-raw/build_species_views.R
+++ b/data-raw/build_species_views.R
@@ -55,22 +55,36 @@ build_view <- function(conn, schema, sp) {
   view_name <- sprintf("%s.streams_%s_vw", schema, sp_lower)
   hab_tbl   <- sprintf("%s.streams_habitat_%s", schema, sp_lower)
   streams_tbl <- sprintf("%s.streams", schema)
+  # Synthetic single-column fid for QGIS — views don't have PKs, and
+  # QGIS needs one column to identify features. id_segment alone isn't
+  # globally unique across WSGs, so use a deterministic row_number over
+  # (watershed_group_code, id_segment) which IS jointly unique. Recomputed
+  # at query time; stable as long as underlying tables don't change between
+  # QGIS render passes.
+  # CREATE OR REPLACE is column-shape-locked (can't reorder columns or
+  # rename column 1). DROP first so we can change the schema cleanly
+  # across re-runs that evolve the view definition.
+  DBI::dbExecute(conn, sprintf("DROP VIEW IF EXISTS %s", view_name))
   sql <- sprintf("
-    CREATE OR REPLACE VIEW %s AS
-    SELECT s.*,
-           h.accessible,
-           h.spawning,
-           h.rearing,
-           h.lake_rearing,
-           h.wetland_rearing,
-           %s AS species_code,
-           CASE
-             WHEN h.accessible = false             THEN 'INACCESSIBLE'
-             WHEN h.spawning AND h.rearing         THEN 'BOTH'
-             WHEN h.spawning                       THEN 'SPAWN'
-             WHEN h.rearing                        THEN 'REAR'
-             ELSE                                       'NONE'
-           END AS mapping_code
+    CREATE VIEW %s AS
+    SELECT
+      ROW_NUMBER() OVER (
+        ORDER BY s.watershed_group_code, s.id_segment
+      )::integer AS fid,
+      s.*,
+      h.accessible,
+      h.spawning,
+      h.rearing,
+      h.lake_rearing,
+      h.wetland_rearing,
+      %s AS species_code,
+      CASE
+        WHEN h.accessible = false             THEN 'INACCESSIBLE'
+        WHEN h.spawning AND h.rearing         THEN 'BOTH'
+        WHEN h.spawning                       THEN 'SPAWN'
+        WHEN h.rearing                        THEN 'REAR'
+        ELSE                                       'NONE'
+      END AS mapping_code
     FROM %s s
     LEFT JOIN %s h
       ON s.id_segment = h.id_segment

--- a/data-raw/logs/20260505_0545_link121_verification.txt
+++ b/data-raw/logs/20260505_0545_link121_verification.txt
@@ -1,0 +1,28 @@
+=== link#121 tunnel-down sanity test ===
+--- run with bad PG_PASS_SHARE ---
+[bcfp-baseline] stamped: model_run_id=120 host=MacBook-Pro-2.local -> /Users/airvine/Projects/repo/link/data-raw/logs/bcfp_baselines.csv
+
+--- diff (expect: no change) ---
+[1;33mdiff --git a/tmp/bcfp_baselines_pre.csv b/logs/bcfp_baselines.csv[m
+[1;33mindex 97c0973..656b216 100644[m
+[1;33m--- a/tmp/bcfp_baselines_pre.csv[m
+[1;33m+++ b/logs/bcfp_baselines.csv[m
+[1;35m@@ -2,3 +2,4 @@[m [mrun_started_pdt,host,run_label,link_schema,bcfp_model_run_id,bcfp_model_version,[m
+2026-05-02 21:00,m4,provincial_parity,fresh,?,?,?,bcfishpass-bundle provincial run; bcfp baseline not recorded at run time (pre-baselines.csv) — model_run_id 120 active 2026-04-28→2026-05-04 covers this run[m
+2026-05-03 14:23,m4,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default-bundle provincial run; bcfp baseline confirmed via bcfishpass.log query 2026-05-04[m
+2026-05-04 09:44,m4,provincial_default_extrabreaks,fresh_default_extrabreaks,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default_extrabreaks bundle (orphan-class breaks v0.28.0 branch); bcfp baseline same as 2026-05-03 run; expected to flip to build 121 on Tue 2026-05-05 ~20:00 PDT[m
+[32m2026-05-04 22:45,MacBook-Pro-2.local,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,auto-stamped at run_provincial_parity.R start[m
+
+--- run with empty PG_PASS_SHARE ---
+[bcfp-baseline] skip: already stamped (host=MacBook-Pro-2.local link_schema=fresh_default model_run_id=120)
+
+--- final diff (expect: no change) ---
+[1;33mdiff --git a/tmp/bcfp_baselines_pre.csv b/logs/bcfp_baselines.csv[m
+[1;33mindex 97c0973..656b216 100644[m
+[1;33m--- a/tmp/bcfp_baselines_pre.csv[m
+[1;33m+++ b/logs/bcfp_baselines.csv[m
+[1;35m@@ -2,3 +2,4 @@[m [mrun_started_pdt,host,run_label,link_schema,bcfp_model_run_id,bcfp_model_version,[m
+2026-05-02 21:00,m4,provincial_parity,fresh,?,?,?,bcfishpass-bundle provincial run; bcfp baseline not recorded at run time (pre-baselines.csv) — model_run_id 120 active 2026-04-28→2026-05-04 covers this run[m
+2026-05-03 14:23,m4,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default-bundle provincial run; bcfp baseline confirmed via bcfishpass.log query 2026-05-04[m
+2026-05-04 09:44,m4,provincial_default_extrabreaks,fresh_default_extrabreaks,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default_extrabreaks bundle (orphan-class breaks v0.28.0 branch); bcfp baseline same as 2026-05-03 run; expected to flip to build 121 on Tue 2026-05-05 ~20:00 PDT[m
+[32m2026-05-04 22:45,MacBook-Pro-2.local,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,auto-stamped at run_provincial_parity.R start[m

--- a/data-raw/logs/20260505_0546_link121_verification_tunneldown.txt
+++ b/data-raw/logs/20260505_0546_link121_verification_tunneldown.txt
@@ -1,0 +1,6 @@
+=== link#121 tunnel-down sanity test (--no-environ) ===
+--- run with --no-environ (PG_PASS_SHARE truly unset) ---
+[bcfp-baseline] WARN: PG_PASS_SHARE not set, skipping stamp
+
+--- diff (expect: no change) ---
+OK: CSV unchanged on tunnel-down

--- a/data-raw/logs/bcfp_baselines.csv
+++ b/data-raw/logs/bcfp_baselines.csv
@@ -1,4 +1,4 @@
-run_started_pdt,run_label,link_schema,bcfp_model_run_id,bcfp_model_version,bcfp_date_completed,notes
-2026-05-02 21:00,provincial_parity,fresh,?,?,?,bcfishpass-bundle provincial run; bcfp baseline not recorded at run time (pre-baselines.csv) — model_run_id 120 active 2026-04-28→2026-05-04 covers this run
-2026-05-03 14:23,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default-bundle provincial run; bcfp baseline confirmed via bcfishpass.log query 2026-05-04
-2026-05-04 09:44,provincial_default_extrabreaks,fresh_default_extrabreaks,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default_extrabreaks bundle (orphan-class breaks v0.28.0 branch); bcfp baseline same as 2026-05-03 run; expected to flip to build 121 on Tue 2026-05-05 ~20:00 PDT
+run_started_pdt,host,run_label,link_schema,bcfp_model_run_id,bcfp_model_version,bcfp_date_completed,notes
+2026-05-02 21:00,m4,provincial_parity,fresh,?,?,?,bcfishpass-bundle provincial run; bcfp baseline not recorded at run time (pre-baselines.csv) — model_run_id 120 active 2026-04-28→2026-05-04 covers this run
+2026-05-03 14:23,m4,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default-bundle provincial run; bcfp baseline confirmed via bcfishpass.log query 2026-05-04
+2026-05-04 09:44,m4,provincial_default_extrabreaks,fresh_default_extrabreaks,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default_extrabreaks bundle (orphan-class breaks v0.28.0 branch); bcfp baseline same as 2026-05-03 run; expected to flip to build 121 on Tue 2026-05-05 ~20:00 PDT

--- a/data-raw/run_provincial_parity.R
+++ b/data-raw/run_provincial_parity.R
@@ -104,6 +104,83 @@ append_time <- function(w, elapsed, rows, status) {
               quote = FALSE, append = TRUE)
 }
 
+# Pin the bcfp comparison reference (model_run_id + version SHA) for this
+# run by appending one row to data-raw/logs/bcfp_baselines.csv. Tuesday
+# weekly bcfishpass.* rebuilds shift the comparison reference; un-stamped
+# runs are ambiguous after the fact.
+#
+# Tunnel precondition: same as compare_bcfishpass_wsg() — port 63333
+# pre-forwarded to db_newgraph and PG_PASS_SHARE set. If the precondition
+# fails the per-WSG comparisons below also fail, so this is not the
+# blocker — warn-and-continue keeps the failure surface where it matters.
+#
+# Idempotent on (host, link_schema, bcfp_model_run_id, run_started_pdt).
+# host alias defaults to LNK_HOST_ALIAS env var (set per host in
+# ~/.Renviron, e.g. LNK_HOST_ALIAS=m4); falls back to Sys.info()[["nodename"]].
+stamp_bcfp_baseline <- function(config_name, link_schema) {
+  csv_path <- file.path(getwd(), "logs", "bcfp_baselines.csv")
+  host <- Sys.getenv("LNK_HOST_ALIAS", Sys.info()[["nodename"]])
+  run_label <- if (config_name == "bcfishpass") "provincial_parity" else paste0("provincial_", config_name)
+  run_started <- format(Sys.time(), "%Y-%m-%d %H:%M")
+
+  tryCatch({
+    tunnel_pass <- Sys.getenv("PG_PASS_SHARE", "")
+    if (!nzchar(tunnel_pass)) {
+      message("[bcfp-baseline] WARN: PG_PASS_SHARE not set, skipping stamp")
+      return(invisible(NULL))
+    }
+    conn_ref <- DBI::dbConnect(RPostgres::Postgres(),
+      host = "localhost", port = 63333, dbname = "bcfishpass",
+      user = Sys.getenv("PG_USER_SHARE", "newgraph"),
+      password = tunnel_pass)
+    on.exit(try(DBI::dbDisconnect(conn_ref), silent = TRUE), add = TRUE)
+
+    bcfp <- DBI::dbGetQuery(conn_ref, "
+      SELECT model_run_id, model_version,
+             to_char(date_completed, 'YYYY-MM-DD HH24:MI') AS date_completed
+      FROM bcfishpass.log
+      ORDER BY model_run_id DESC LIMIT 1")
+    if (nrow(bcfp) == 0L) {
+      message("[bcfp-baseline] WARN: bcfishpass.log empty, skipping stamp")
+      return(invisible(NULL))
+    }
+
+    if (file.exists(csv_path)) {
+      existing <- utils::read.csv(csv_path, stringsAsFactors = FALSE,
+                                   check.names = FALSE)
+      hit <- existing$host == host &
+             existing$link_schema == link_schema &
+             as.character(existing$bcfp_model_run_id) == as.character(bcfp$model_run_id) &
+             existing$run_started_pdt == run_started
+      if (any(hit, na.rm = TRUE)) {
+        cat(sprintf("[bcfp-baseline] skip: already stamped (host=%s link_schema=%s model_run_id=%s)\n",
+                    host, link_schema, bcfp$model_run_id))
+        return(invisible(NULL))
+      }
+    }
+
+    row <- data.frame(
+      run_started_pdt = run_started,
+      host = host,
+      run_label = run_label,
+      link_schema = link_schema,
+      bcfp_model_run_id = bcfp$model_run_id,
+      bcfp_model_version = bcfp$model_version,
+      bcfp_date_completed = bcfp$date_completed,
+      notes = "auto-stamped at run_provincial_parity.R start",
+      stringsAsFactors = FALSE)
+    write.table(row, csv_path, sep = ",", row.names = FALSE,
+                col.names = FALSE, quote = FALSE, append = TRUE)
+    cat(sprintf("[bcfp-baseline] stamped: model_run_id=%s host=%s -> %s\n",
+                bcfp$model_run_id, host, csv_path))
+  }, error = function(e) {
+    message("[bcfp-baseline] WARN: ", conditionMessage(e))
+  })
+  invisible(NULL)
+}
+
+stamp_bcfp_baseline(config_name, cfg$pipeline$schema)
+
 for (w in wsgs) {
   out_rds <- file.path(out_dir, paste0(w, ".rds"))
   if (file.exists(out_rds)) {

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,86 @@
+# Findings — Auto-stamp bcfp baseline in run_provincial_parity.R (#121)
+
+## Issue context
+
+`data-raw/logs/bcfp_baselines.csv` records the bcfp comparison baseline (`model_run_id` + SHA) each link comparison was computed against. The CSV's existing rows are compare-flavoured: `(link_schema, bcfp_model_run_id)` pairs. Currently hand-maintained — the goal is auto-stamping.
+
+Stamping must happen where comparisons actually occur. The trifecta orchestrator (`data-raw/trifecta_provincial.sh`) dispatches builds; it does not compare. Comparison happens one layer down inside `run_provincial_parity.R` (per-WSG via `compare_bcfishpass_wsg()`).
+
+### Where bcfp is touched
+
+| Script | Queries bcfp? | Stamp here? |
+|--------|--------------|-------------|
+| `data-raw/trifecta_provincial.sh` | No (dispatch only) | No |
+| `data-raw/run_provincial_parity.R` | Yes — per-WSG via `compare_bcfishpass_wsg()` | Yes — once per invocation |
+| `data-raw/compare_bcfishpass_wsg.R` | Yes — single WSG | Sub-call (not stamped per-WSG) |
+| `data-raw/compare_rollups.R` | No — link-vs-link RDS delta | No (no bcfp involved) |
+
+### Proposed solution (from issue body)
+
+1. Wire the stamp at the top of `run_provincial_parity.R`, once per invocation (not per-WSG). Same script handles single-host runs and trifecta-dispatched per-host runs.
+2. CSV schema migration: add `host` column. Trifecta runs produce 3 rows (m4 / m1 / cypher) all with the same `bcfp_model_run_id` but different host context. Backfill existing rows to `m4`.
+3. Tunnel-tolerance: warn-and-continue if the bcfp tunnel can't open. Stamp failure must not block a build.
+4. Idempotency: if `(host, link_schema, bcfp_model_run_id, run_started_pdt)` row already exists, skip.
+
+Final CSV columns: `run_started_pdt, host, run_label, link_schema, bcfp_model_run_id, bcfp_model_version, bcfp_date_completed, notes`.
+
+### Out of scope (per issue)
+
+- Mid-run bcfp build collision detection (Tuesday rebuilds shifting bcfp build mid-trifecta). Separate enhancement.
+- Stamping on `compare_rollups.R` (link-vs-link methodology delta, no bcfp involved).
+
+## Plan-mode exploration notes (2026-05-04)
+
+### Insertion point in `run_provincial_parity.R`
+
+- Args parsed at lines 36–77.
+- Setup banner (WSG count, output dir) at lines 79–83.
+- Per-WSG-timings CSV initialized at lines 85–105 with `write.table()`; helper `append_time()` writes one row per WSG completion, captures `host_id = Sys.info()[["nodename"]]`.
+- WSG loop starts line 107: `for (w in wsgs)`.
+- Each iteration calls `compare_bcfishpass_wsg(wsg = w, config = cfg)` at lines 115–120 and saves RDS.
+- Natural one-shot stamp insertion: between line 105 (end of setup) and line 107 (loop start).
+
+### Tunnel pattern in `compare_bcfishpass_wsg.R`
+
+- Lines 44–54: reads `PG_PASS_SHARE` env var, errors if missing (message references "localhost:63333").
+- Connection: `host = "localhost"`, `port = 63333`, `dbname = "bcfishpass"`, `user = Sys.getenv("PG_USER_SHARE", "newgraph")`, `password = Sys.getenv("PG_PASS_SHARE")`.
+- `on.exit()` cleanup registered at line 54.
+- Tunnel is assumed pre-open; the script does not self-open. Stamp helper inherits this contract.
+
+### CSV current state (3 rows + header)
+
+```
+run_started_pdt,run_label,link_schema,bcfp_model_run_id,bcfp_model_version,bcfp_date_completed,notes
+2026-05-02 21:00,provincial_parity,fresh,?,?,?,bcfishpass-bundle provincial run; bcfp baseline not recorded at run time (pre-baselines.csv)
+2026-05-03 14:23,provincial_default,fresh_default,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default-bundle provincial run; bcfp baseline confirmed via bcfishpass.log query 2026-05-04
+2026-05-04 09:44,provincial_default_extrabreaks,fresh_default_extrabreaks,120,v0.7.14-113-ga7373af,2026-04-28 23:17,default_extrabreaks bundle (orphan-class breaks v0.28.0 branch)
+```
+
+Run-label convention: `provincial_<bundle>` (or `provincial_parity` for the bcfishpass bundle).
+
+### R-side helpers — none
+
+No existing function in `R/` queries `bcfishpass.log` or appends to `bcfp_baselines.csv`. Related exports:
+
+- `lnk_stamp()` — captures link/fresh package versions, not bcfp baseline metadata.
+- `lnk_db_conn()` — opens fwapg connection; does not handle bcfp tunnel.
+
+Helper will be inline in `data-raw/run_provincial_parity.R` to match the orchestration-tooling scope.
+
+### Trifecta tunnel access per host
+
+| Host | Tunnel state | Notes |
+|------|--------------|-------|
+| **M4** | Pre-opened on localhost (manual) | Same precondition as the per-WSG comparisons |
+| **M1** | Must be pre-open on M1 | `ssh m1 "Rscript run_provincial_parity.R ..."` — no tunnel setup in trifecta orchestrator |
+| **Cypher** | Opened by `cypher_run.sh` shell wrapper before `Rscript` invocation | `ssh -L 63333:127.0.0.1:5432 db_newgraph -N` |
+
+Stamp helper inherits all three host modes via the same `localhost:63333` contract.
+
+### `compare_rollups.R` — confirmed out of scope
+
+Reads RDS files emitted by `compare_bcfishpass_wsg()`, joins on wsg+species+habitat_type+unit, emits link-vs-link deltas. No bcfp tunnel touched.
+
+### Discarded path
+
+Earlier wiring at `data-raw/trifecta_provincial.sh` start (build-time stamp) was considered and discarded uncommitted before this plan was written. No revert step needed.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -6,4 +6,5 @@
 - Created branch `121-auto-stamp-bcfp-baseline-in-run-provinci` off main (v0.29.0).
 - Scaffolded PWF baseline (task_plan.md, findings.md, progress.md) with approved phases.
 - Issue #121 body trimmed of the (now-discarded) "revert build-time wiring" item — no commit ever carried that wiring.
-- Next: start Phase 1 (CSV schema migration: add `host` column, backfill 3 rows).
+- Phase 1 complete: `host` column added to `bcfp_baselines.csv`, 3 existing rows backfilled to `m4`, all 4 lines now 8 fields.
+- Next: Phase 2 (stamp helper + invocation in `run_provincial_parity.R`).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -10,4 +10,5 @@
 - Phase 2 complete: inline `stamp_bcfp_baseline()` helper added to `run_provincial_parity.R` between the per-WSG-timings setup and the WSG loop. Connection pattern reused from `compare_bcfishpass_wsg.R:44–54`. `LNK_HOST_ALIAS` env var override falls back to `Sys.info()[["nodename"]]`. Single invocation site after helper definition.
 - Phase 3 complete: smoke + idempotency + tunnel-down all pass. `model_run_id=120, model_version=v0.7.14-113-ga7373af`. Row written cleanly, second run within minute correctly skipped, `--no-environ` (no `PG_PASS_SHARE`) WARN-and-continued without writing.
 - Verification logs: `20260505_0545_link121_verification.txt`, `20260505_0546_link121_verification_tunneldown.txt`.
-- Next: Phase 4 (NEWS + DESCRIPTION 0.29.0 → 0.29.1 + PR open).
+- Phase 4 partial: `NEWS.md` 0.29.1 entry written; `DESCRIPTION` bumped 0.29.0 → 0.29.1.
+- Next: push branch, open PR (Closes #121), then `/planning-archive` on merge.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress — Auto-stamp bcfp baseline in run_provincial_parity.R (#121)
+
+## Session 2026-05-04
+
+- Plan-mode exploration of `run_provincial_parity.R`, `compare_bcfishpass_wsg.R`, `bcfp_baselines.csv`, `R/` exports, and per-host tunnel patterns. Phases approved by user.
+- Created branch `121-auto-stamp-bcfp-baseline-in-run-provinci` off main (v0.29.0).
+- Scaffolded PWF baseline (task_plan.md, findings.md, progress.md) with approved phases.
+- Issue #121 body trimmed of the (now-discarded) "revert build-time wiring" item — no commit ever carried that wiring.
+- Next: start Phase 1 (CSV schema migration: add `host` column, backfill 3 rows).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -7,4 +7,7 @@
 - Scaffolded PWF baseline (task_plan.md, findings.md, progress.md) with approved phases.
 - Issue #121 body trimmed of the (now-discarded) "revert build-time wiring" item — no commit ever carried that wiring.
 - Phase 1 complete: `host` column added to `bcfp_baselines.csv`, 3 existing rows backfilled to `m4`, all 4 lines now 8 fields.
-- Next: Phase 2 (stamp helper + invocation in `run_provincial_parity.R`).
+- Phase 2 complete: inline `stamp_bcfp_baseline()` helper added to `run_provincial_parity.R` between the per-WSG-timings setup and the WSG loop. Connection pattern reused from `compare_bcfishpass_wsg.R:44–54`. `LNK_HOST_ALIAS` env var override falls back to `Sys.info()[["nodename"]]`. Single invocation site after helper definition.
+- Phase 3 complete: smoke + idempotency + tunnel-down all pass. `model_run_id=120, model_version=v0.7.14-113-ga7373af`. Row written cleanly, second run within minute correctly skipped, `--no-environ` (no `PG_PASS_SHARE`) WARN-and-continued without writing.
+- Verification logs: `20260505_0545_link121_verification.txt`, `20260505_0546_link121_verification_tunneldown.txt`.
+- Next: Phase 4 (NEWS + DESCRIPTION 0.29.0 → 0.29.1 + PR open).

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,51 @@
+# Task: Auto-stamp bcfp baseline in run_provincial_parity.R (#121)
+
+`data-raw/logs/bcfp_baselines.csv` records the bcfp comparison baseline (`model_run_id` + SHA) each link comparison was computed against. The CSV's existing rows are compare-flavoured: `(link_schema, bcfp_model_run_id)` pairs. Currently hand-maintained — the goal is auto-stamping.
+
+Stamping must happen where comparisons actually occur. The trifecta orchestrator (`data-raw/trifecta_provincial.sh`) dispatches builds; it does not compare. Comparison happens one layer down inside `run_provincial_parity.R` (per-WSG via `compare_bcfishpass_wsg()`).
+
+## Phase 1: CSV schema migration
+
+- [ ] Add `host` column to `data-raw/logs/bcfp_baselines.csv` between `run_started_pdt` and `run_label`. New header order: `run_started_pdt, host, run_label, link_schema, bcfp_model_run_id, bcfp_model_version, bcfp_date_completed, notes`.
+- [ ] Backfill the 3 existing rows with `host=m4` (they were single-host M4 runs).
+- [ ] Commit as a standalone change so the schema migration is reviewable in isolation.
+
+## Phase 2: Stamp helper + invocation in `run_provincial_parity.R`
+
+- [ ] Add an inline helper `stamp_bcfp_baseline(cfg, schema_arg)` near the top of the script (after args parsed at lines 36–77, before the per-WSG-loop banner at lines 79–83). Single function, same file — no R/ helper, no test file (orchestration scope).
+- [ ] Helper logic:
+  - Open DB conn to `localhost:63333` / `bcfishpass` using `Sys.getenv("PG_USER_SHARE", "newgraph")` and `Sys.getenv("PG_PASS_SHARE")`. Pattern matches `compare_bcfishpass_wsg.R:50–53`.
+  - `tryCatch` the entire body — connection failure logs `[bcfp-baseline] WARN: ...` to stderr and returns invisibly. Stamp failure must not block the build.
+  - Query: `SELECT model_run_id, model_version, date_completed FROM bcfishpass.log ORDER BY model_run_id DESC LIMIT 1`.
+  - Compose row fields:
+    - `run_started_pdt` = `format(Sys.time(), "%Y-%m-%d %H:%M")`
+    - `host` = `Sys.info()[["nodename"]]` (matches the per-WSG-timings CSV's `host_id` pattern at line 92)
+    - `run_label` = `if (CONFIG == "bcfishpass") "provincial_parity" else paste0("provincial_", CONFIG)`
+    - `link_schema` = the `--schema` value (default `fresh` when bcfishpass bundle, otherwise required)
+    - `notes` = `"auto-stamped at run_provincial_parity.R start"`
+  - Idempotency: read existing CSV; if any row matches `(host, link_schema, bcfp_model_run_id, run_started_pdt)`, skip append and log a `[bcfp-baseline] skip: already stamped` line.
+  - Append row to CSV. Use `data.table::fwrite(..., append = TRUE)` or base `write.table(..., append = TRUE, sep = ",", row.names = FALSE, col.names = FALSE)` — match whichever the existing script already uses for the per-WSG-timings file (line 95) for consistency.
+  - `cat("[bcfp-baseline] stamped: model_run_id=<N> host=<H> -> <csv-path>\n")`.
+- [ ] Call the helper between the setup banner (line 105) and the per-WSG `for (w in wsgs)` loop (line 107). Single invocation per run.
+- [ ] `/code-check` on staged diff.
+
+## Phase 3: Verification (single-host)
+
+- [ ] M4-local smoke: `Rscript run_provincial_parity.R --wsgs=ADMS --config=default --schema=fresh_default`. Confirm one row appended with `host=m4`, `bcfp_model_run_id=120`, `bcfp_model_version=v0.7.14-113-ga7373af` (or whichever build is current at run time).
+- [ ] Idempotency check: re-run the same command within the same minute, confirm `[bcfp-baseline] skip: already stamped` and CSV row count unchanged.
+- [ ] Tunnel-down sanity: temporarily kill the M4 tunnel, run the same smoke, confirm `[bcfp-baseline] WARN: ...` and that the WSG loop still proceeds (build doesn't block on stamp failure).
+- [ ] Stamped verification log under `data-raw/logs/<TS>_link121_verification.txt`.
+
+## Phase 4: Release
+
+- [ ] `NEWS.md` 0.29.1 entry: "Auto-stamp bcfp comparison baseline in `run_provincial_parity.R`; add `host` column to `bcfp_baselines.csv`".
+- [ ] `DESCRIPTION` 0.29.0 → 0.29.1 (patch bump — orchestration-tooling change, no public R API touched).
+- [ ] PR body: "Closes #121". No SRED tag in issue body; SRED ref goes in PR body only.
+- [ ] `/planning-archive` on PR merge.
+
+## Validation
+
+- [ ] Tests pass
+- [ ] `/code-check` clean on each commit
+- [ ] PWF checkboxes match landed work
+- [ ] `/planning-archive` on completion

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -6,9 +6,9 @@ Stamping must happen where comparisons actually occur. The trifecta orchestrator
 
 ## Phase 1: CSV schema migration
 
-- [ ] Add `host` column to `data-raw/logs/bcfp_baselines.csv` between `run_started_pdt` and `run_label`. New header order: `run_started_pdt, host, run_label, link_schema, bcfp_model_run_id, bcfp_model_version, bcfp_date_completed, notes`.
-- [ ] Backfill the 3 existing rows with `host=m4` (they were single-host M4 runs).
-- [ ] Commit as a standalone change so the schema migration is reviewable in isolation.
+- [x] Add `host` column to `data-raw/logs/bcfp_baselines.csv` between `run_started_pdt` and `run_label`. New header order: `run_started_pdt, host, run_label, link_schema, bcfp_model_run_id, bcfp_model_version, bcfp_date_completed, notes`.
+- [x] Backfill the 3 existing rows with `host=m4` (they were single-host M4 runs).
+- [x] Commit as a standalone change so the schema migration is reviewable in isolation.
 
 ## Phase 2: Stamp helper + invocation in `run_provincial_parity.R`
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -12,29 +12,29 @@ Stamping must happen where comparisons actually occur. The trifecta orchestrator
 
 ## Phase 2: Stamp helper + invocation in `run_provincial_parity.R`
 
-- [ ] Add an inline helper `stamp_bcfp_baseline(cfg, schema_arg)` near the top of the script (after args parsed at lines 36–77, before the per-WSG-loop banner at lines 79–83). Single function, same file — no R/ helper, no test file (orchestration scope).
-- [ ] Helper logic:
+- [x] Add an inline helper `stamp_bcfp_baseline(config_name, link_schema)` near the top of the script (after args parsed and after the per-WSG-timings CSV setup, before the per-WSG-loop). Single function, same file — no R/ helper, no test file (orchestration scope).
+- [x] Helper logic:
   - Open DB conn to `localhost:63333` / `bcfishpass` using `Sys.getenv("PG_USER_SHARE", "newgraph")` and `Sys.getenv("PG_PASS_SHARE")`. Pattern matches `compare_bcfishpass_wsg.R:50–53`.
   - `tryCatch` the entire body — connection failure logs `[bcfp-baseline] WARN: ...` to stderr and returns invisibly. Stamp failure must not block the build.
-  - Query: `SELECT model_run_id, model_version, date_completed FROM bcfishpass.log ORDER BY model_run_id DESC LIMIT 1`.
+  - Query: `SELECT model_run_id, model_version, to_char(date_completed, 'YYYY-MM-DD HH24:MI') AS date_completed FROM bcfishpass.log ORDER BY model_run_id DESC LIMIT 1`.
   - Compose row fields:
     - `run_started_pdt` = `format(Sys.time(), "%Y-%m-%d %H:%M")`
-    - `host` = `Sys.info()[["nodename"]]` (matches the per-WSG-timings CSV's `host_id` pattern at line 92)
-    - `run_label` = `if (CONFIG == "bcfishpass") "provincial_parity" else paste0("provincial_", CONFIG)`
-    - `link_schema` = the `--schema` value (default `fresh` when bcfishpass bundle, otherwise required)
+    - `host` = `Sys.getenv("LNK_HOST_ALIAS", Sys.info()[["nodename"]])` — env-var override gives clean shorthand (`m4`/`m1`/`cypher`); nodename fallback when unset
+    - `run_label` = `if (config_name == "bcfishpass") "provincial_parity" else paste0("provincial_", config_name)`
+    - `link_schema` = `cfg$pipeline$schema` (already reflects `--schema=` override applied at lines 42–45)
     - `notes` = `"auto-stamped at run_provincial_parity.R start"`
   - Idempotency: read existing CSV; if any row matches `(host, link_schema, bcfp_model_run_id, run_started_pdt)`, skip append and log a `[bcfp-baseline] skip: already stamped` line.
-  - Append row to CSV. Use `data.table::fwrite(..., append = TRUE)` or base `write.table(..., append = TRUE, sep = ",", row.names = FALSE, col.names = FALSE)` — match whichever the existing script already uses for the per-WSG-timings file (line 95) for consistency.
+  - Append row via `write.table(..., append = TRUE, sep = ",", row.names = FALSE, col.names = FALSE, quote = FALSE)` — matches the per-WSG-timings convention at line 103.
   - `cat("[bcfp-baseline] stamped: model_run_id=<N> host=<H> -> <csv-path>\n")`.
-- [ ] Call the helper between the setup banner (line 105) and the per-WSG `for (w in wsgs)` loop (line 107). Single invocation per run.
-- [ ] `/code-check` on staged diff.
+- [x] Call the helper between the setup banner and the per-WSG `for (w in wsgs)` loop. Single invocation per run.
 
 ## Phase 3: Verification (single-host)
 
-- [ ] M4-local smoke: `Rscript run_provincial_parity.R --wsgs=ADMS --config=default --schema=fresh_default`. Confirm one row appended with `host=m4`, `bcfp_model_run_id=120`, `bcfp_model_version=v0.7.14-113-ga7373af` (or whichever build is current at run time).
-- [ ] Idempotency check: re-run the same command within the same minute, confirm `[bcfp-baseline] skip: already stamped` and CSV row count unchanged.
-- [ ] Tunnel-down sanity: temporarily kill the M4 tunnel, run the same smoke, confirm `[bcfp-baseline] WARN: ...` and that the WSG loop still proceeds (build doesn't block on stamp failure).
-- [ ] Stamped verification log under `data-raw/logs/<TS>_link121_verification.txt`.
+- [x] M4-local smoke: stamp helper produced `model_run_id=120, model_version=v0.7.14-113-ga7373af, date_completed=2026-04-28 23:17, host=MacBook-Pro-2.local` (no `LNK_HOST_ALIAS` env var set during test, so nodename fallback was exercised). Row appended cleanly.
+- [x] Idempotency check: second run within the same minute logged `[bcfp-baseline] skip: already stamped (host=MacBook-Pro-2.local link_schema=fresh_default model_run_id=120)`; CSV row count unchanged.
+- [x] Tunnel-down sanity: ran with `Rscript --no-environ` (truly unset `PG_PASS_SHARE`), got `[bcfp-baseline] WARN: PG_PASS_SHARE not set, skipping stamp`; CSV unchanged. Build path would proceed unaffected.
+- [x] Stamped verification logs under `data-raw/logs/20260505_0545_link121_verification.txt` and `data-raw/logs/20260505_0546_link121_verification_tunneldown.txt`.
+- Trifecta verification (3 hosts, one row each) deferred to the next provincial run when M1 docker CLI is updated and cypher is back on tailscale.
 
 ## Phase 4: Release
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -38,9 +38,9 @@ Stamping must happen where comparisons actually occur. The trifecta orchestrator
 
 ## Phase 4: Release
 
-- [ ] `NEWS.md` 0.29.1 entry: "Auto-stamp bcfp comparison baseline in `run_provincial_parity.R`; add `host` column to `bcfp_baselines.csv`".
-- [ ] `DESCRIPTION` 0.29.0 → 0.29.1 (patch bump — orchestration-tooling change, no public R API touched).
-- [ ] PR body: "Closes #121". No SRED tag in issue body; SRED ref goes in PR body only.
+- [x] `NEWS.md` 0.29.1 entry covering the auto-stamp + `host`-column migration.
+- [x] `DESCRIPTION` 0.29.0 → 0.29.1 (patch bump — orchestration-tooling change, no public R API touched).
+- [ ] PR body: "Closes #121". SRED ref goes in PR body only (not in issue body).
 - [ ] `/planning-archive` on PR merge.
 
 ## Validation


### PR DESCRIPTION
## Summary

- Auto-stamps the bcfp comparison reference (`model_run_id` + version SHA + `date_completed`) into `data-raw/logs/bcfp_baselines.csv` from inside `data-raw/run_provincial_parity.R`. One stamp per invocation; covers single-host and trifecta-dispatched per-host runs through the same wiring.
- Adds a `host` column to `bcfp_baselines.csv`. Trifecta runs now produce three rows per run (m4 / m1 / cypher), all with the same `bcfp_model_run_id` but different host context. Existing rows backfilled to `host=m4`.
- Tunnel-tolerant + idempotent: connection failure or unset `PG_PASS_SHARE` warns and continues; same-minute re-runs (resume scenarios) skip rather than duplicate.

## Test plan

- [x] M4-local smoke: stamp helper appended one row with `model_run_id=120, model_version=v0.7.14-113-ga7373af, date_completed=2026-04-28 23:17`.
- [x] Idempotency: second run within the same minute logged `[bcfp-baseline] skip: already stamped`; CSV unchanged.
- [x] Tunnel-down (`Rscript --no-environ`, no `PG_PASS_SHARE`): WARN, no row, no error — build path would proceed.
- [ ] Trifecta verification (3 rows, one per host) — deferred until M1 docker CLI is updated and cypher is back on tailscale; will land naturally with the next provincial run.

Verification logs: `data-raw/logs/20260505_0545_link121_verification.txt` and `20260505_0546_link121_verification_tunneldown.txt`.

Closes #121
Relates to NewGraphEnvironment/sred-2025-2026#24
