### PR TITLE
data-raw/snapshot_bcfp.sh: manual snapshot of bcfp deps from public sources (v0.31.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.31.0
+Version: 0.31.1
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# link 0.31.1
+
+Closes [#137](https://github.com/NewGraphEnvironment/link/issues/137). New `data-raw/snapshot_bcfp.sh` shell script loads bcfp dependencies into a local Postgres from public sources only — no SSH tunnel, no DB pg_dump. Prepares the local fwapg for `lnk_pipeline_crossings()` (link#138, in flight) and parity comparisons.
+
+- BCDC PSCIS via Python `bcdata bc2pg --refresh` → `whse_fish.pscis_*` (4 tables).
+- CABD dams via `ogr2ogr` from CABD's public GeoJSON API → `cabd.dams`.
+- bchamp `modelled_stream_crossings.gpkg.zip` via `curl` + `ogr2ogr` → `fresh.modelled_stream_crossings`.
+- bchamp `observations.parquet` via `ogr2ogr /vsicurl/...` → `bcfishobs.observations` (same artifact bcfp's `jobs/load_observations` consumes).
+- Optional `--with-bcfp-views`: pulls Simon's bcfp output views (`crossings_vw`, `streams_vw`) from `s3://newgraph/` for parity comparison.
+- Stamps `data-raw/logs/bcfp_baselines.csv` with the bcfp build identifier from `s3://fresh-bc/bcfishpass/log.json` via `lnk_baseline_append()`.
+
+Documented in `data-raw/README.md` under a new `## Bootstrap` section.
+
 # link 0.31.0
 
 Closes [#117](https://github.com/NewGraphEnvironment/link/issues/117). csv-sync flips from GitHub-API SHA-walking to reading from `s3://fresh-bc/bcfishpass/` (populated weekly by NewGraphEnvironment/db_newgraph). Cadence drops from daily to weekly Wed afternoon. Eliminates the 1–7 day drift between bundle CSVs and the upstream tunnel rebuild SHA.

--- a/data-raw/README.md
+++ b/data-raw/README.md
@@ -8,6 +8,49 @@ target.** Pick the verb prefix from the categories below; suffix the
 target (e.g. `_provincial`, `_wsg`, `_schema`, `_breaks`) so the purpose
 reads left-to-right.
 
+## Bootstrap
+
+One-time setup so `lnk_pipeline_crossings()` (link#138) and parity comparisons can run against a local fwapg without a tunnel.
+
+| Script | Purpose |
+|--------|---------|
+| `snapshot_bcfp.sh` | Loads bcfp dependencies into the local Postgres from public sources only. PSCIS via Python `bcdata bc2pg`, CABD dams via CABD GeoJSON API, modelled crossings + observations from bchamp objectstore. Optional `--with-bcfp-views` also pulls Simon's bcfp output views from `s3://newgraph` for parity comparison. Stamps `data-raw/logs/bcfp_baselines.csv` with the upstream build identifier (link#117 ledger). |
+
+### Prereqs
+
+- Local Postgres with PostGIS. `PGUSER`/`PGPASSWORD`/`PGHOST`/`PGPORT`/`PGDATABASE` env vars or `~/.pgpass` (or a single `DATABASE_URL`).
+- Python `bcdata` CLI: `pip install bcdata`.
+- GDAL `ogr2ogr` with GeoJSON + parquet drivers (Homebrew GDAL has both).
+- `curl`, `unzip`.
+- `aws` CLI (only for `--with-bcfp-views`; anonymous read works).
+- R with link package installed (for the baseline-stamp step).
+
+### Quick start
+
+```bash
+cd ~/Projects/repo/link
+
+# Primitives only (~5 min):
+bash data-raw/snapshot_bcfp.sh
+
+# Plus parity-comparison views (~7 min):
+bash data-raw/snapshot_bcfp.sh --with-bcfp-views
+```
+
+### What lands in your local DB
+
+- `whse_fish.pscis_assessment_svw`, `pscis_design_proposal_svw`, `pscis_habitat_confirmation_svw`, `pscis_remediation_svw` (BCDC PSCIS)
+- `cabd.dams` (CABD public API)
+- `fresh.modelled_stream_crossings` (bchamp gpkg)
+- `bcfishobs.observations` (bchamp parquet — same artifact bcfp's `jobs/load_observations` consumes)
+- `data-raw/logs/bcfp_baselines.csv` — appended row stamping which upstream build the snapshot reflects.
+
+With `--with-bcfp-views`:
+
+- `fresh.crossings_bcfp`, `fresh.streams_bcfp` (bcfp output, dumped weekly Sun by Simon's `dump_weekly`; aligned with the most recent Tue rebuild SHA between Wed and the next Tue).
+
+After running this script, `lnk_pipeline_crossings()` (link#138) and `lnk_pipeline_access(barrier_sources = list(...))` work end-to-end against locally-loaded primitives.
+
 ## Pipeline drivers (top-down)
 
 The dispatch hierarchy: trifecta → run_provincial → compare_wsg.

--- a/data-raw/snapshot_bcfp.sh
+++ b/data-raw/snapshot_bcfp.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# data-raw/snapshot_bcfp.sh
+#
+# Manual snapshot of bcfp dependencies into a local Postgres (fwapg) so
+# lnk_pipeline_crossings() (link#138) and parity comparisons can run
+# without a tunnel. Pulls only from public sources -- no SSH, no DB
+# pg_dump, no AWS auth.
+#
+# Loads (in order):
+#   1. BCDC PSCIS via Python `bcdata bc2pg` -> whse_fish.pscis_*
+#   2. CABD dams via ogr2ogr (GeoJSON API) -> cabd.dams
+#   3. bchamp modelled crossings (gpkg.zip) -> fresh.modelled_stream_crossings
+#   4. bchamp observations (parquet) -> bcfishobs.observations
+#      (matches bcfp's jobs/load_observations -- the canonical source)
+#   5. (--with-bcfp-views) Simon's bcfp output views from s3://newgraph
+#      -> fresh.crossings_bcfp / fresh.streams_bcfp (parity comparison)
+#   6. Stamp data-raw/logs/bcfp_baselines.csv with the bcfp build identifier
+#      from s3://fresh-bc/bcfishpass/log.json (link#117 ledger).
+#
+# Prereqs:
+#   - Local Postgres with PostGIS. Connection via PG* env vars or ~/.pgpass.
+#   - Python `bcdata` CLI (`pip install bcdata`).
+#   - GDAL `ogr2ogr` (Homebrew GDAL has GeoJSON + parquet drivers).
+#   - `curl`, `unzip`.
+#   - `aws` CLI (only for --with-bcfp-views).
+#   - R with link package installed (for the baseline-stamp step).
+#
+# Required env (or pgpass):
+#   PGUSER, PGPASSWORD, PGHOST, PGPORT, PGDATABASE
+#   OR a single DATABASE_URL (postgres://user:pass@host:port/dbname)
+#
+# Usage:
+#   bash data-raw/snapshot_bcfp.sh                     # primitives only
+#   bash data-raw/snapshot_bcfp.sh --with-bcfp-views   # + comparison views
+#
+# Runtime: ~5 min for primitives; +2-3 min with --with-bcfp-views.
+
+set -euxo pipefail
+
+WITH_BCFP_VIEWS=0
+for arg in "$@"; do
+  case "$arg" in
+    --with-bcfp-views) WITH_BCFP_VIEWS=1 ;;
+    *) echo "Unknown arg: $arg" >&2; exit 1 ;;
+  esac
+done
+
+# Resolve DATABASE_URL from PG* env if not already set.
+if [ -z "${DATABASE_URL:-}" ]; then
+  DATABASE_URL="postgresql://${PGUSER:?}:${PGPASSWORD:?}@${PGHOST:-localhost}:${PGPORT:-5432}/${PGDATABASE:?}"
+fi
+PSQL="psql $DATABASE_URL -v ON_ERROR_STOP=1"
+
+# Ensure required schemas exist.
+$PSQL -c "CREATE SCHEMA IF NOT EXISTS whse_fish;"
+$PSQL -c "CREATE SCHEMA IF NOT EXISTS cabd;"
+$PSQL -c "CREATE SCHEMA IF NOT EXISTS fresh;"
+$PSQL -c "CREATE SCHEMA IF NOT EXISTS bcfishobs;"
+
+# -----------------------------------------
+# 1. BCDC PSCIS
+# -----------------------------------------
+for tbl in pscis_assessment_svw \
+          pscis_design_proposal_svw \
+          pscis_habitat_confirmation_svw \
+          pscis_remediation_svw; do
+  bcdata bc2pg --refresh "whse_fish.${tbl}" --db_url "$DATABASE_URL"
+done
+
+# -----------------------------------------
+# 2. CABD dams (public API; same URL as bcfp's jobs/load_weekly)
+# -----------------------------------------
+ogr2ogr -f PostgreSQL \
+  "PG:$DATABASE_URL" \
+  -overwrite \
+  --config OGR_TRUNCATE=YES \
+  --config PG_USE_COPY=YES \
+  -nln cabd.dams \
+  "https://cabd-web.azurewebsites.net/cabd-api/features/dams?filter=province_territory_code:eq:bc&filter=use_analysis:eq:true" \
+  OGRGeoJSON
+
+# -----------------------------------------
+# 3. bchamp modelled_stream_crossings (gpkg.zip)
+# -----------------------------------------
+TMPDIR_MSC=$(mktemp -d)
+trap "rm -rf $TMPDIR_MSC" EXIT
+
+curl -fsSL \
+  -o "$TMPDIR_MSC/modelled_stream_crossings.gpkg.zip" \
+  https://nrs.objectstore.gov.bc.ca/bchamp/modelled_stream_crossings.gpkg.zip
+
+unzip -qun "$TMPDIR_MSC/modelled_stream_crossings.gpkg.zip" -d "$TMPDIR_MSC"
+
+ogr2ogr -f PostgreSQL \
+  "PG:$DATABASE_URL" \
+  -overwrite \
+  --config PG_USE_COPY=YES \
+  -nln fresh.modelled_stream_crossings \
+  "$TMPDIR_MSC/modelled_stream_crossings.gpkg" \
+  modelled_stream_crossings
+
+# -----------------------------------------
+# 4. bchamp observations (parquet) -- matches bcfp's jobs/load_observations
+# -----------------------------------------
+ogr2ogr -f PostgreSQL \
+  "PG:$DATABASE_URL" \
+  -overwrite \
+  --config PG_USE_COPY=YES \
+  -nln bcfishobs.observations \
+  /vsicurl/https://nrs.objectstore.gov.bc.ca/bchamp/bcfishobs/observations.parquet \
+  observations
+
+# -----------------------------------------
+# 5. (optional) Simon's bcfp output views for parity comparison
+# -----------------------------------------
+if [ "$WITH_BCFP_VIEWS" = "1" ]; then
+  for view in bcfishpass.crossings_vw bcfishpass.streams_vw; do
+    target="fresh.${view#bcfishpass.}_bcfp"
+
+    ogr2ogr -f PostgreSQL \
+      "PG:$DATABASE_URL" \
+      -overwrite \
+      --config PG_USE_COPY=YES \
+      -nln "$target" \
+      "/vsizip//vsicurl/https://newgraph.s3.us-west-2.amazonaws.com/${view}.fgb.zip" \
+      "${view}"
+  done
+fi
+
+# -----------------------------------------
+# 6. Stamp the baseline ledger with the bcfp build identifier
+# -----------------------------------------
+RUN_LABEL="snapshot-$(date -u +%Y%m%d)"
+NOTES="manual snapshot via data-raw/snapshot_bcfp.sh"
+if [ "$WITH_BCFP_VIEWS" = "1" ]; then
+  NOTES="$NOTES; --with-bcfp-views"
+fi
+
+Rscript -e "
+suppressMessages(library(link))
+log <- lnk_bucket_log()
+lnk_baseline_append(log,
+  run_label = '$RUN_LABEL',
+  notes     = paste0('$NOTES; head_sha=', substr(log\$head_sha, 1, 7))
+)
+cat(sprintf('Stamped %s with bcfp build %s (head_sha=%s)\\n',
+            'data-raw/logs/bcfp_baselines.csv',
+            log\$model_version,
+            substr(log\$head_sha, 1, 7)))
+" || {
+  echo "WARNING: baseline stamp failed (link package may not be installed). Snapshot completed."
+  exit 0
+}
+
+echo "snapshot_bcfp.sh: complete."

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,41 @@
+# Findings — manual snapshot of bcfp dependencies (#137)
+
+## Issue context
+
+Issue #137 in NewGraphEnvironment/link. Title: "data-raw: manual snapshot of bcfp dependencies into local fresh schema". Phase A of the self-sufficiency roadmap (link#117 + db_newgraph PR #5 shipped Phase 0).
+
+## Source authority confirmed during plan-mode exploration
+
+| Table | Source | Loader pattern | Why this source |
+|---|---|---|---|
+| `whse_fish.pscis_*` (4 tables) | BCDC catalogue | Python `bcdata bc2pg --refresh` | Canonical loader; Simon's db_newgraph + bcfp use same pattern |
+| `cabd.dams` | `https://cabd-web.azurewebsites.net/cabd-api/features/dams?filter=province_territory_code:eq:bc&filter=use_analysis:eq:true` | ogr2ogr from GeoJSON | Same URL bcfp's `jobs/load_weekly` uses |
+| `fresh.modelled_stream_crossings` | `https://nrs.objectstore.gov.bc.ca/bchamp/modelled_stream_crossings.gpkg.zip` | curl + ogr2ogr | Bcfp's `model_00_stream_crossings` builds + uploads this WEEKLY out of bcfp DB during Tue rebuild (confirmed 2026-05-07) |
+| `bcfishobs.observations` | `https://nrs.objectstore.gov.bc.ca/bchamp/bcfishobs/observations.parquet` | ogr2ogr from /vsicurl parquet | Same as bcfp's `jobs/load_observations`. Authoritative — what bcfp actually consumes |
+
+### NOT used: `s3://newgraph/bcfishobs.fiss_fish_obsrvtn_events_vw.fgb.zip`
+
+This is a view dump from a different workflow (`db_newgraph/jobs/dump_weekly`, runs Sunday). It's a single-view subset of the bcfishobs schema, not what bcfp consumes. The authoritative path is the parquet from bchamp. Do not use the s3://newgraph fgb.
+
+### Comparison-side bcfp views (optional)
+
+- `s3://newgraph/bcfishpass.crossings_vw.fgb.zip` — current bcfp output, dumped Sunday (after the previous Tue rebuild). Aligned with the most recent rebuild SHA between Wed and following Tue. Useful for parity diffing in #138 Phase 5.
+- `s3://newgraph/bcfishpass.streams_vw.fgb.zip` — same.
+
+## Existing primitives reused
+
+- `R/lnk_bucket_log.R` (#117) — reads `s3://fresh-bc/bcfishpass/log.json` for build identifier.
+- `R/lnk_baseline_append.R` (#117) — appends ledger row.
+- bcfp reference: `jobs/load_weekly` (CABD pattern), `jobs/load_modelled_stream_crossings` (bchamp gpkg pattern), `jobs/load_observations` (bchamp parquet pattern).
+
+## Cross-refs
+
+- #117 (closed/v0.31.0) — csv-sync rewrite. Provides `lnk_bucket_log` + `lnk_baseline_append`.
+- #138 (in flight, parked) — `lnk_pipeline_crossings` consumer. Phase 5 parity needs the comparison-side views from this snapshot.
+- NewGraphEnvironment/db_newgraph PR #5 — populates s3://fresh-bc/bcfishpass/log.json that this script reads for the baseline stamp.
+
+## Out-of-scope
+
+- Drift-monitor automation (weekly GHA + crate schema-validate). Defer.
+- Habitat-table refactor in `lnk_pipeline_mapping_code`. Separate concern.
+- Optional launchd plist for weekly auto-refresh. Anyone who wants it can write 10 lines.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,9 @@
+# Progress — manual snapshot of bcfp dependencies (#137)
+
+## Session 2026-05-08
+
+- Plan-mode exploration: confirmed observations source is `bchamp/bcfishobs/observations.parquet` (matches bcfp's `jobs/load_observations`); the s3://newgraph fgb dump of `fiss_fish_obsrvtn_events_vw` is a different artifact and NOT what bcfp consumes.
+- Cadence alignment confirmed: Simon's dump_weekly Sun 03:00 UTC captures most-recent Tue rebuild output. bcfp views from s3://newgraph are aligned with the most recent rebuild SHA at any time between Wed and the next Tue.
+- Branch `137-data-raw-manual-snapshot-of-bcfp-depende` created off main.
+- Scaffolded PWF baseline.
+- Next: Phase 1 — write `data-raw/snapshot_bcfp.sh`.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -6,4 +6,6 @@
 - Cadence alignment confirmed: Simon's dump_weekly Sun 03:00 UTC captures most-recent Tue rebuild output. bcfp views from s3://newgraph are aligned with the most recent rebuild SHA at any time between Wed and the next Tue.
 - Branch `137-data-raw-manual-snapshot-of-bcfp-depende` created off main.
 - Scaffolded PWF baseline.
-- Next: Phase 1 — write `data-raw/snapshot_bcfp.sh`.
+- Phase 1 done: `data-raw/snapshot_bcfp.sh` shipped — 6 sections + `--with-bcfp-views` flag. `bash -n` clean.
+- Phase 2 done: `data-raw/README.md` `## Bootstrap` section added with prereqs + quick-start + output schema list.
+- Phase 3 in progress: DESCRIPTION + NEWS bumped to 0.31.1. Tests no-op pass (808). Commit + push + PR + merge next.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -4,28 +4,29 @@ Shell script that loads the primitives `lnk_pipeline_crossings()` (#138) needs, 
 
 ## Phase 1: `data-raw/snapshot_bcfp.sh` shell script
 
-- [ ] Header with prereqs (`PG*` / `~/.pgpass`, `bcdata` Python CLI, `ogr2ogr`, `curl`, `aws` CLI). `set -euxo pipefail`.
-- [ ] Section 1: BCDC PSCIS via `bcdata bc2pg --refresh whse_fish.pscis_*` (4 tables).
-- [ ] Section 2: CABD dams via `ogr2ogr` from CABD GeoJSON API → `cabd.dams`.
-- [ ] Section 3: bchamp `modelled_stream_crossings.gpkg.zip` via `curl` + `ogr2ogr` → `fresh.modelled_stream_crossings`.
-- [ ] Section 4: bchamp `observations.parquet` via `ogr2ogr ... /vsicurl/...` → `bcfishobs.observations`. Mirrors bcfp's `jobs/load_observations`.
-- [ ] Section 5 (optional, gated by `--with-bcfp-views`): Simon's bcfp views from `s3://newgraph` → `fresh.crossings_bcfp` / `fresh.streams_bcfp`.
-- [ ] Section 6: stamp `data-raw/logs/bcfp_baselines.csv` via `Rscript -e 'lnk_baseline_append(lnk_bucket_log(), run_label = "snapshot-<date>", notes = "...")'`.
+- [x] Header with prereqs + `set -euxo pipefail`.
+- [x] Section 1: BCDC PSCIS via `bcdata bc2pg --refresh whse_fish.pscis_*` (4 tables).
+- [x] Section 2: CABD dams via `ogr2ogr` from CABD GeoJSON API → `cabd.dams`.
+- [x] Section 3: bchamp `modelled_stream_crossings.gpkg.zip` via `curl` + `ogr2ogr` → `fresh.modelled_stream_crossings`.
+- [x] Section 4: bchamp `observations.parquet` via `ogr2ogr ... /vsicurl/...` → `bcfishobs.observations`. Mirrors bcfp's `jobs/load_observations`.
+- [x] Section 5 (optional, gated by `--with-bcfp-views`): Simon's bcfp views from `s3://newgraph` → `fresh.crossings_bcfp` / `fresh.streams_bcfp`.
+- [x] Section 6: stamp `data-raw/logs/bcfp_baselines.csv` via `Rscript -e 'lnk_baseline_append(lnk_bucket_log(), ...)'`.
+- [x] `bash -n` syntax check passes.
 
 ## Phase 2: `data-raw/README.md` documentation
 
-- [ ] Document `snapshot_bcfp.sh` purpose + when to run.
-- [ ] Prereqs section (CLI tools + install hints).
-- [ ] Quick-start invocation + expected runtime.
-- [ ] Output schema list.
-- [ ] Pointer to `lnk_pipeline_crossings()` (#138) as the consumer.
+- [x] Added `## Bootstrap` section (placed before existing `## Pipeline drivers`).
+- [x] Prereqs section (CLI tools + `pip install bcdata` hint).
+- [x] Quick-start invocation (with + without `--with-bcfp-views`) + expected runtime.
+- [x] Output schema list.
+- [x] Pointer to `lnk_pipeline_crossings()` (#138) as the consumer.
 
 ## Phase 3: NEWS + DESCRIPTION + open PR
 
-- [ ] DESCRIPTION 0.31.0 → 0.31.1 (patch — data-raw + docs).
-- [ ] NEWS.md 0.31.1 entry.
+- [x] DESCRIPTION 0.31.0 → 0.31.1.
+- [x] NEWS.md 0.31.1 entry.
+- [x] `devtools::test()` clean (808 PASS / 0 FAIL — no R changes, no-op as expected).
 - [ ] `/code-check` clean on staged diff.
-- [ ] `devtools::test()` + `lintr::lint_package()` clean.
 - [ ] Commit, push, open PR closing #137 with SRED tag.
 - [ ] `/gh-pr-merge` → tag v0.31.1.
 - [ ] `/planning-archive`.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,38 @@
+# Task: data-raw snapshot_bcfp.sh — manual snapshot of bcfp dependencies (#137)
+
+Shell script that loads the primitives `lnk_pipeline_crossings()` (#138) needs, plus optional bcfp output views for parity verification, into the local fwapg from public sources only (no SSH tunnel).
+
+## Phase 1: `data-raw/snapshot_bcfp.sh` shell script
+
+- [ ] Header with prereqs (`PG*` / `~/.pgpass`, `bcdata` Python CLI, `ogr2ogr`, `curl`, `aws` CLI). `set -euxo pipefail`.
+- [ ] Section 1: BCDC PSCIS via `bcdata bc2pg --refresh whse_fish.pscis_*` (4 tables).
+- [ ] Section 2: CABD dams via `ogr2ogr` from CABD GeoJSON API → `cabd.dams`.
+- [ ] Section 3: bchamp `modelled_stream_crossings.gpkg.zip` via `curl` + `ogr2ogr` → `fresh.modelled_stream_crossings`.
+- [ ] Section 4: bchamp `observations.parquet` via `ogr2ogr ... /vsicurl/...` → `bcfishobs.observations`. Mirrors bcfp's `jobs/load_observations`.
+- [ ] Section 5 (optional, gated by `--with-bcfp-views`): Simon's bcfp views from `s3://newgraph` → `fresh.crossings_bcfp` / `fresh.streams_bcfp`.
+- [ ] Section 6: stamp `data-raw/logs/bcfp_baselines.csv` via `Rscript -e 'lnk_baseline_append(lnk_bucket_log(), run_label = "snapshot-<date>", notes = "...")'`.
+
+## Phase 2: `data-raw/README.md` documentation
+
+- [ ] Document `snapshot_bcfp.sh` purpose + when to run.
+- [ ] Prereqs section (CLI tools + install hints).
+- [ ] Quick-start invocation + expected runtime.
+- [ ] Output schema list.
+- [ ] Pointer to `lnk_pipeline_crossings()` (#138) as the consumer.
+
+## Phase 3: NEWS + DESCRIPTION + open PR
+
+- [ ] DESCRIPTION 0.31.0 → 0.31.1 (patch — data-raw + docs).
+- [ ] NEWS.md 0.31.1 entry.
+- [ ] `/code-check` clean on staged diff.
+- [ ] `devtools::test()` + `lintr::lint_package()` clean.
+- [ ] Commit, push, open PR closing #137 with SRED tag.
+- [ ] `/gh-pr-merge` → tag v0.31.1.
+- [ ] `/planning-archive`.
+
+## Validation
+
+- [ ] Tests pass (no R changes — should be no-op)
+- [ ] `/code-check` clean on each commit
+- [ ] PWF checkboxes match landed work
+- [ ] `/planning-archive` on completion


### PR DESCRIPTION
## Summary

New `data-raw/snapshot_bcfp.sh` shell script. Loads bcfp dependencies into a local Postgres from public sources only (no SSH tunnel, no DB pg_dump). Prepares the local fwapg for `lnk_pipeline_crossings()` (link#138, in flight) and parity comparisons.

## What it loads

| Table | Source | Loader |
|---|---|---|
| `whse_fish.pscis_*` (4 BCDC tables) | BCDC catalogue | Python `bcdata bc2pg --refresh` |
| `cabd.dams` | CABD's public GeoJSON API (same URL bcfp's `jobs/load_weekly` uses) | `ogr2ogr` |
| `fresh.modelled_stream_crossings` | bchamp `modelled_stream_crossings.gpkg.zip` | `curl` + `ogr2ogr` |
| `bcfishobs.observations` | bchamp `observations.parquet` (same artifact bcfp's `jobs/load_observations` consumes) | `ogr2ogr /vsicurl/...` |
| `fresh.crossings_bcfp` / `fresh.streams_bcfp` (optional, `--with-bcfp-views`) | `s3://newgraph/bcfishpass.{crossings,streams}_vw.fgb.zip` (anonymous read) | `aws s3 cp` + `ogr2ogr` |

Stamps `data-raw/logs/bcfp_baselines.csv` with the bcfp build identifier from `s3://fresh-bc/bcfishpass/log.json` via `lnk_baseline_append(lnk_bucket_log())`.

## Documentation

`data-raw/README.md` — new `## Bootstrap` section: prereqs (CLI tools + `pip install bcdata`), quick-start invocation, output schema list, pointer to `lnk_pipeline_crossings()` (#138) as the consumer.

## Test plan

- [x] `bash -n` syntax check on the script
- [x] Full R test suite no-op (808 PASS / 0 FAIL — no R changes)
- [ ] Manual smoke on local fwapg post-merge: confirm 7 tables exist after a clean run
- [ ] Resume #138 Phase 2+3+5 work using the loaded primitives

Closes #137.

Relates to NewGraphEnvironment/sred-2025-2026#24
