### PR TITLE
fix: snapshot_bcfp.sh Parquet prereq SIGPIPE under set -euo pipefail (#160)

### DIFF
--- a/data-raw/snapshot_bcfp.sh
+++ b/data-raw/snapshot_bcfp.sh
@@ -78,7 +78,11 @@ if [ -n "$MISSING" ]; then
   echo "See data-raw/README.md for install instructions per host." >&2
   exit 1
 fi
-if ! ogr2ogr --formats 2>/dev/null | grep -qi parquet; then
+# grep without -q (and redirect to /dev/null) so it reads all input and
+# doesn't close the pipe early. With -q + set -euo pipefail, ogr2ogr gets
+# SIGPIPE (exit 141), pipefail propagates, `!` flips it, FATAL fires
+# even though the Parquet driver IS present (link#160).
+if ! ogr2ogr --formats 2>/dev/null | grep -i parquet > /dev/null; then
   echo "FATAL: ogr2ogr lacks Parquet driver. Need conda-forge or Homebrew GDAL." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Replace `grep -qi parquet` with `grep -i parquet > /dev/null` in the Parquet prereq check so `set -euo pipefail` + early-exit grep doesn't SIGPIPE-kill `ogr2ogr` and trigger a false FATAL.

Symptom on cypher (and any host with the conda-forge GDAL stack): `bash data-raw/snapshot_bcfp.sh` always FATALs on the Parquet check even though the driver IS present:

```
$ ssh cypher 'bash ~/Projects/repo/link/data-raw/snapshot_bcfp.sh'
FATAL: ogr2ogr lacks Parquet driver. Need conda-forge or Homebrew GDAL.
```

`grep -q` exits on first match → closes pipe → `ogr2ogr` gets SIGPIPE → exit 141 → pipefail propagates → `!` flips → FATAL fires.

Originally chased through NewGraphEnvironment/rtj#129 as a conda-env / non-interactive PATH issue. That was a misdiagnosis; the PATH from rtj#66/#123 was always correct. Real bug was here.

## Test plan

- [x] `bash -n data-raw/snapshot_bcfp.sh` — syntax clean
- [x] Reproduced bug on cypher with prior `grep -q` form (exit 141)
- [x] Verified fix on cypher (snapshot 228340873): `head -90 data-raw/snapshot_bcfp.sh | bash` passes through the Parquet prereq cleanly (exit 0)
- [ ] Full `snapshot_bcfp.sh` run on cypher (with PG creds) — to follow after merge

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
