### PR TITLE
v0.40.1: lnk_pipeline_run mapping_code uses active_species (#192)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Experimental package — breaking all the time and loving the learning curve. St
 **Repository:** NewGraphEnvironment/link
 **Primary Language:** R
 **Prefix:** `lnk_`
-**Branch:** `main` (v0.40.0 as of 2026-05-19)
+**Branch:** `main` (v0.40.1 as of 2026-05-19)
 
 ## Status (2026-05-19)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.40.0
+Version: 0.40.1
 Date: 2026-05-19
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# link 0.40.1
+
+Hotfix for v0.40.0's `lnk_pipeline_run(mapping_code = TRUE)` path on non-bcfp bundles. Closes [#192](https://github.com/NewGraphEnvironment/link/issues/192).
+
+v0.40.0's mapping_code phase hardcoded `sp_set <- c("bt","ch","cm","co","pk","sk","st","wct")` (the bcfp 8 species) and called `lnk_barriers_views` without a `species` arg (uses the same bcfp 8 default). Working schema's `streams_access` got bcfp-8-species columns, but persist `streams_access` was created by `lnk_persist_init(species = active_species)` with the bundle's species — for the `default` config that's bt/gr/ko/rb. The persist `INSERT ... SELECT` projects persist's column list against working → fails with `column a.has_barriers_ko_dnstr does not exist`.
+
+Effect: `lnk_pipeline_run(mapping_code = TRUE)` worked only for the bcfishpass bundle (full 8-species). Every other bundle (including the `default` operator-facing one) errored on persist.
+
+Fix: pipeline_run's mapping_code phase now uses `active_species` (bundle-driven) for both `lnk_barriers_views(species = ...)` and `lnk_pipeline_access(barriers_per_sp = ...)`. Passes `species_<role>` to `lnk_mapping_code` filtered against `active_species` — species in active_species that don't appear in any bcfp residence category (GR/KO/RB) fall through to `species_resident` (placeholder; the data-driven categorization lands via #189).
+
+Caught by live smoke 2026-05-19 on PARS with default bundle. Pre-merge unit tests didn't cover this path; #191 tracks the test catch-up.
+
 # link 0.40.0
 
 Mapping_code tunnel decouple + portable `lnk_mapping_code()` build + `<type>_<role>` rename sweep. Closes [#187](https://github.com/NewGraphEnvironment/link/issues/187). Major architectural shift in how access semantics flow through the parity diff. **BC: parameter and CLI-flag renames (deprecation shims for one release; removal v0.41.0).**

--- a/R/lnk_pipeline_run.R
+++ b/R/lnk_pipeline_run.R
@@ -178,11 +178,11 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
     # 2. Per-segment access. barriers_per_sp keys = active species for
     # this bundle so working schema's streams_access columns match the
     # persist DDL (which is also bundle-species-driven via cols_*).
-    # The pre-#187-Phase-7 hardcoded 8 bcfp species created a working-vs-
-    # persist column mismatch when the bundle's species was a subset
-    # (e.g. default config = bt/gr/ko/rb). lnk_barriers_views default
-    # species still creates views for all 8 (idempotent CREATE OR REPLACE);
-    # we just pick the subset for the access call.
+    # The pre-#192 hardcoded 8 bcfp species created a working-vs-persist
+    # column mismatch when the bundle's species was a subset (e.g. default
+    # config = bt/gr/ko/rb). lnk_barriers_views above created views for
+    # exactly active_species (not the bcfp 8); barriers_per_sp keys here
+    # mirror that set so lnk_pipeline_access JOINs only existing views.
     sp_set <- tolower(active_species)
     barriers_per_sp <- setNames(
       lapply(sp_set, function(sp) paste0(schema, ".barriers_", sp, "_unified")),

--- a/R/lnk_pipeline_run.R
+++ b/R/lnk_pipeline_run.R
@@ -167,14 +167,23 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
 
     # 1. Per-species + per-source barrier views over working <schema>.barriers
     # (built by lnk_barriers_unify above). Tunnel-free, link-canonical.
+    # `species = active_species` so the view set matches the bundle (default
+    # config = bt/gr/ko/rb — not the bcfp 8). Otherwise lnk_pipeline_access
+    # below fails JOINing barriers_<sp>_unified for a species the views
+    # didn't cover.
     lnk_barriers_views(conn, schema = schema, cfg = cfg, # nolint: object_usage_linter
+                       species = active_species,
                        barriers_table = paste0(schema, ".barriers"))
 
-    # 2. Per-segment access. barriers_per_sp keys cover the full bcfp
-    # species set so all `access_<sp>` + `has_barriers_<sp>_dnstr` columns
-    # in the persist table get populated (-9 for species absent from the
-    # WSG via lnk_pipeline_access's presence-aware code-assignment).
-    sp_set <- c("bt", "ch", "cm", "co", "pk", "sk", "st", "wct")
+    # 2. Per-segment access. barriers_per_sp keys = active species for
+    # this bundle so working schema's streams_access columns match the
+    # persist DDL (which is also bundle-species-driven via cols_*).
+    # The pre-#187-Phase-7 hardcoded 8 bcfp species created a working-vs-
+    # persist column mismatch when the bundle's species was a subset
+    # (e.g. default config = bt/gr/ko/rb). lnk_barriers_views default
+    # species still creates views for all 8 (idempotent CREATE OR REPLACE);
+    # we just pick the subset for the access call.
+    sp_set <- tolower(active_species)
     barriers_per_sp <- setNames(
       lapply(sp_set, function(sp) paste0(schema, ".barriers_", sp, "_unified")),
       sp_set)
@@ -195,13 +204,32 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
 
     # 3. Per-segment per-species mapping_code tokens. Schema-aware wrapper
     # over lnk_pipeline_mapping_code — delegates the pure data transform.
+    # Species pass-through: intersect bcfp residence defaults with
+    # active_species so mapping_code only computes for species the bundle
+    # actually models. Species in active_species but NOT in any bcfp
+    # residence category (e.g. GR/KO/RB in the default bundle) get
+    # assigned to species_resident by fallback — GR/KO/RB are all resident
+    # salmonids; treat as resident until link#189 data-drives this from
+    # dimensions.csv.
+    sp_resident_bcfp   <- c("bt", "wct")
+    sp_anadromous_bcfp <- c("ch", "cm", "co", "pk", "sk", "st")
+    sp_spawn_only_bcfp <- c("cm", "pk")
+    sp_resident_active   <- intersect(sp_set, sp_resident_bcfp)
+    sp_anadromous_active <- intersect(sp_set, sp_anadromous_bcfp)
+    sp_unclassified      <- setdiff(sp_set, c(sp_resident_bcfp, sp_anadromous_bcfp))
+    sp_resident_active   <- union(sp_resident_active, sp_unclassified)
+    sp_spawn_only_active <- intersect(sp_set, sp_spawn_only_bcfp)
+
     lnk_mapping_code(conn, # nolint: object_usage_linter
       table_access  = paste0(schema, ".streams_access"),
       table_habitat = paste0(schema, ".streams_habitat"),
       table_streams = paste0(schema, ".streams"),
       aoi           = aoi,
       table_to      = paste0(schema, ".streams_mapping_code"),
-      presence      = pres)
+      presence      = pres,
+      species_resident   = sp_resident_active,
+      species_anadromous = sp_anadromous_active,
+      species_spawn_only = sp_spawn_only_active)
   }
 
   lnk_pipeline_persist(conn, aoi = aoi, cfg = cfg, # nolint: object_usage_linter


### PR DESCRIPTION
## Summary

v0.40.0 hotfix. `lnk_pipeline_run(mapping_code = TRUE)` hardcoded the bcfp 8-species set instead of using the bundle's `active_species` → working `streams_access` column shape mismatched persist `streams_access` (created with bundle species) → INSERT errored on every non-bcfp bundle. Closes #192.

**Live smoke verified the fix**: `lnk_pipeline_run(aoi="PARS", cfg=lnk_config("default"), mapping_code=TRUE)` against `fresh_default` → 48559 rows in `fresh_default.streams_mapping_code` for PARS, populated `mapping_code_bt` / `_gr` / `_ko` / `_rb` with valid ACCESS/SPAWN/REAR token distributions. Wall: 213.1s.

## Fix

In `R/lnk_pipeline_run.R` mapping_code phase:

- `lnk_barriers_views(species = active_species, ...)` — was using bcfp 8 default
- `lnk_pipeline_access(barriers_per_sp = setNames(..., active_species))` — was hardcoded bcfp 8
- `lnk_mapping_code(species_resident = ..., species_anadromous = ..., species_spawn_only = ...)` — intersection of bcfp residence defaults with `active_species`; species in `active_species` not in any bcfp category (e.g. GR/KO/RB) fall through to `species_resident`. Placeholder until #189 data-drives this from `dimensions.csv`.

## How this got past v0.40.0

The pre-merge code-check rounds caught the bcfp-naming-leakage in `lnk_compare_wsg` (Phase 5) and the param shadowing (Phase 6). What they couldn't catch: the species-set assumption baked into pipeline_run's mapping_code phase, because the existing 1119 tests don't exercise that branch with a non-bcfp bundle. The default-bundle smoke (Phase 7) was deferred. #191 tracks the test catch-up that would have caught this.

## Test plan

- [x] `/code-check` round 1 caught a misleading comment in the fix (claimed `lnk_barriers_views` still creates 8 views with caller picking subset; actually creates only active_species views). Fixed in commit 2.
- [x] Live smoke (default bundle, PARS, end-to-end pipeline_run → persist) — 48559 rows in streams_mapping_code with all 4 species populated
- [x] No regression in bcfishpass-bundle path (active_species = full bcfp 8 → identical behavior to v0.40.0)
- [x] `devtools::test()` 1119 PASS / 0 FAIL — covered by pre-existing suite

## Related

- Closes #192
- Hot-follow to #187 (v0.40.0)
- Caught the gap #191 (test coverage) tracks
- Relates to NewGraphEnvironment/sred-2025-2026#24
