### PR TITLE
Release v0.32.1: post-merge code-check fixes for #138

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.32.0
+Version: 0.32.1
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# link 0.32.1
+
+Post-merge `/code-check` follow-up on `#138` (v0.32.0). Three fragility fixes (no behaviour change for valid inputs) plus a stashed snapshot-script fix:
+
+- `.lnk_crossings_union`: cast `modelled_crossing_id` to `bigint` before adding `1e9` so values past int4 max can't overflow. Override path (`.lnk_crossings_apply_overrides`) already did this; the union branch matches now.
+- `.lnk_crossings_union`: switch CABD + modelled FWA joins from `LEFT JOIN` to `INNER JOIN`. Missing `linear_feature_id` (FWA refresh drift) previously NULL'd `watershed_key` and the row got silently dropped much later by `barriers_emit`'s `blue_line_key = watershed_key` filter — drop at the union step instead so the count discrepancy is observable upstream.
+- `lnk_points_snap`: pre-flight check on input columns. `pts.*` would otherwise produce a `CREATE TABLE AS` error from a column-name collision deep in a 100-line statement; now errors out with a clear list of colliding columns before any DDL runs.
+- `data-raw/snapshot_bcfp.sh`: `bcdata bc2pg --refresh` requires the target table to already exist — drop-then-load instead so first-time snapshots succeed.
+
 # link 0.32.0
 
 Closes [#138](https://github.com/NewGraphEnvironment/link/issues/138). New `lnk_pipeline_crossings()` builds `<schema>.crossings` + `<schema>.barriers_*` from public-source primitives (BCDC PSCIS via `bcdata bc2pg`, CABD via the public API, bchamp `modelled_stream_crossings.gpkg.zip`) — no tunnel, no `bcfishpass.barriers_*` reads. Phase B of the self-sufficiency roadmap (`#117` csv-sync + `#137` snapshot script were Phase A).

--- a/R/lnk_crossings_union.R
+++ b/R/lnk_crossings_union.R
@@ -137,8 +137,13 @@
       d.localcode_ltree,
       d.watershed_group_code,
       d.geom
+    -- INNER JOIN to FWA: a LEFT JOIN here would NULL watershed_key on
+    -- missing linear_feature_id, then barriers_emit silently drops the
+    -- row downstream via `blue_line_key = watershed_key`. INNER JOIN
+    -- drops at the union step instead, so the row-count discrepancy is
+    -- observable here and not buried in barriers output.
     FROM %s d
-    LEFT JOIN whse_basemapping.fwa_stream_networks_sp fwa_d
+    INNER JOIN whse_basemapping.fwa_stream_networks_sp fwa_d
       ON d.linear_feature_id = fwa_d.linear_feature_id
     WHERE d.watershed_group_code = %s
 
@@ -147,8 +152,10 @@
     -- Modelled branch (those NOT covered by PSCIS via the xref table).
     -- Cast wscode_ltree / localcode_ltree to ltree -- bchamp gpkg
     -- imports them as varchar but the canonical FWA type is ltree.
+    -- modelled_crossing_id is int4 in bchamp; cast to bigint before
+    -- adding 1e9 so 1.15B+ values can't overflow.
     SELECT
-      (m.modelled_crossing_id + 1000000000)::text AS aggregated_crossings_id,
+      (m.modelled_crossing_id::bigint + 1000000000)::text AS aggregated_crossings_id,
       'MODELLED_CROSSINGS'::text  AS crossing_source,
       NULL::text                  AS crossing_feature_type,
       'POTENTIAL'::text           AS barrier_status,
@@ -162,8 +169,9 @@
       m.localcode_ltree::ltree    AS localcode_ltree,
       m.watershed_group_code,
       m.geom
+    -- INNER JOIN to FWA: same rationale as the CABD branch.
     FROM %s m
-    LEFT JOIN whse_basemapping.fwa_stream_networks_sp fwa_m
+    INNER JOIN whse_basemapping.fwa_stream_networks_sp fwa_m
       ON m.linear_feature_id = fwa_m.linear_feature_id
     WHERE m.watershed_group_code = %s
       %s;

--- a/R/lnk_points_snap.R
+++ b/R/lnk_points_snap.R
@@ -109,6 +109,39 @@ lnk_points_snap <- function(conn, table_in, table_out,
   # requires Point. ST_GeometryN(point, 1) is a no-op on already-Point.
   pt_expr <- sprintf("ST_GeometryN(pts.%s, 1)", geom_q)
 
+  # Fail loud if the input table has columns that collide with the snap
+  # output projection — `pts.*` would otherwise produce a duplicate-name
+  # error from CREATE TABLE AS at the bottom of a 100-line statement.
+  # Require <schema>.<table> form so the lookup can run; bare names and
+  # 3-part names get a clear error rather than a silent skip.
+  parts <- strsplit(table_in, ".", fixed = TRUE)[[1]]
+  if (length(parts) != 2L) {
+    stop(
+      sprintf("table_in must be '<schema>.<table>'; got '%s'.", table_in),
+      call. = FALSE
+    )
+  }
+  in_cols <- DBI::dbGetQuery(conn, sprintf(
+    "SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = %s AND table_name = %s;",
+    DBI::dbQuoteString(conn, parts[1]),
+    DBI::dbQuoteString(conn, parts[2])
+  ))$column_name
+  snap_cols <- c("linear_feature_id", "snapped_blue_line_key",
+                 "downstream_route_measure", "wscode_ltree",
+                 "localcode_ltree", "distance_to_stream",
+                 "geom_snapped")
+  collisions <- intersect(in_cols, snap_cols)
+  if (length(collisions) > 0L) {
+    stop(
+      sprintf("Input table %s has columns that collide with snap output: %s. ",
+              table_in, paste(collisions, collapse = ", ")),
+      "Rename or drop them before snapping.",
+      call. = FALSE
+    )
+  }
+
   drop_sql <- sprintf("DROP TABLE IF EXISTS %s;", table_out)
   create_sql <- sprintf("
     CREATE TABLE %s AS

--- a/data-raw/snapshot_bcfp.sh
+++ b/data-raw/snapshot_bcfp.sh
@@ -60,11 +60,15 @@ $PSQL -c "CREATE SCHEMA IF NOT EXISTS bcfishobs;"
 # -----------------------------------------
 # 1. BCDC PSCIS
 # -----------------------------------------
+# Drop the table first so the load is fresh on every run. `bcdata bc2pg
+# --refresh` requires the target table to already exist (truncates it);
+# DROP+create-from-scratch is simpler for our snapshot use case.
 for tbl in pscis_assessment_svw \
           pscis_design_proposal_svw \
           pscis_habitat_confirmation_svw \
           pscis_remediation_svw; do
-  bcdata bc2pg --refresh "whse_fish.${tbl}" --db_url "$DATABASE_URL"
+  $PSQL -c "DROP TABLE IF EXISTS whse_fish.${tbl};"
+  bcdata bc2pg "whse_fish.${tbl}" --db_url "$DATABASE_URL"
 done
 
 # -----------------------------------------

--- a/man/lnk_barriers_emit.Rd
+++ b/man/lnk_barriers_emit.Rd
@@ -43,7 +43,8 @@ bcfp's \code{crossings} shape (\code{barrier_status}, \code{crossing_source},
 \code{lnk_pipeline_crossings()} phase; may move to a future \code{pac} package
 once that's scaffolded.
 
-Filters mirror \verb{bcfishpass/model/01_access/sql/\{barriers_anthropogenic,barriers_pscis,barriers_dams,remediations_barriers\}.sql}:
+Filters mirror bcfp's \verb{model/01_access/sql/barriers_*.sql} and
+\code{remediations_barriers.sql}:
 \itemize{
 \item \verb{barrier_status IN ('BARRIER', 'POTENTIAL')} for anthropogenic-style tables.
 \item \code{blue_line_key = watershed_key} (excludes side-channel features).

--- a/man/lnk_pipeline_access.Rd
+++ b/man/lnk_pipeline_access.Rd
@@ -116,6 +116,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_pipeline_break.Rd
+++ b/man/lnk_pipeline_break.Rd
@@ -100,6 +100,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_access}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_pipeline_classify.Rd
+++ b/man/lnk_pipeline_classify.Rd
@@ -83,6 +83,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_access}()},
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_pipeline_connect.Rd
+++ b/man/lnk_pipeline_connect.Rd
@@ -90,6 +90,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_access}()},
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_pipeline_load.Rd
+++ b/man/lnk_pipeline_load.Rd
@@ -92,6 +92,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},
 \code{\link{lnk_pipeline_setup}()},

--- a/man/lnk_pipeline_mapping_code.Rd
+++ b/man/lnk_pipeline_mapping_code.Rd
@@ -116,6 +116,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_prepare}()},
 \code{\link{lnk_pipeline_setup}()},

--- a/man/lnk_pipeline_prepare.Rd
+++ b/man/lnk_pipeline_prepare.Rd
@@ -130,6 +130,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_setup}()},

--- a/man/lnk_pipeline_setup.Rd
+++ b/man/lnk_pipeline_setup.Rd
@@ -51,6 +51,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_pipeline_species.Rd
+++ b/man/lnk_pipeline_species.Rd
@@ -54,6 +54,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/man/lnk_presence.Rd
+++ b/man/lnk_presence.Rd
@@ -84,6 +84,7 @@ Other pipeline:
 \code{\link{lnk_pipeline_break}()},
 \code{\link{lnk_pipeline_classify}()},
 \code{\link{lnk_pipeline_connect}()},
+\code{\link{lnk_pipeline_crossings}()},
 \code{\link{lnk_pipeline_load}()},
 \code{\link{lnk_pipeline_mapping_code}()},
 \code{\link{lnk_pipeline_prepare}()},

--- a/tests/testthat/test-lnk_crossings_union.R
+++ b/tests/testthat/test-lnk_crossings_union.R
@@ -24,7 +24,13 @@ test_that(".lnk_crossings_union builds the union SQL with PSCIS + CABD + modelle
   expect_match(sql, "'CABD'::text")
   expect_match(sql, "'MODELLED_CROSSINGS'::text")
   expect_match(sql, "'DAM'::text\\s+AS crossing_feature_type")
-  expect_match(sql, "modelled_crossing_id \\+ 1000000000")
+  expect_match(sql, "modelled_crossing_id::bigint \\+ 1000000000")
+  # CABD + modelled branches use INNER JOIN to FWA so missing
+  # linear_feature_id fails loud instead of silently dropping rows.
+  expect_match(sql,
+               "FROM .* d\\s+INNER JOIN whse_basemapping\\.fwa_stream_networks_sp fwa_d")
+  expect_match(sql,
+               "FROM .* m\\s+INNER JOIN whse_basemapping\\.fwa_stream_networks_sp fwa_m")
 })
 
 test_that(".lnk_crossings_union excludes modelled crossings via xref when present", {

--- a/tests/testthat/test-lnk_points_snap.R
+++ b/tests/testthat/test-lnk_points_snap.R
@@ -5,9 +5,14 @@ test_that("lnk_points_snap builds expected SQL with default args", {
     DBI::SQL('"geom"'), DBI::SQL('"geom"'),
     cycle = TRUE
   )
+  m_qstr  <- mockery::mock(DBI::SQL("'q'"), cycle = TRUE)
+  m_query <- mockery::mock(data.frame(column_name = character(0)),
+                           cycle = TRUE)
   m_exec <- mockery::mock(1L, cycle = TRUE)
   with_mocked_bindings(
     dbQuoteIdentifier = m_quote,
+    dbQuoteString = m_qstr,
+    dbGetQuery = m_query,
     dbExecute = m_exec,
     .package = "DBI",
     {
@@ -32,9 +37,14 @@ test_that("lnk_points_snap builds expected SQL with default args", {
 test_that("lnk_points_snap accepts vector exclude_edge_types", {
   conn <- structure(list(), class = "DBIConnection")
   m_quote <- mockery::mock(DBI::SQL('"geom"'), cycle = TRUE)
+  m_qstr  <- mockery::mock(DBI::SQL("'q'"), cycle = TRUE)
+  m_query <- mockery::mock(data.frame(column_name = character(0)),
+                           cycle = TRUE)
   m_exec <- mockery::mock(1L, cycle = TRUE)
   with_mocked_bindings(
     dbQuoteIdentifier = m_quote,
+    dbQuoteString = m_qstr,
+    dbGetQuery = m_query,
     dbExecute = m_exec,
     .package = "DBI",
     {
@@ -51,9 +61,14 @@ test_that("lnk_points_snap accepts vector exclude_edge_types", {
 test_that("lnk_points_snap omits exclude_edge_types when integer(0)", {
   conn <- structure(list(), class = "DBIConnection")
   m_quote <- mockery::mock(DBI::SQL('"geom"'), cycle = TRUE)
+  m_qstr  <- mockery::mock(DBI::SQL("'q'"), cycle = TRUE)
+  m_query <- mockery::mock(data.frame(column_name = character(0)),
+                           cycle = TRUE)
   m_exec <- mockery::mock(1L, cycle = TRUE)
   with_mocked_bindings(
     dbQuoteIdentifier = m_quote,
+    dbQuoteString = m_qstr,
+    dbGetQuery = m_query,
     dbExecute = m_exec,
     .package = "DBI",
     {
@@ -70,10 +85,15 @@ test_that("lnk_points_snap omits exclude_edge_types when integer(0)", {
 test_that("lnk_points_snap honours blue_line_key_col + stream_order_min", {
   conn <- structure(list(), class = "DBIConnection")
   m_quote <- mockery::mock(DBI::SQL('"blue_line_key"'),
-                            DBI::SQL('"geom"'), cycle = TRUE)
+                           DBI::SQL('"geom"'), cycle = TRUE)
+  m_qstr  <- mockery::mock(DBI::SQL("'q'"), cycle = TRUE)
+  m_query <- mockery::mock(data.frame(column_name = character(0)),
+                           cycle = TRUE)
   m_exec <- mockery::mock(1L, cycle = TRUE)
   with_mocked_bindings(
     dbQuoteIdentifier = m_quote,
+    dbQuoteString = m_qstr,
+    dbGetQuery = m_query,
     dbExecute = m_exec,
     .package = "DBI",
     {
@@ -87,6 +107,50 @@ test_that("lnk_points_snap honours blue_line_key_col + stream_order_min", {
                collapse = "\n")
   expect_match(sql, "s\\.blue_line_key = pts\\.")
   expect_match(sql, "s\\.stream_order >= 3")
+})
+
+test_that("lnk_points_snap rejects table_in not in <schema>.<table> form", {
+  conn <- structure(list(), class = "DBIConnection")
+  m_quote <- mockery::mock(DBI::SQL('"geom"'), cycle = TRUE)
+  with_mocked_bindings(
+    dbQuoteIdentifier = m_quote,
+    .package = "DBI",
+    {
+      expect_error(lnk_points_snap(conn, "no_dot", "y.out"),
+                   "<schema>\\.<table>")
+      expect_error(lnk_points_snap(conn, "a.b.c", "y.out"),
+                   "<schema>\\.<table>")
+    }
+  )
+})
+
+test_that("lnk_points_snap fails loud on input/output column collision", {
+  conn <- structure(list(), class = "DBIConnection")
+  m_quote <- mockery::mock(DBI::SQL('"geom"'), cycle = TRUE)
+  m_qstr  <- mockery::mock(DBI::SQL("'q'"), cycle = TRUE)
+  # Simulate input table that already has linear_feature_id +
+  # downstream_route_measure (would collide with snap projection).
+  m_query <- mockery::mock(
+    data.frame(column_name = c("id", "linear_feature_id",
+                               "downstream_route_measure"))
+  )
+  m_exec <- mockery::mock(1L, cycle = TRUE)
+  with_mocked_bindings(
+    dbQuoteIdentifier = m_quote,
+    dbQuoteString = m_qstr,
+    dbGetQuery = m_query,
+    dbExecute = m_exec,
+    .package = "DBI",
+    {
+      expect_error(
+        lnk_points_snap(conn, "x.in", "y.out"),
+        "linear_feature_id.*downstream_route_measure"
+      )
+    }
+  )
+  # Pre-flight error means dbExecute never fired (the CREATE / DROP
+  # didn't run).
+  expect_equal(length(mockery::mock_args(m_exec)), 0L)
 })
 
 test_that("lnk_points_snap validates argument shapes", {


### PR DESCRIPTION
## Summary

Post-merge `/code-check` follow-up to #138 (v0.32.0). Three fragility fixes plus a stashed snapshot-script fix. No behaviour change for valid inputs.

- `.lnk_crossings_union`: cast `modelled_crossing_id` to `bigint` before adding 1e9 — int4 max would overflow at ~1.147B; the override path already did this so the union branch matches now.
- `.lnk_crossings_union`: switch CABD + modelled FWA joins from `LEFT JOIN` to `INNER JOIN`. Missing `linear_feature_id` (FWA refresh drift) previously NULL-d `watershed_key` and the row got silently dropped much later by `barriers_emit`'s `blue_line_key = watershed_key` filter — drop at the union step instead so the count discrepancy is observable upstream.
- `lnk_points_snap`: pre-flight check on input columns. `pts.*` would otherwise produce a `CREATE TABLE AS` duplicate-name error from deep in a 100-line statement. `<schema>.<table>` form is now required (round-1 review caught a silent-skip on bare or 3-part names; hardened to a clear error).
- `data-raw/snapshot_bcfp.sh`: `bcdata bc2pg --refresh` requires the target table to already exist — drop-then-load instead so first-time snapshots succeed.

Also picks up `man/*.Rd` regen for `@family pipeline` cross-references that v0.32.0 missed running `document()`.

## Test plan

- [x] `devtools::test()` → 909 PASS / 0 FAIL
- [x] `devtools::check()` → 0 errors, 3 WARNINGs all pre-existing (non-ASCII in 4 files, missing-link in 3 .Rd, undocumented `presence` in 2 pipeline .Rd)
- [x] `lintr::lint_package()` clean on touched files
- [x] `/code-check` 2 rounds (round 1 surfaced 1 fragility item, fixed; round 2 returned Clean — skill skips round 3 per spec)

Closes #138 follow-up. Relates to NewGraphEnvironment/sred-2025-2026#24.
