### PR TITLE
v0.40.2: lnk_pipeline_run sizes persist DDL to cfg$species (#194)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Experimental package — breaking all the time and loving the learning curve. St
 **Repository:** NewGraphEnvironment/link
 **Primary Language:** R
 **Prefix:** `lnk_`
-**Branch:** `main` (v0.40.1 as of 2026-05-19)
+**Branch:** `main` (v0.40.2 as of 2026-05-19)
 
 ## Status (2026-05-19)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.40.1
+Version: 0.40.2
 Date: 2026-05-19
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# link 0.40.2
+
+Hotfix for wide-table species-set evolution in v0.40.0/v0.40.1's `lnk_pipeline_run(mapping_code = TRUE)` path. Closes [#194](https://github.com/NewGraphEnvironment/link/issues/194).
+
+v0.40.1 made the mapping_code phase use `active_species` (per-WSG subset of bundle species) for working schema's `streams_access` columns — matching the persist DDL because `lnk_persist_init` was also passed `active_species`. But persist is province-wide. When WSG #2 has a different active subset than WSG #1, the persist table is locked to #1's column set and #2's INSERT projection fails:
+
+```
+ERROR: column "has_barriers_ch_dnstr" of relation "streams_access" does not exist
+```
+
+Live smoke 2026-05-19: PARS ran first (default config, active = bt/gr/ko/rb) → 4-column persist DDL. BULK next (default config, active = bt/ch/co/pk/sk/st/rb — BULK is salmon-bearing in the Skeena) → 7-column INSERT projection against 4-column table → fail.
+
+Fix: `lnk_pipeline_run` passes `cfg$species` (full bundle, 11 species for `default` config) to `lnk_persist_init` instead of `active_species`. Persist DDL is bundle-sized; per-WSG INSERTs in `lnk_pipeline_persist` continue using `active_species` for projection so unused species' columns get NULL. Per-species habitat tables (`streams_habitat_<sp>`) similarly created for the full bundle — extras stay empty until populated.
+
+Verified live: PARS + BULK now coexist in `fresh_default.streams_access` / `fresh_default.streams_mapping_code` with their respective active subsets, NULL for non-active columns.
+
+**Migration**: existing persist tables created with narrower DDL do NOT auto-grow. Drop `<persist_schema>.streams_access`, `<persist_schema>.streams_mapping_code`, and `<persist_schema>.streams_habitat_long_vw`, then re-run `lnk_pipeline_run(mapping_code = TRUE)` to recreate them with the bundle-wide DDL.
+
+No regression in bcfishpass bundle: `cfg$species` = bcfp 8 = active for most bcfp-bundle WSGs → identical INSERT projection.
+
 # link 0.40.1
 
 Hotfix for v0.40.0's `lnk_pipeline_run(mapping_code = TRUE)` path on non-bcfp bundles. Closes [#192](https://github.com/NewGraphEnvironment/link/issues/192).

--- a/R/lnk_pipeline_run.R
+++ b/R/lnk_pipeline_run.R
@@ -145,7 +145,16 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
          call. = FALSE)
   }
 
-  lnk_persist_init(conn, cfg, species = active_species) # nolint: object_usage_linter
+  # Persist DDL sized to the FULL bundle (cfg$species), not the per-WSG
+  # active subset (link#194). Wide tables (streams_access,
+  # streams_mapping_code) have one column per species — first WSG would
+  # lock the column set if we passed active_species, then subsequent WSGs
+  # with different active sets would fail INSERT. Per-WSG INSERTs still
+  # use active_species (in lnk_pipeline_persist below) so unused species'
+  # columns get NULL for WSGs that don't model them. Per-species habitat
+  # tables (streams_habitat_<sp>) get created for the full bundle too —
+  # empty tables for species no WSG populates are cheap.
+  lnk_persist_init(conn, cfg, species = cfg$species) # nolint: object_usage_linter
 
   # Always unify barriers — makes `<persist_schema>.barriers` canonical
   # for any future reader (e.g. a decoupled mapping_code comparison).


### PR DESCRIPTION
## Summary

v0.40.1 hotfix. `lnk_pipeline_run` now passes `cfg$species` (full bundle) to `lnk_persist_init` instead of `active_species` (per-WSG subset). Persist DDL is bundle-sized so heterogeneous-active-set WSGs coexist in the same persist tables. Closes #194.

**Live verified**: PARS (active = bt/gr/ko/rb) then BULK (active = bt/ch/co/pk/sk/st/rb) both populate `fresh_default.streams_access` + `fresh_default.streams_mapping_code` after drop+re-init. Persist DDL = 24 cols (id_segment + watershed_group_code + 11 species × 2). Each WSG's INSERT covers its active subset; non-active species' columns get NULL. Tunnel was down throughout — confirms tunnel-free pipeline_run path.

## Fix

One-line change in `R/lnk_pipeline_run.R`:
- Before: `lnk_persist_init(conn, cfg, species = active_species)` — first WSG locks persist DDL to its species subset.
- After: `lnk_persist_init(conn, cfg, species = cfg$species)` — bundle-wide persist DDL.

`lnk_pipeline_persist` continues using `active_species` for per-WSG INSERT projection (unchanged) so unused species' columns get NULL.

## Migration

Existing persist tables created with narrower DDL do NOT auto-grow. Drop and re-init:

```sql
DROP TABLE IF EXISTS <persist_schema>.streams_access;
DROP TABLE IF EXISTS <persist_schema>.streams_mapping_code;
DROP VIEW IF EXISTS <persist_schema>.streams_habitat_long_vw;
```

Then re-run `lnk_pipeline_run(mapping_code = TRUE)` for any WSG to recreate them at bundle width.

## Test plan

- [x] `/code-check` round 1 clean
- [x] Live verification: PARS + BULK end-to-end with default bundle, drop + re-init persist, both populate correctly with active-subset projections + NULL elsewhere
- [x] No regression in bcfishpass bundle: `cfg$species` = bcfp 8 = active for most bcfp-bundle WSGs → identical projection
- [x] Tunnel-free path verified: ran with tunnel down, exit 0

## Related

- Closes #194
- Hot-follow to #192 (v0.40.1) which fixed the working-schema half of the species-set issue but missed the persist-DDL half
- Caught by live smoke — same gap #191 (test coverage) tracks
- Relates to NewGraphEnvironment/sred-2025-2026#24
