### PR TITLE
wsgs_run_pipeline.sh: --cy-workspaces= passthrough for Tier 1/2 (#178)

### DIFF
--- a/data-raw/wsgs_run_pipeline.sh
+++ b/data-raw/wsgs_run_pipeline.sh
@@ -26,6 +26,10 @@
 #   --config=<name>    bundle name (default: bcfishpass)
 #   --schema=<name>    override cfg$pipeline$schema (default: bundle default)
 #   --no-cyphers       M4+M1 only — skip cypher spin/prep/burn entirely
+#   --cy-workspaces=A,B,C  cypher tofu workspaces to spin (default: job1,job2,job3).
+#                          Pass a subset like `--cy-workspaces=job1` for Tier 1
+#                          integration tests, or `--cy-workspaces=job1,job2` for Tier 2.
+#                          Mutually exclusive with --no-cyphers.
 #   --force            forward --force to per-host Rscript (bypass resume gates)
 #   --skip-smoke       skip the smoke pre-check
 #   --no-mapping-code  drop the mapping_code lens
@@ -47,6 +51,7 @@ CONFIG_NAME="bcfishpass"
 SCHEMA=""
 NO_CYPHERS=0
 FORCE_FLAG=""
+CY_WORKSPACES="job1,job2,job3"
 for arg in "$@"; do
   case "$arg" in
     --skip-smoke)      SKIP_SMOKE=1 ;;
@@ -57,10 +62,20 @@ for arg in "$@"; do
     --config=*)        CONFIG_NAME="${arg#--config=}" ;;
     --schema=*)        SCHEMA="${arg#--schema=}" ;;
     --no-cyphers)      NO_CYPHERS=1 ;;
+    --cy-workspaces=*) CY_WORKSPACES="${arg#--cy-workspaces=}" ;;
     --force)           FORCE_FLAG="--force" ;;
     *) echo "FATAL: unknown arg: $arg" >&2; exit 1 ;;
   esac
 done
+
+# Parse cypher workspace list into array. Empty CY_WS_ARR when --no-cyphers
+# is set so downstream `for WS in "${CY_WS_ARR[@]}"` loops become no-ops.
+if [ "$NO_CYPHERS" = "1" ] || [ -z "$CY_WORKSPACES" ]; then
+  CY_WS_ARR=()
+else
+  IFS=',' read -r -a CY_WS_ARR <<< "$CY_WORKSPACES"
+fi
+N_CY=${#CY_WS_ARR[@]}
 
 MAPPING_FLAG="--with-mapping-code"
 [ "$NO_MAPPING" = "1" ] && MAPPING_FLAG=""
@@ -95,11 +110,15 @@ echo "  keep-cy:     $([ "$KEEP_CYPHERS" = "0" ] && echo no || echo YES)"
 
 # Auto-skip smoke when the smoke harness's preconditions are not met.
 # trifecta_smoke.sh assumes 3 cypher workspaces (job1/job2/job3) and a
-# fixed per-host WSG triplet; both break under --no-cyphers or --wsgs.
-# Setting SKIP_SMOKE here (after the log redirect) keeps the notice in
-# the log for post-hoc inspection.
-if [ "$SKIP_SMOKE" = "0" ] && { [ "$NO_CYPHERS" = "1" ] || [ -n "$WSGS_FILTER" ]; }; then
-  echo "[auto-skip-smoke] --no-cyphers or --wsgs is set; trifecta_smoke.sh"
+# fixed per-host WSG triplet; all break under --no-cyphers, --wsgs, or
+# a non-default --cy-workspaces (e.g. Tier 1 / Tier 2 integration tests
+# with 1 or 2 cyphers). Setting SKIP_SMOKE here (after the log redirect)
+# keeps the notice in the log for post-hoc inspection.
+if [ "$SKIP_SMOKE" = "0" ] && \
+   { [ "$NO_CYPHERS" = "1" ] || [ -n "$WSGS_FILTER" ] || \
+     [ "$CY_WORKSPACES" != "job1,job2,job3" ]; }; then
+  echo "[auto-skip-smoke] one of {--no-cyphers, --wsgs, non-default"
+  echo "                   --cy-workspaces} is set; trifecta_smoke.sh"
   echo "                   assumptions don't hold — skipping Step 6."
   SKIP_SMOKE=1
 fi
@@ -115,18 +134,18 @@ burn_cyphers() {
   if [ "$KEEP_CYPHERS" = "1" ]; then
     echo "=== trap EXIT: --keep-cyphers given; NOT burning ==="
     echo "  manually: cd ~/Projects/repo/rtj/scripts/cypher && \\"
-    echo "    for WS in job1 job2 job3; do ./cypher_down.sh --workspace \$WS & done; wait"
+    echo "    for WS in ${CY_WS_ARR[*]}; do ./cypher_down.sh --workspace \$WS & done; wait"
     return $rc
   fi
   echo "=== Step 10: BURN CYPHERS (trap EXIT, mandatory) ==="
   cd ~/Projects/repo/rtj/scripts/cypher
-  for WS in job1 job2 job3; do
+  for WS in "${CY_WS_ARR[@]}"; do
     ./cypher_down.sh --workspace "$WS" > "$LOG_DIR/${TS}_burn_$WS.log" 2>&1 &
   done
   wait
   echo "--- destruction verification ---"
   local clean=1
-  for WS in job1 job2 job3; do
+  for WS in "${CY_WS_ARR[@]}"; do
     local n
     n=$(cd ~/Projects/repo/rtj/env/do/dev/cypher && TF_WORKSPACE="$WS" tofu state list 2>/dev/null | wc -l | tr -d ' ')
     echo "  cy[$WS]: $n tofu resources (expect 0)"
@@ -193,17 +212,17 @@ wait $M4_PID || { echo "FATAL: M4 snapshot failed; see $LOG_DIR/${TS}_snapshot_m
 wait $M1_PID || { echo "FATAL: M1 snapshot failed; see $LOG_DIR/${TS}_snapshot_m1.log"; exit 1; }
 echo "  ✓ snapshots done"
 
-# --- Step 3: spin 3 cyphers (parallel) — skipped under --no-cyphers ---
+# --- Step 3: spin N cyphers (parallel) — N = ${#CY_WS_ARR[@]} ---
 declare -A CY_IP
-if [ "$NO_CYPHERS" = "0" ]; then
-  echo "=== Step 3: cypher_up.sh job1/job2/job3 ==="
+if [ "$N_CY" -gt 0 ]; then
+  echo "=== Step 3: cypher_up.sh ${CY_WS_ARR[*]} ($N_CY cypher$([ $N_CY -eq 1 ] || echo s)) ==="
   cd ~/Projects/repo/rtj/scripts/cypher
-  for WS in job1 job2 job3; do
+  for WS in "${CY_WS_ARR[@]}"; do
     ./cypher_up.sh --workspace "$WS" > "$LOG_DIR/${TS}_up_$WS.log" 2>&1 &
   done
   wait
   cd "$REPO_ROOT"
-  for WS in job1 job2 job3; do
+  for WS in "${CY_WS_ARR[@]}"; do
     IP=$(cd ~/Projects/repo/rtj/env/do/dev/cypher && TF_WORKSPACE="$WS" tofu output -raw droplet_ip 2>/dev/null) || {
       echo "FATAL: tofu output droplet_ip failed for $WS; see $LOG_DIR/${TS}_up_$WS.log"
       exit 1
@@ -215,14 +234,14 @@ if [ "$NO_CYPHERS" = "0" ]; then
   CYPHERS_UP=1   # trap EXIT will now attempt burn
 
   # --- Step 4: per-cypher prep (parallel) ---
-  echo "=== Step 4: cypher_prep.sh on all 3 cyphers ==="
-  for WS in job1 job2 job3; do
+  echo "=== Step 4: cypher_prep.sh on $N_CY cypher$([ $N_CY -eq 1 ] || echo s) ==="
+  for WS in "${CY_WS_ARR[@]}"; do
     IP="${CY_IP[$WS]}"
     ( scp -q data-raw/cypher_prep.sh "cypher@$IP:/tmp/cypher_prep.sh" && \
       ssh "cypher@$IP" "bash /tmp/cypher_prep.sh" ) > "$LOG_DIR/${TS}_prep_$WS.log" 2>&1 &
   done
   wait
-  for WS in job1 job2 job3; do
+  for WS in "${CY_WS_ARR[@]}"; do
     if ! grep -q "snapshot_bcfp.sh: complete" "$LOG_DIR/${TS}_prep_$WS.log" 2>/dev/null; then
       echo "FATAL: cypher[$WS] prep failed; see $LOG_DIR/${TS}_prep_$WS.log"
       exit 1
@@ -238,13 +257,11 @@ echo "=== Step 5: runs_archive.sh on all hosts ==="
 bash data-raw/runs_archive.sh > "$LOG_DIR/${TS}_archive_m4.log" 2>&1 &
 ssh m1 'cd ~/Projects/repo/link/data-raw && ./runs_archive.sh' \
   > "$LOG_DIR/${TS}_archive_m1.log" 2>&1 &
-if [ "$NO_CYPHERS" = "0" ]; then
-  for WS in job1 job2 job3; do
-    IP="${CY_IP[$WS]}"
-    ssh "cypher@$IP" 'cd ~/Projects/repo/link/data-raw && ./runs_archive.sh' \
-      > "$LOG_DIR/${TS}_archive_$WS.log" 2>&1 &
-  done
-fi
+for WS in "${CY_WS_ARR[@]}"; do
+  IP="${CY_IP[$WS]}"
+  ssh "cypher@$IP" 'cd ~/Projects/repo/link/data-raw && ./runs_archive.sh' \
+    > "$LOG_DIR/${TS}_archive_$WS.log" 2>&1 &
+done
 wait
 echo "  ✓ archived"
 
@@ -263,17 +280,17 @@ if [ "$SKIP_SMOKE" = "0" ]; then
 fi
 
 # --- Step 7: FULL DISPATCH ---
-# When --no-cyphers OR --wsgs is set, omit --cy-workspaces so
-# wsgs_dispatch.sh runs with the M4+M1-only plan it derives
-# from DISPATCH_FLAGS (which includes --no-cyphers, --wsgs, etc.).
-if [ "$NO_CYPHERS" = "0" ] && [ -z "$WSGS_FILTER" ]; then
-  TRIFECTA_CY_ARG="--cy-workspaces=job1,job2,job3"
-  echo "=== Step 7: full provincial dispatch (~80-95 min wall) ==="
+# Cypher workspaces flow through verbatim from the umbrella's
+# --cy-workspaces=. When --no-cyphers is set, $N_CY=0 and the arg
+# is omitted (dispatcher then sees no cypher hosts).
+if [ "$N_CY" -gt 0 ]; then
+  TRIFECTA_CY_ARG="--cy-workspaces=$CY_WORKSPACES"
+  echo "=== Step 7: dispatch ($N_CY cypher$([ $N_CY -eq 1 ] || echo s)) ==="
 else
   TRIFECTA_CY_ARG=""
-  echo "=== Step 7: subset dispatch — see DISPATCH_FLAGS below ==="
+  echo "=== Step 7: dispatch (M4+M1 only) ==="
 fi
-echo "  DISPATCH_FLAGS=$DISPATCH_FLAGS"
+echo "  DISPATCH_FLAGS=$DISPATCH_FLAGS $TRIFECTA_CY_ARG"
 cd "$REPO_ROOT/data-raw"
 if ! bash wsgs_dispatch.sh $TRIFECTA_CY_ARG $DISPATCH_FLAGS $MAPPING_FLAG \
      > "$LOG_DIR/${TS}_full.log" 2>&1; then
@@ -324,16 +341,15 @@ if [ -z "$M1_BUCKET" ]; then
   echo "  ✗ failed to extract m1 bucket from $ORCH_LOG"
   exit 1
 fi
-if [ "$NO_CYPHERS" = "0" ]; then
-  CY1_BUCKET=$(grep '^  cypher\[job1\] bucket:' "$ORCH_LOG" | sed 's/.*bucket: //' || true)
-  CY2_BUCKET=$(grep '^  cypher\[job2\] bucket:' "$ORCH_LOG" | sed 's/.*bucket: //' || true)
-  CY3_BUCKET=$(grep '^  cypher\[job3\] bucket:' "$ORCH_LOG" | sed 's/.*bucket: //' || true)
-  if [ -z "$CY1_BUCKET" ] || [ -z "$CY2_BUCKET" ] || [ -z "$CY3_BUCKET" ]; then
-    echo "  ✗ failed to extract cypher buckets from $ORCH_LOG"
-    echo "    cy1=$CY1_BUCKET  cy2=$CY2_BUCKET  cy3=$CY3_BUCKET"
+declare -A CY_BUCKETS
+for WS in "${CY_WS_ARR[@]}"; do
+  B=$(grep "^  cypher\\[$WS\\] bucket:" "$ORCH_LOG" | sed 's/.*bucket: //' || true)
+  if [ -z "$B" ]; then
+    echo "  ✗ failed to extract cypher[$WS] bucket from $ORCH_LOG"
     exit 1
   fi
-fi
+  CY_BUCKETS[$WS]="$B"
+done
 
 # Resolve target schema name: explicit --schema wins, else look up
 # cfg$pipeline$schema for the bundle. Explicit guards rather than a
@@ -359,46 +375,33 @@ fi
 echo "  target schema: $TARGET_SCHEMA"
 
 cd "$REPO_ROOT/data-raw"
-if [ "$NO_CYPHERS" = "0" ]; then
-  SOURCES_R="list(
-    list(host = 'm1',                                  via = 'docker', bucket = strsplit(Sys.getenv('M1_BUCKET'),  ',')[[1]]),
-    list(host = paste0('cypher@', Sys.getenv('CY1_IP')), via = 'docker', bucket = strsplit(Sys.getenv('CY1_BUCKET'), ',')[[1]]),
-    list(host = paste0('cypher@', Sys.getenv('CY2_IP')), via = 'docker', bucket = strsplit(Sys.getenv('CY2_BUCKET'), ',')[[1]]),
-    list(host = paste0('cypher@', Sys.getenv('CY3_IP')), via = 'docker', bucket = strsplit(Sys.getenv('CY3_BUCKET'), ',')[[1]])
-  )"
-  M1_BUCKET="$M1_BUCKET" CY1_BUCKET="$CY1_BUCKET" CY2_BUCKET="$CY2_BUCKET" CY3_BUCKET="$CY3_BUCKET" \
-  CY1_IP="${CY_IP[job1]}" CY2_IP="${CY_IP[job2]}" CY3_IP="${CY_IP[job3]}" \
-  TARGET_SCHEMA="$TARGET_SCHEMA" SOURCES_R="$SOURCES_R" \
-  Rscript -e '
+
+# Build SOURCES_R as a list literal dynamically. M1 always present;
+# any cyphers in CY_WS_ARR get their own entry with IP + bucket. The
+# R-side `eval(parse(text=...))` materializes the list. Each cypher
+# bucket is passed via env var CY_BUCKET_<WS>; each cypher IP via
+# CY_IP_<WS>. The R snippet reads these by Sys.getenv() to avoid
+# quoting hazards across the shell↔R boundary.
+SOURCES_R_LINES="list(\n    list(host = 'm1', via = 'docker', bucket = strsplit(Sys.getenv('M1_BUCKET'), ',')[[1]])"
+ENV_PREFIX="M1_BUCKET=\"$M1_BUCKET\""
+for WS in "${CY_WS_ARR[@]}"; do
+  SOURCES_R_LINES="${SOURCES_R_LINES},\n    list(host = paste0('cypher@', Sys.getenv('CY_IP_${WS}')), via = 'docker', bucket = strsplit(Sys.getenv('CY_BUCKET_${WS}'), ',')[[1]])"
+  ENV_PREFIX="$ENV_PREFIX CY_BUCKET_${WS}=\"${CY_BUCKETS[$WS]}\" CY_IP_${WS}=\"${CY_IP[$WS]}\""
+done
+SOURCES_R="$(printf '%b\n  )' "$SOURCES_R_LINES")"
+
+eval "$ENV_PREFIX TARGET_SCHEMA=\"$TARGET_SCHEMA\" SOURCES_R=\"\$SOURCES_R\" Rscript -e '
 suppressPackageStartupMessages({library(link)})
-source("schema_consolidate.R")
-sources <- eval(parse(text = Sys.getenv("SOURCES_R")))
-result <- schema_consolidate(schema = Sys.getenv("TARGET_SCHEMA"),
+source(\"schema_consolidate.R\")
+sources <- eval(parse(text = Sys.getenv(\"SOURCES_R\")))
+result <- schema_consolidate(schema = Sys.getenv(\"TARGET_SCHEMA\"),
                               sources = sources, backup = TRUE)
 print(result)
-saveRDS(result, "/tmp/consolidate_result.rds")
-' > "$LOG_DIR/${TS}_consolidate.log" 2>&1 || {
-    echo "  ✗ schema_consolidate.R failed; see $LOG_DIR/${TS}_consolidate.log"
-    exit 1
-  }
-else
-  # M1-only consolidate (no cyphers).
-  M1_BUCKET="$M1_BUCKET" TARGET_SCHEMA="$TARGET_SCHEMA" \
-  Rscript -e '
-suppressPackageStartupMessages({library(link)})
-source("schema_consolidate.R")
-result <- schema_consolidate(
-  schema  = Sys.getenv("TARGET_SCHEMA"),
-  sources = list(list(host = "m1", via = "docker",
-                       bucket = strsplit(Sys.getenv("M1_BUCKET"), ",")[[1]])),
-  backup  = TRUE)
-print(result)
-saveRDS(result, "/tmp/consolidate_result.rds")
-' > "$LOG_DIR/${TS}_consolidate.log" 2>&1 || {
-    echo "  ✗ schema_consolidate.R failed; see $LOG_DIR/${TS}_consolidate.log"
-    exit 1
-  }
-fi
+saveRDS(result, \"/tmp/consolidate_result.rds\")
+'" > "$LOG_DIR/${TS}_consolidate.log" 2>&1 || {
+  echo "  ✗ schema_consolidate.R failed; see $LOG_DIR/${TS}_consolidate.log"
+  exit 1
+}
 echo "  ✓ consolidated (see $LOG_DIR/${TS}_consolidate.log)"
 cd "$REPO_ROOT"
 


### PR DESCRIPTION
## Summary

Wires `--cy-workspaces=A,B,C` through `wsgs_run_pipeline.sh` (the operator umbrella) for Tier 1 + Tier 2 of #178. Before this PR the umbrella was hardcoded for `job1,job2,job3` (full provincial) or `--no-cyphers` (M4+M1 only) — single-cypher integration tests couldn't fire because the operator-facing flag never existed at the umbrella layer.

## Tier 1 acceptance (live)

```bash
bash data-raw/wsgs_run_pipeline.sh \
  --wsgs=BULK,KISP,KLUM,MORR,ZYMO,LCHL,NECR,FRAN,MORK,UFRA,WILL,TABR,LSAL \
  --config=default --schema=fresh_default \
  --cy-workspaces=job1 --with-mapping-code
```

| Metric | Result |
|---|---|
| Single autonomous command | ✓ |
| Wall time | 22m (cypher spin + dispatch + consolidate + burn) |
| WSGs in M4 `fresh_default.streams` | **13/13** (Skeena 2024 + Fraser 2025 study area) |
| RDS pulled | 31 OK / 0 errors |
| cy1 burn | ✓ 0 tofu resources, ✓ no doctl droplets |
| Cypher cost | ~$0.50 |

## Changes

- New `--cy-workspaces=A,B,C` flag on the umbrella; default `job1,job2,job3`.
- `CY_WS_ARR` array threaded through Steps 3 (spin), 4 (prep), 5 (archive), 7 (dispatch passthrough), 9 (consolidate sources list), and trap-EXIT burn.
- Step 9 SOURCES_R list literal built dynamically from `CY_WS_ARR`; per-cypher bucket + IP passed via `CY_BUCKET_<WS>` / `CY_IP_<WS>` env vars; R-side `Sys.getenv()` reads by name. Eliminates the CY1/CY2/CY3 triplet assumption.
- Auto-skip-smoke extended: also skips when `--cy-workspaces` differs from canonical 3 (smoke harness assumes full fleet).

Requires bash 4+ for associative arrays (M4 runs 5.x).

## Filed-but-not-closed follow-ups

While running Tier 1 we identified four orthogonal improvements (filed as separate issues, not bundled here):

- **#180** — Step 0 pre-clean should be additive-by-default; `--reset-schema` opts into full wipe.
- **#181** — Add `--tables=schema.table,...` to `state_clean.sh` for surgical drops.
- **#182** — `cypher_prep.sh` pipefail masking (snapshot_bcfp failure → `| tail -5` → silent continue).
- **#183** — Pre-flight sibling-host parity hook (link+fresh version+SHA) with `--auto-install`.

## Test plan

- [x] `bash -n` clean on `wsgs_run_pipeline.sh`
- [x] SOURCES_R construction empirically dry-run verified (1-cypher case → valid R `list(m1, cypher@<ip>)`)
- [x] Tier 1 live: 13/13 WSGs, 22m wall, exit 0
- [x] cy1 burn-clean verified
- [x] `/code-check` clean

## Related Issues

- Closes #178 Tier 1. Tier 2 + Tier 3 still in #178.
- Relates to NewGraphEnvironment/sred-2025-2026#24

Generated with Claude Code
