### PR TITLE
v0.40.3: persist per-source flags in streams_access (#196)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,18 @@
 
 Experimental package — breaking all the time and loving the learning curve. Stream-network habitat-classification tooling layered over `fresh`. Under active development; APIs and outputs change without notice.
 
+> **Read [`RUNBOOK.md`](RUNBOOK.md) first.** It is the durable mental model of the barrier → access → mapping_code machinery (what feeds what, where each rule lives, the gotchas). This `CLAUDE.md` carries conventions + status; the RUNBOOK carries the *mechanics*. Don't re-derive the system from source each session — read the runbook, and update it in-commit when the mechanics change.
+
 ## Repository Context
 
 **Repository:** NewGraphEnvironment/link
 **Primary Language:** R
 **Prefix:** `lnk_`
 **Branch:** `main` (v0.40.2 as of 2026-05-19)
+
+## Status (2026-05-23) — ACTIVE HANDOFF
+
+**Picking up this repo? Read [`planning/active/HANDOFF.md`](planning/active/HANDOFF.md) first, then [`RUNBOOK.md`](RUNBOOK.md).** Work on branch `196-streams-access-source-flags` is mid-stream and handing off to M1. The mapping_code/access mechanism is solved and the next fix (Phase 4d) is scoped — do not start over. v0.40.3 (persist per-source flags) is ready to ship; the dam/access divergence is characterized with a drafted fix + issue.
 
 ## Status (2026-05-19)
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.40.2
-Date: 2026-05-19
+Version: 0.40.3
+Date: 2026-05-23
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",
            role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# link 0.40.3
+
+Persist the per-source downstream-barrier flag columns in `streams_access` so `lnk_pipeline_mapping_code`'s second token (`DAM`/`MODELLED`/`ASSESSED`/`REMEDIATED`/`NONE`) populates from persisted state instead of defaulting to `NONE`. Three coupled fixes ([#196](https://github.com/NewGraphEnvironment/link/issues/196)): `lnk_persist_init` adds the six flag columns to the `streams_access` DDL; `lnk_pipeline_run` pre-persists barriers before the mapping_code phase for cross-WSG dam visibility (link#152); `lnk_pipeline_persist` projects the flag columns in the INSERT (the DDL/INSERT pair must match — the missing projection was the actual `NONE`-token bug).
+
+Adds `RUNBOOK.md` — the durable mental model of the barrier → access → mapping_code machinery, including the authoritative bcfp access-set mechanism (read from `smnorris/bcfishpass@v0.7.15`). Note: the per-species *accessibility* set still carries dams (it should be natural-only + observation/habitat-overridden, per bcfp); dam-downstream segments therefore still emit a bare habitat token rather than `SPAWN;DAM`. Characterized in RUNBOOK §5 with a scoped fix (follow-up issue).
+
 # link 0.40.2
 
 Hotfix for wide-table species-set evolution in v0.40.0/v0.40.1's `lnk_pipeline_run(mapping_code = TRUE)` path. Closes [#194](https://github.com/NewGraphEnvironment/link/issues/194).

--- a/R/lnk_persist_init.R
+++ b/R/lnk_persist_init.R
@@ -60,12 +60,34 @@ cols_streams_access_base <- c(
   id_segment                = "integer NOT NULL",
   watershed_group_code      = "varchar(4) NOT NULL"
 )
-# Conditional cols `remediated_dnstr_ind` + `has_observation_key_upstr`
-# are written by lnk_pipeline_access only when remediations /
-# observations tables are passed. Omitted from the persist base shape
-# until a consumer requires them — adding them would force every caller
-# to pass those upstream tables. Re-introduce as nullable columns + a
-# null-tolerant persist projection when needed.
+#' Per-source flag column generator for `streams_access` (link#196).
+#'
+#' Returns a named character vector keyed by column-name → DDL type for
+#' the per-barrier-source downstream flags + the indicator columns.
+#' These columns are consumed by `lnk_pipeline_mapping_code` for the
+#' second-token classification (DAM / MODELLED / ASSESSED / REMEDIATED /
+#' NONE). Without them persisted, `lnk_mapping_code` reads the persist
+#' table and finds the flags absent → all second tokens default to
+#' NONE (the v0.40.2 PARS BT bug).
+#'
+#' Hardcoded source classes (anthropogenic / pscis / dams /
+#' remediations) match the keys `lnk_pipeline_run` passes as
+#' `barrier_sources` to `lnk_pipeline_access`. Data-driving these per
+#' bundle is link#197 territory.
+#' @noRd
+.lnk_cols_streams_access_source_flags <- function() {
+  c(
+    has_barriers_anthropogenic_dnstr = "boolean",
+    has_barriers_pscis_dnstr         = "boolean",
+    has_barriers_dams_dnstr          = "boolean",
+    has_barriers_remediations_dnstr  = "boolean",
+    dam_dnstr_ind                    = "boolean",
+    remediated_dnstr_ind             = "boolean"
+  )
+}
+
+# `has_observation_key_upstr` is observations-conditional; still
+# omitted from the persist base shape until a consumer requires it.
 
 #' Per-species column generator for `streams_access`.
 #'
@@ -358,6 +380,7 @@ lnk_persist_init <- function(conn, cfg, species, force_recreate = FALSE) {
   # consumer expectation + bcfp's `bcfishpass.streams_access` shape.
   # Generated DDL: base cols + dynamic per-species (has_barriers + access).
   cols_streams_access <- c(cols_streams_access_base,
+                           .lnk_cols_streams_access_source_flags(),
                            .lnk_cols_streams_access_per_sp(species))
   .lnk_db_execute(conn, sprintf(
     "CREATE TABLE IF NOT EXISTS %s.streams_access (\n  %s\n)",

--- a/R/lnk_pipeline_persist.R
+++ b/R/lnk_pipeline_persist.R
@@ -119,7 +119,13 @@ lnk_pipeline_persist <- function(conn, aoi, cfg, species,
   ))) > 0L
   if (access_present) {
     access_table <- paste0(tn$schema, ".streams_access")
+    # MUST mirror the DDL column set in lnk_persist_init exactly:
+    # base + per-source flags (#196) + per-species. Missing the source
+    # flags here was the v0.40.3 bug — DDL had the columns but the INSERT
+    # projection didn't populate them, so they stayed NULL and
+    # lnk_pipeline_mapping_code's second token defaulted to NONE.
     access_cols_v <- c(cols_streams_access_base,
+                       .lnk_cols_streams_access_source_flags(),
                        .lnk_cols_streams_access_per_sp(species))
     access_cols <- paste(names(access_cols_v), collapse = ", ")
     # SELECT projection: pull watershed_group_code from streams (JOIN),

--- a/R/lnk_pipeline_run.R
+++ b/R/lnk_pipeline_run.R
@@ -197,14 +197,20 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
     lnk_barriers_views(conn, schema = schema, cfg = cfg, # nolint: object_usage_linter
                        species = active_species)
 
-    # 2. Per-segment access. barriers_per_sp keys = active species for
-    # this bundle so working schema's streams_access columns match the
-    # persist DDL (which is also bundle-species-driven via cols_*).
-    # The pre-#192 hardcoded 8 bcfp species created a working-vs-persist
-    # column mismatch when the bundle's species was a subset (e.g. default
-    # config = bt/gr/ko/rb). lnk_barriers_views above created views for
-    # exactly active_species (not the bcfp 8); barriers_per_sp keys here
-    # mirror that set so lnk_pipeline_access JOINs only existing views.
+    # 2. Per-segment access. barriers_per_sp drives `accessible` (token1
+    # ACCESS + token2 gate). KNOWN-DIVERGENT from bcfp — see RUNBOOK.md §5.
+    # bcfp's per-species access set (`barriers_<sp>`, built in
+    # smnorris/bcfishpass model/01_access/sql/model_access_bt.sql) is
+    # NATURAL barriers only (gradient at the species threshold + falls +
+    # subsurface), MINUS barriers with upstream observations / confirmed
+    # habitat, plus user_definite — dams are NEVER in it (they annotate
+    # access via token2, not block it). link's `_unified` views instead
+    # carry ALL barriers incl dams (blocks_species universal, §2a), so
+    # dam-downstream segments read inaccessible and lose their `;DAM`
+    # token. The correct fix is a natural-only per-species *feature* view
+    # with the override applied (reproducing bcfp barriers_<sp>) — real
+    # work, scoped separately, not a table swap. `_min` cannot be used
+    # here: it is a break-spec with no id column (RUNBOOK §2b).
     sp_set <- tolower(active_species)
     barriers_per_sp <- setNames(
       lapply(sp_set, function(sp) paste0(schema, ".barriers_", sp, "_unified")),

--- a/R/lnk_pipeline_run.R
+++ b/R/lnk_pipeline_run.R
@@ -174,15 +174,28 @@ lnk_pipeline_run <- function(conn, aoi, cfg, loaded,
   if (isTRUE(mapping_code)) {
     pres <- lnk_presence(loaded$wsg_species_presence, aoi) # nolint: object_usage_linter
 
-    # 1. Per-species + per-source barrier views over working <schema>.barriers
-    # (built by lnk_barriers_unify above). Tunnel-free, link-canonical.
-    # `species = active_species` so the view set matches the bundle (default
-    # config = bt/gr/ko/rb — not the bcfp 8). Otherwise lnk_pipeline_access
-    # below fails JOINing barriers_<sp>_unified for a species the views
-    # didn't cover.
+    # 0. Pre-persist current WSG's barriers + streams + habitat into
+    # <persist_schema> BEFORE building views. lnk_barriers_views defaults
+    # to reading the persist barriers table — necessary for cross-WSG
+    # access lookups (e.g. PARS BT through Bennett dams in PCEA/UPCE,
+    # link#152). My #187 Phase 4 worked around an ordering issue by
+    # pointing views at working <schema>.barriers, but that loses the
+    # cross-WSG visibility. Fix: persist current WSG's barriers FIRST,
+    # so persist holds current + all previously-persisted WSGs by the
+    # time the views are built. Second persist call below re-runs
+    # idempotently and adds streams_access + streams_mapping_code.
+    # link#196.
+    lnk_pipeline_persist(conn, aoi = aoi, cfg = cfg, # nolint: object_usage_linter
+                         species = active_species, schema = schema)
+
+    # 1. Per-species + per-source barrier views over PERSIST
+    # <persist_schema>.barriers (default — see #196). Province-wide,
+    # tunnel-free, link-canonical. Sees current WSG (just persisted) +
+    # all previously-persisted WSGs (cross-WSG dam visibility).
+    # `species = active_species` so the view set matches the bundle
+    # (default config = bt/gr/ko/rb — not the bcfp 8).
     lnk_barriers_views(conn, schema = schema, cfg = cfg, # nolint: object_usage_linter
-                       species = active_species,
-                       barriers_table = paste0(schema, ".barriers"))
+                       species = active_species)
 
     # 2. Per-segment access. barriers_per_sp keys = active species for
     # this bundle so working schema's streams_access columns match the

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -10,6 +10,41 @@ bitten us. When the mechanics change, update this file in the same commit.
 
 ---
 
+## 0. Getting going (operate on a fresh machine — e.g. M1)
+
+The modelling runs against a local Postgres (docker `fresh-db`) holding the bcfp
+inputs. DB state is **machine-local** — rebuild it from public sources, no DB
+dump needed. One-time prereqs (GDAL+Parquet driver, uv, bcdata, psql) install via
+kdot `install_geo.sh`.
+
+```bash
+# 1. Docker daemon + local fwapg
+open -a Docker                                    # if daemon down; wait ~30s
+cd ~/Projects/repo/fresh/docker && docker compose up -d db
+
+# 2. Install link
+cd ~/Projects/repo/link && Rscript -e 'pak::local_install(upgrade = FALSE, ask = FALSE)'
+
+# 3. Snapshot bcfp inputs into local fwapg (tunnel-free, public sources, ~5-8 min)
+PGUSER=postgres PGPASSWORD=postgres PGHOST=localhost PGPORT=5432 PGDATABASE=fwapg \
+  bash data-raw/snapshot_bcfp.sh --with-bcfp-views --force
+#   loads whse_fish.pscis_*, cabd.dams, fresh.modelled_stream_crossings,
+#   bcfishobs.observations (+ bcfp crossings_vw). streams_vw silently fails
+#   (1.6 GB, see §6) — use the tunnel for bcfp streams parity instead.
+
+# 4. bcfp comparison tunnel (parity diffs ONLY — the build itself is tunnel-free)
+ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+  -L 63333:127.0.0.1:5432 db_newgraph -N -f
+psql "host=localhost port=63333 dbname=bcfishpass user=newgraph" \
+  -c "SELECT model_run_id, model_version FROM bcfishpass.log ORDER BY 1 DESC LIMIT 1;"
+```
+
+Local fwapg conn: `host=localhost port=5432 dbname=fwapg user=postgres
+password=postgres`. (M1's `~/.Renviron` defaults `PG_*_SHARE` to the tunnel
+`:63333` — for the local build set `Sys.setenv()` to `:5432` in R; see the
+m1-testing pattern in `fresh/CLAUDE.md`.) Then build:
+`lnk_pipeline_run(conn, "PARS", cfg, loaded, schema, mapping_code = TRUE)`.
+
 ## 1. The big picture
 
 link reproduces bcfishpass's per-segment, per-species habitat + connectivity

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,364 @@
+# link RUNBOOK — how the system actually works
+
+Durable mental model of link's barrier → access → mapping_code machinery.
+Written because the data flow spans ~8 R files and gets re-derived from scratch
+every session (especially after context compaction). Read this first.
+
+For *what's shipped* and *conventions*, see `CLAUDE.md`. This doc is the
+*mechanics*: what feeds what, where each rule lives, and the gotchas that have
+bitten us. When the mechanics change, update this file in the same commit.
+
+---
+
+## 1. The big picture
+
+link reproduces bcfishpass's per-segment, per-species habitat + connectivity
+classification, tunnel-free, for any watershed group (WSG) or AOI.
+
+```
+per-WSG pipeline (lnk_pipeline_run, working schema working_<aoi>)
+  setup → load → prepare → crossings → barriers_unify → break → classify
+        → connect → species → persist_init → persist
+                                                  │
+   with mapping_code = TRUE, an extra phase runs before persist:
+        barriers_views → pipeline_access → mapping_code
+                                                  │
+                                                  ▼
+   persist (province-wide <persist_schema>, e.g. fresh_default)
+     streams, streams_habitat_<sp>, barriers,
+     streams_access, streams_mapping_code, streams_habitat_long_vw (view)
+```
+
+The **working schema** is per-WSG scratch. The **persist schema** is
+province-wide and cross-WSG — this is what QGIS, comparisons, and the
+mapping_code views read. Persisting is idempotent per WSG (DELETE-WHERE-WSG +
+INSERT).
+
+---
+
+## 2. Barriers: the heart of it
+
+### 2a. `blocks_species` — the per-segment blocking predicate
+
+`lnk_barriers_unify()` consolidates four barrier families into
+`<schema>.barriers`, each row carrying a **`blocks_species text[]`** column.
+`lnk_pipeline_access` later asks `WHERE 'BT' = ANY(blocks_species)`.
+
+**The blocking rule depends on the barrier family — this is the single most
+important table in the system:**
+
+| Family | Source table | `blocks_species` | Species-specific? |
+|---|---|---|---|
+| **Gradient** | `gradient_barriers_raw` | species where `access_gradient_max ≤ gradient_class/100` | **YES** — from `parameters_fresh.csv` |
+| **Anthropogenic** (PSCIS, **CABD dams**, modelled crossings) | `crossings WHERE barrier_status IN ('BARRIER','POTENTIAL')` | **ALL species** (universal) | **NO** |
+| **Falls** | `falls` | ALL species | NO |
+| **Subsurface flow** | `barriers_subsurfaceflow` (opt-in) | ALL species | NO |
+
+Gradient classes (`gradient_barriers_raw.gradient_class`, basis points) map to
+fractional thresholds via `.lnk_classes_bcfp` (`lnk_pipeline_prepare.R`):
+`1500→0.15, 2000→0.20, 2500→0.25, 3000→0.30`. A class blocks species `s` when
+`class_value ≥ s$access_gradient_max`. BT's `access_gradient_max` is 0.25, so a
+2500-class gradient blocks BT; CH/CO/SK at 0.15 are blocked from 1500 up.
+
+**Key consequence: dams block *all* species universally.** There is no
+per-species dam rule in any config file. A dam (CABD, via the anthropogenic
+family) gets `blocks_species = {all species}`. **This is the #196 bug.** bcfp
+does NOT put dams in the per-species *access* set at all (§5) — they're a
+downstream *descriptor*, not an accessibility barrier. link conflating the two
+in `blocks_species` is the root cause; see §5 for the authoritative bcfp
+mechanism and the fix shape.
+
+Remediations (PASSABLE) are **not** in `blocks_species`. They flow separately
+via `<schema>.barriers_remediations` for the sequence-aware `remediated_dnstr_ind`.
+
+### 2b. The three barrier table shapes — do not confuse them
+
+| Shape | Example | Columns | Built for | Has feature id? |
+|---|---|---|---|---|
+| **break-spec** | `barriers_<sp>_min` | `blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree` | `frs_break_apply` (segmenting streams) | **NO** |
+| **feature view** | `barriers_<sp>_unified` | `id_barrier AS barriers_<sp>_unified_id, barrier_source, blocks_species, geom, …` | `frs_network_features` (downstream walks) | **YES** |
+| **persist table** | `<persist>.barriers` | `cols_barriers` shape | cross-WSG source of truth | YES (`id_barrier`) |
+
+`barriers_<sp>_unified` is a **view over the persist `barriers` table**, filtered
+`WHERE '<SP>' = ANY(blocks_species)`. Because it reads persist (province-wide),
+it sees **cross-WSG** barriers — this is the link#152 fix (PARS drains through
+dams in PCEA/UPCE; those dams are only visible via persist, never in PARS-local
+tables).
+
+`barriers_<sp>_min` (gradient + falls, minimal-reduced) is a **break-spec** — it
+has NO id column, so it **cannot** feed `frs_network_features` /
+`barriers_per_sp`. (Tried in #196; failed with `barriers_bt_min_id does not
+exist`.) `barriers_per_sp` mechanically requires the *feature view* shape.
+
+---
+
+## 3. Access: `lnk_pipeline_access()`
+
+Computes `<schema>.streams_access` — per-segment, per-species accessibility plus
+downstream barrier-source flags. Two distinct inputs, two distinct roles:
+
+- **`barriers_per_sp`** — named list `sp → barriers_<sp>_unified`. Drives
+  `has_barriers_<sp>_dnstr` (is a blocking barrier downstream for this species).
+  This is **accessibility** — feeds `accessible` in mapping_code. Each table's
+  feature id is derived as `<table>_id` and passed to `frs_network_features`.
+- **`barrier_sources`** — named list of source-typed feature tables
+  (`anthropogenic`, `pscis`, `dams`, `remediations`). Drives the
+  `has_barriers_<source>_dnstr` / `dam_dnstr_ind` / `remediated_dnstr_ind`
+  flags. This is **classification** (what *kind* of barrier is downstream), NOT
+  accessibility. Feeds token2 (DAM/MODELLED/ASSESSED/…).
+
+The output flag columns (`has_barriers_{anthropogenic,pscis,dams,remediations}_dnstr`,
+`dam_dnstr_ind`, `remediated_dnstr_ind`) MUST be persisted — see §6 gotcha.
+
+---
+
+## 4. mapping_code tokens: `lnk_pipeline_mapping_code()`
+
+Token format: `{ACCESS|SPAWN|REAR|""};{NONE|DAM|MODELLED|ASSESSED|REMEDIATED}[;INTERMITTENT]`
+
+For each species, per segment (`lnk_pipeline_mapping_code.R:~196-289`):
+
+```
+accessible = !has_barriers_<sp>_dnstr  &  has_data        # from barriers_per_sp
+
+token1 (non-spawn-only):
+  ACCESS  if accessible AND spawning==0 AND rearing==0     # accessible, no habitat
+  SPAWN   elif spawning > 0                                # ← fires regardless of access
+  REAR    elif spawning==0 AND rearing > 0                 # ← fires regardless of access
+  else NA
+
+token2 = ifelse(accessible, mc_barrier, NA)                # ← GATED on accessible
+token3 = ifelse(accessible & intermittent, "INTERMITTENT", NA)
+
+mc_barrier (from barrier_sources flags, resident vs anadromous differ slightly):
+  REMEDIATED if remediated_dnstr
+  DAM        elif dam_dnstr
+  ASSESSED   elif anthropogenic & pscis        (resident) / elif pscis (anadr)
+  MODELLED   elif anthropogenic                (no pscis)
+  NONE       elif no anthropogenic
+```
+
+Note the asymmetry: **SPAWN/REAR fire on habitat presence regardless of
+accessibility**, but **token2 (the barrier descriptor) is suppressed when the
+segment is inaccessible**.
+
+`no_data` (NA `has_barriers_<sp>_dnstr`) → emit `""`. Species absent from the WSG
+(via `presence`) → emit `""` for all rows.
+
+---
+
+## 5. The per-species access set — how bcfp does it (and where link diverges)
+
+This is THE thing to understand. Source of truth, read 2026-05-23 from
+`smnorris/bcfishpass@v0.7.15` (read-only via `gh api`):
+
+- `model/01_access/sql/model_access_bt.sql` — builds `bcfishpass.barriers_bt`
+- `model/01_access/sql/load_streams_access.sql` — rolls per-species barriers
+  downstream into `streams_access`
+- `model/02_habitat_linear/sql/load_streams_mapping_code.sql` — token assembly
+
+### bcfp's `barriers_<sp>` = natural-only, species-specific, override-filtered
+
+`barriers_bt` (the per-species set that drives accessibility) is built as:
+
+```
+( barriers_gradient WHERE barrier_type IN ('GRADIENT_25','GRADIENT_30')   -- ≥ BT's 25% threshold
+  ∪ barriers_falls
+  ∪ barriers_subsurfaceflow )
+  MINUS barriers with any upstream BT/salmon/steelhead OBSERVATION   -- "fish above ⟹ passable"
+  MINUS barriers with any upstream confirmed HABITAT (user_habitat_classification)
+  ∪ ALL barriers_user_definite                                      -- user hard barriers, never overridden
+```
+
+Salmon use the lower gradient classes; that's the per-species axis. **Dams,
+PSCIS, and modelled crossings are NOT in `barriers_<sp>` at all.** They never
+make a segment inaccessible.
+
+Anthropogenic barriers live in a SEPARATE axis: `streams_access` carries both
+`barriers_<sp>_dnstr` (per-species access, natural+definite) AND
+`barriers_anthropogenic_dnstr` / `barriers_dams_dnstr` / `barriers_pscis_dnstr`
+(descriptors). `dam_dnstr_ind = array[barriers_anthropogenic_dnstr[1]] &&
+barriers_dams_dnstr` — "is the next downstream anthropogenic barrier a dam?".
+
+### How bcfp emits `SPAWN;DAM`
+
+mapping_code (`load_streams_mapping_code.sql`) gates the barrier token on
+`barriers_bt_dnstr = array[]::text[]` (accessible) — **identical to link's
+`ifelse(accessible, mc_barrier, NA)`**. So `SPAWN;DAM` happens when:
+`barriers_bt_dnstr = []` (no NATURAL barrier downstream → accessible) AND
+`spawning_bt > 0` (token1 SPAWN) AND `dam_dnstr_ind = true` (a dam is downstream
+→ token2 DAM). The dam doesn't block access; it annotates it.
+
+### Where link diverges (the #196 bug, fully characterized)
+
+link's `barriers_per_sp = barriers_<sp>_unified` = **all** barriers (incl dams,
+PSCIS, modelled) WHERE species ∈ `blocks_species` (§2a). Two wrongs:
+
+1. **Wrong content.** It includes dams/anthropogenic. bcfp's `barriers_<sp>` is
+   natural-only. So every PARS segment below a dam reads `has_barriers_bt_dnstr
+   = TRUE` → `accessible = FALSE` → token2 `;DAM` suppressed → bare `SPAWN`.
+2. **No override applied.** bcfp removes barriers with upstream observations /
+   confirmed habitat. link HAS this logic — `lnk_barrier_overrides`
+   (`lnk_pipeline_prepare.R:519`) — but its output `<schema>.barrier_overrides`
+   feeds only `lnk_pipeline_classify` (habitat gating), NOT
+   `lnk_pipeline_access` (mapping_code accessibility). So link's habitat token
+   (SPAWN/REAR) is override-aware but its `accessible` flag is not.
+
+Note: link's `access_<sp>` integer (`lnk_pipeline_access.R:364`,
+`ifelse(blocked, 0, ifelse(observed, 2, 1))`) IS observation-aware and matches
+bcfp's `access_bt` code — but mapping_code reads `has_barriers_<sp>_dnstr`, not
+`access_<sp>`.
+
+### The fix shape
+
+`barriers_per_sp` must reproduce bcfp's `barriers_<sp>`: a **feature-shaped**
+(has-id, §2b) per-species view of **natural barriers only** — gradient at the
+species' threshold + falls + subsurface — with the observation/habitat override
+applied and `user_barriers_definite` unioned in. Dams stay in `barrier_sources`
+(token2 only). This is real work (a per-species access-barrier builder), not a
+table swap. Confirm with `fresh.streams_vw_bcfp` once it loads (the snapshot's
+streams view failed on a transient gzip error 2026-05-23; retry).
+
+What does **NOT** work: `barriers_<sp>_min` (break-spec, no id, §2b) — though its
+*content* (gradient+falls) is close to the right base.
+
+### Does dam blocking "depend on species"? (recurring question)
+
+Two senses, keep them apart:
+
+- **Access (does a dam make a segment inaccessible):** NO — confirmed across both
+  bcfp models (`model_access_bt.sql` uses `GRADIENT_25/30`;
+  `model_access_ch_cm_co_pk_sk.sql` uses `GRADIENT_15/20/25/30`). **No species'
+  access set contains dams.** Accessibility *is* species-specific, but via two
+  levers that **already live in `parameters_fresh.csv`** — you do NOT add dam
+  rules to match bcfp:
+  - `access_gradient_max` → gradient class per species (salmon 0.15, BT 0.25).
+  - `observation_threshold` / `observation_date_min` / `observation_species` →
+    the override. These match bcfp exactly: BT row = threshold 1, date 1900,
+    species `BT;CH;CO;SK;PK;CM;ST` (bcfp: ≥1 obs, BT+salmon+steelhead, "passable
+    by salmon ⟹ passable by BT"); CH row = threshold 5, date 1990, species
+    `CH;CM;CO;PK;SK` (bcfp: >5 obs since 1990). The rules exist and are
+    species-specific; they're just not wired into `lnk_pipeline_access` yet.
+- **Descriptor (token2):** YES, species-class-specific and already in link —
+  resident (`mcbi_r`: next-downstream-dam, sequence-aware via `dam_dnstr_ind`)
+  vs anadromous (`mcbi_a`: any dam downstream via `barriers_dams_dnstr`).
+
+**Extend-vs-reproduce fork — "dam override":** many CABD dams exist on paper but
+are passable (decommissioned, partial, fishway-equipped, or fish demonstrably
+above). The *general* version of this — let a dam be overridden out of the
+relevant set by evidence — should **reuse the existing override machinery**
+(`lnk_barrier_overrides`: observations / confirmed habitat / control), NOT a
+bespoke fishway-passability model. The CABD `passability_status` mapping already
+drops `Passable` dams (`barrier_status='PASSABLE'`); "dam override" extends the
+same evidence-based rules to the rest. Call it **dam-override** (the situation
+varies — fishway is just one case; the name shouldn't bake in the mechanism).
+This is a **departure from bcfp** (bcfp keeps all dams as descriptors and never
+overrides them per-species) and an opt-in axis — it breaks the exact-reproduction
+bar (CLAUDE.md), so decide deliberately: match bcfp first (wiring fix above),
+then layer dam-override on the same rules engine.
+
+### Validation WSGs (dam-influenced)
+
+bcfp dams by WSG (from `fresh.crossings_vw_bcfp`): the canonical dam +
+anadromous-above test is **LFRA** (Lower Fraser) — Coquitlam, Alouette, Stave
+Falls, Ruskin dams, all classic sockeye-reintroduction-above-dam cases where the
+observation override drives above-dam access. **PARS** (resident/BT, drains
+through Bennett=PCEA / Peace Canyon=UPCE) covers the resident flavor. Validate
+the access fix on **PARS + LFRA together** — resident + anadromous, two dam
+systems, exercises both `mcbi_r`/`mcbi_a` paths.
+
+### Design implication: `blocks_species` is probably the wrong abstraction
+
+bcfp has no binary "blocks_species" predicate. It keeps two orthogonal axes:
+**natural access** (per-species, gradient-typed, observation/habitat-overridden)
+and **anthropogenic descriptor** (dam/pscis/modelled, passability-typed). link's
+`blocks_species text[]` collapses both into one set computed once at unify time —
+which (a) bakes dams into access wrongly, and (b) loses the override (computed
+later). A redesign that carries barrier *ingredients* (type, gradient class,
+passability, fishway) and classifies access *late and per-context* — the way
+fresh's `label` / `label_block` gradation already allows — is the abstract-system
+direction. Not yet scoped; candidate issue.
+
+---
+
+## 6. Gotchas that have cost real time
+
+- **Persist column changes are a matched pair.** Adding a column to
+  `streams_access` / `streams_mapping_code` means editing **two independently
+  constructed sites**: the CREATE TABLE DDL in `lnk_persist_init.R` *and* the
+  INSERT projection in `lnk_pipeline_persist.R`. The DDL having the column does
+  NOT make the INSERT populate it — they don't share a projection. Missing the
+  source-flag generator in the INSERT was the v0.40.3 `NONE`-token bug. Verify
+  DDL + INSERT together against live data.
+- **Tunnel-free build, tunnel-only diff.** The *build* (pipeline_run +
+  mapping_code) needs **no tunnel** — gradient/falls are local, cross-WSG dams
+  come from persist. The bcfp tunnel (`localhost:63333`) is needed ONLY for the
+  parity *diff*, and it's flaky. Prefer the local snapshot
+  (`fresh.streams_vw_bcfp`) over the live tunnel for comparison — it's
+  tunnel-free and reproducible. The tunnel will be retired.
+- **Redo the snapshot weekly.** bcfp rebuilds Tuesdays (`bcfishpass.log` →
+  `model_run_id`, `model_version`). `bash data-raw/snapshot_bcfp.sh
+  --with-bcfp-views --force` (PG* env → local docker fwapg) refreshes both
+  link's inputs AND `fresh.*_vw_bcfp` for comparison. Tunnel-free (public
+  sources: BCDC, CABD, bchamp objectstore, s3://newgraph).
+- **`snapshot_bcfp.sh --with-bcfp-views` silently ships no streams.** The
+  `bcfishpass.streams_vw.fgb.zip` on s3 is ~1.6 GB and won't stream through
+  `ogr2ogr /vsizip//vsicurl` — the gzip read dies mid-file (`decompression
+  failed z_err=-1`). Worse: **ogr2ogr exits 0** on this premature termination,
+  so the snapshot's `set -euo pipefail` doesn't catch it and the script reports
+  success with only `crossings_vw_bcfp` loaded (the small view streams fine).
+  The parity-critical streams comparison data is just missing. Fix when touched:
+  download the zip with `curl` first, `unzip`, then `ogr2ogr` from the local
+  `.fgb`; and verify a row count post-load rather than trusting the exit code.
+  Until then, `streams_vw_bcfp` parity needs the ~1.6 GB download or the tunnel.
+- **Don't persist from a half-built working schema.** `lnk_pipeline_persist`
+  DELETE-WHERE-WSGs the persist tables before INSERT — running it against an
+  incomplete working schema wipes good province-wide data for that WSG.
+- **Double-persist wall time.** `mapping_code = TRUE` currently pre-persists
+  barriers (for cross-WSG views) *and* persists at the end → PARS ~16 min vs
+  ~3.5 min normal. Pre-persisting only barriers (not streams+habitat) is the
+  open optimization (#196 Phase 5).
+
+---
+
+## 7. Where every rule lives
+
+| Rule | File | Drives |
+|---|---|---|
+| Per-species gradient access threshold | `configs/<name>/parameters_fresh.csv` → `access_gradient_max` | gradient `blocks_species` (§2a) |
+| Per-species observation override | `parameters_fresh.csv` → `observation_*` | barrier-skip via observations |
+| Habitat dimensions (spawn/rear by gradient, channel width, lake/stream, …) | `configs/<name>/dimensions.csv` → `lnk_rules_build()` → `rules.yaml` | `frs_habitat_classify()` (token1 habitat) |
+| Species residence (resident/anadromous/spawn-only) | **hardcoded** defaults in `lnk_pipeline_mapping_code()` | which mc_barrier flavor + spawn-only token1 |
+| Dam / anthropogenic blocking | **nowhere** — universal `all species` in `lnk_barriers_unify` | `blocks_species` (§2a). Not rules-driven. |
+
+Two gaps worth knowing: **species residence** is hardcoded (data-drive is
+follow-up #189), and **dam blocking is not rules-driven** at all (universal).
+If dam blocking should ever become species-specific, it's a new
+per-source-per-species column + `lnk_barriers_unify` change — not a tweak.
+
+---
+
+## 8. Fast verification recipes
+
+```bash
+# What does bcfp emit for a WSG's mapping_code (local snapshot, no tunnel)?
+docker exec fresh-db psql -U postgres -d fwapg -c \
+  "SELECT mapping_code_bt, count(*) FROM fresh.streams_vw_bcfp
+   WHERE watershed_group_code='PARS' GROUP BY 1 ORDER BY 2 DESC;"
+
+# What does link emit (after a mapping_code=TRUE run)?
+docker exec fresh-db psql -U postgres -d fwapg -c \
+  "SELECT mapping_code_bt, count(*) FROM fresh_default.streams_mapping_code
+   WHERE watershed_group_code='PARS' GROUP BY 1 ORDER BY 2 DESC;"
+
+# Inspect a barrier view's shape / blocks_species
+docker exec fresh-db psql -U postgres -d fwapg -c \
+  "SELECT pg_get_viewdef('fresh_default.barriers_bt_unified', true);"
+
+# Single-WSG tunnel-free build (the headline path)
+bash data-raw/wsgs_run_m4_offline.sh --wsgs=PARS --config=default \
+  --schema=fresh_default --force --mapping-code
+```
+
+Local docker fwapg: `host=localhost port=5432 dbname=fwapg user=postgres
+password=postgres` (compose at `~/Projects/repo/fresh/docker/`).

--- a/planning/active/HANDOFF.md
+++ b/planning/active/HANDOFF.md
@@ -47,6 +47,9 @@ min and you're oriented.
 
 ## DB state does NOT travel — rebuild on M1
 
+**Get going: follow `RUNBOOK.md` §0 (docker → install → snapshot → tunnel)** —
+the canonical fresh-machine bootstrap. Summary below.
+
 The docker `fresh-db` (snapshot + persist tables + working schemas) is M4-local.
 On M1 you must either rebuild or use the tunnel:
 

--- a/planning/active/HANDOFF.md
+++ b/planning/active/HANDOFF.md
@@ -15,8 +15,9 @@ min and you're oriented.
    2026-05-23 section (bcfp source read authoritatively).
 3. **`planning/active/phase4d_plan_draft.md`** — the approved-direction fix,
    scoped (composition + wiring, not new modelling).
-4. **`planning/active/issue_phase4d_draft.md`** + **`issue_blocks_species_redesign_draft.md`**
-   — issue bodies to FILE (user said yes; review then `gh issue create`).
+4. **#200** (access-set reproduction — the Phase 4d fix) and **#201**
+   (blocks_species redesign + dam-override, depends on #200). FILED. Bodies also
+   in `issue_phase4d_draft.md` / `issue_blocks_species_redesign_draft.md`.
 5. `task_plan.md` / `progress.md` — checkboxes + session log.
 
 ## State (what's done / decided)
@@ -30,17 +31,19 @@ min and you're oriented.
   override + user_definite. Dams are descriptors (token2), never in the access
   set. link diverges by (1) carrying dams in `barriers_per_sp` and (2) wiring
   the override to classify (habitat) not access.
-- **User decisions (approved):** (1) ship v0.40.3; (2) file the Phase 4d issue;
-  (3) file the blocks_species/dam-override redesign issue (later, depends on 4d).
+- **User decisions (approved + done):** (1) ship v0.40.3 (PR #199); (2) filed
+  Phase 4d as **#200**; (3) filed blocks_species/dam-override redesign as **#201**
+  (depends on #200).
 - `lnk_pipeline_run` `barriers_per_sp` is reverted to `_unified` —
   KNOWN-DIVERGENT (dam-downstream segments emit bare `SPAWN`, not `SPAWN;DAM`).
   Phase 4d fixes it.
 
 ## What's NOT done (pick up here)
 
-- File the two issues (drafts ready, user approved).
-- Build Phase 4d (the access-set fix). Plan is in `phase4d_plan_draft.md`.
+- Merge **PR #199** (v0.40.3) from a stable connection: `/gh-pr-merge 199`.
+- Build **#200** (the access-set fix). Plan is in `phase4d_plan_draft.md`.
 - Validate on **PARS + LFRA** (resident + anadromous dam systems).
+- Then **#201** (blocks_species redesign + dam-override) — depends on #200.
 
 ## DB state does NOT travel — rebuild on M1
 

--- a/planning/active/HANDOFF.md
+++ b/planning/active/HANDOFF.md
@@ -1,0 +1,67 @@
+# HANDOFF — #196 mapping_code / access work → M1 (2026-05-23)
+
+**You are picking up mid-stream. Do NOT start over. The mechanism is solved and
+the next step is planned.** Read this, then `RUNBOOK.md`, then the PWF files. ~5
+min and you're oriented.
+
+> Why this file exists: memory (`~/.claude/...`) is machine-local and did NOT
+> travel from M4. The repo is the only bridge. Everything you need is committed.
+
+## Read in this order
+
+1. **`RUNBOOK.md`** (repo root) — the durable mental model. §5 is the heart:
+   how bcfp's per-species access set works and exactly where link diverges.
+2. **`planning/active/findings.md`** — the investigation trace + the RESOLVED
+   2026-05-23 section (bcfp source read authoritatively).
+3. **`planning/active/phase4d_plan_draft.md`** — the approved-direction fix,
+   scoped (composition + wiring, not new modelling).
+4. **`planning/active/issue_phase4d_draft.md`** + **`issue_blocks_species_redesign_draft.md`**
+   — issue bodies to FILE (user said yes; review then `gh issue create`).
+5. `task_plan.md` / `progress.md` — checkboxes + session log.
+
+## State (what's done / decided)
+
+- **v0.40.3 ready to ship.** Branch `196-streams-access-source-flags`. Persist
+  per-source-flag fixes (commits 91f3f90, e23819a, 475e397) are correct +
+  verified in isolation. DESCRIPTION + NEWS bumped. PR open (or open it:
+  `/gh-pr-push`) → merge with `/gh-pr-merge` from a stable connection.
+- **Mechanism SOLVED** (RUNBOOK §5). bcfp `barriers_<sp>` = natural-only
+  (gradient@species-threshold + falls + subsurface) − observation/habitat
+  override + user_definite. Dams are descriptors (token2), never in the access
+  set. link diverges by (1) carrying dams in `barriers_per_sp` and (2) wiring
+  the override to classify (habitat) not access.
+- **User decisions (approved):** (1) ship v0.40.3; (2) file the Phase 4d issue;
+  (3) file the blocks_species/dam-override redesign issue (later, depends on 4d).
+- `lnk_pipeline_run` `barriers_per_sp` is reverted to `_unified` —
+  KNOWN-DIVERGENT (dam-downstream segments emit bare `SPAWN`, not `SPAWN;DAM`).
+  Phase 4d fixes it.
+
+## What's NOT done (pick up here)
+
+- File the two issues (drafts ready, user approved).
+- Build Phase 4d (the access-set fix). Plan is in `phase4d_plan_draft.md`.
+- Validate on **PARS + LFRA** (resident + anadromous dam systems).
+
+## DB state does NOT travel — rebuild on M1
+
+The docker `fresh-db` (snapshot + persist tables + working schemas) is M4-local.
+On M1 you must either rebuild or use the tunnel:
+
+- **Inputs + bcfp comparison:** `PGUSER=postgres PGPASSWORD=postgres
+  PGHOST=localhost PGPORT=5432 PGDATABASE=fwapg bash data-raw/snapshot_bcfp.sh
+  --with-bcfp-views --force` (tunnel-free, public sources). **Known bug
+  (RUNBOOK §6):** the 1.6 GB `streams_vw` fgb silently fails to load via
+  `/vsizip//vsicurl` (ogr2ogr exits 0). For bcfp streams parity you need to
+  curl-download + unzip + load locally, or use the tunnel.
+- **link output:** re-run `lnk_pipeline_run(conn, "PARS"/"LFRA", cfg, loaded,
+  schema, mapping_code = TRUE)` to repopulate persist (`fresh_default`).
+- M1's `~/.Renviron` defaults `PG_*_SHARE` to the tunnel (`:63333`). For local
+  docker use `Sys.setenv()` in R to point at `:5432` (see fresh/CLAUDE.md, the
+  m1-testing pattern).
+
+## Environment
+
+- docker fresh-db compose: `~/Projects/repo/fresh/docker/` (`docker compose up -d db`).
+- bcfp tunnel: `ssh -o BatchMode=yes -L 63333:127.0.0.1:5432 db_newgraph -N -f`
+  (flaky from M4; M1 reaches it natively). Build is tunnel-free; only parity diff needs it.
+- bcfp this week: model_run_id 123 (`v0.7.15-...`). Snapshot reloaded 2026-05-23.

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -36,7 +36,29 @@ CAUTION: running `lnk_pipeline_persist` against the incomplete `working_pars_dbg
 - `barriers_dams_unified` (view over persist) = 178 dams province-wide; PARS-local `barriers_dams` = 0. Confirms cross-WSG dams only visible via persist.
 - bcfp `streams_mapping_code` has no `watershed_group_code`; JOIN `bcfishpass.streams ON segmented_stream_id`.
 
+## Cause 4 — METHODOLOGY, not a bug (the deepest finding)
+
+After all 3 persist fixes, streams_access flags persist correctly (dams 48561, dam_ind 32370 for PARS) but mapping_code STILL diverges from bcfp. Root: `access_bt = 0` (BLOCKED) for ALL 48561 PARS segments, because every PARS segment has a downstream dam (Bennett/Peace Canyon in PCEA — PARS drains through them). link#152 cross-WSG barriers correctly flag this.
+
+`lnk_pipeline_mapping_code:236` `accessible <- !has_barriers_sp & !no_data`. With every segment blocked:
+- token1 (`:262-268`): `ACCESS` requires `accessible` → never fires; only SPAWN/REAR (habitat-driven) or NA
+- token2 (`:276`): `ifelse(accessible, mc_barrier, NA)` → always NA → no `;DAM`
+- token3 (`:277`): same → no `;INTERMITTENT`
+
+Result: link emits `SPAWN` / `REAR` / `` (blank). bcfp emits `SPAWN;DAM` / `ACCESS;DAM` / `REAR;DAM` for the SAME segments — bcfp does NOT gate token1/token2 on downstream-dam accessibility.
+
+This is the v0.40.0 methodology shift at the semantic level: pre-#187 access used bcfp-staged barriers → matched bcfp (98.63%). Post-#187 access uses link's own cross-WSG-aware barriers → all PARS segments read blocked → tokens collapse.
+
+**DECISION NEEDED (user domain call)**:
+1. Match bcfp — emit token2 (DAM/MODELLED/etc) + keep habitat token1 regardless of `accessible`. Change the `accessible` gating in lnk_pipeline_mapping_code:262-277.
+2. Keep link's stricter semantics (blocked → suppress habitat token). More defensible biologically but won't match bcfp.
+3. Read bcfp's mapping_code SQL (smnorris/bcfishpass) to learn their exact accessibility definition first.
+
+This is NOT in #196's original scope (persist flags). #196's 3 commits are correct + shippable on their own merit (flags should persist). The token semantics is a separate concern — likely a new issue, possibly intertwined with #197 (rules engine) since the `accessible`-gating IS a rule.
+
 ## Open
 
+- **Cause 4 methodology decision** — blocks PARS-vs-bcfp parity. Pending user.
 - Wall time 956s (~16 min) for one PARS run — double-persist overhead. See task_plan Phase 5.
 - BULK also needs a clean rebuild (damaged in earlier debug churn).
+- access_bt=0 everywhere also means the rollup (spawn/rear km) may be affected — verify whether habitat km changed vs historic.

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,42 @@
+# Findings — #196 streams_access per-source flags + cross-WSG mapping_code
+
+## The bug chain (2026-05-19)
+
+After v0.40.0–v0.40.2 shipped the mapping_code decouple, attempting PARS-vs-bcfp parity revealed link's `mapping_code_bt` second token was `NONE` everywhere, where bcfp had `DAM`/`MODELLED`/`ASSESSED`. Three root causes, found in sequence:
+
+### Cause 1 — persist DDL missing per-source flag columns (Phase 1)
+
+`lnk_pipeline_mapping_code:174-194` probes the access tibble for `has_barriers_{anthropogenic,pscis,dams,remediations}_dnstr`, `dam_dnstr_ind`, `remediated_dnstr_ind` to classify the second token. #187 Phase 2 dropped these from `cols_streams_access_base` (wrong reasoning: "conditional on remediations/observations"; actually only on `barrier_sources` which pipeline_run always passes). Persist `streams_access` lacked the columns → `has()` probes FALSE → token `NONE`.
+
+### Cause 2 — views over working not persist (Phase 2)
+
+#187 Phase 4 set `lnk_barriers_views(barriers_table = paste0(schema, ".barriers"))` (working schema, per-WSG local). Lost cross-WSG dam visibility (PARS BT needs Bennett/Peace Canyon dams in PCEA/UPCE — the link#152 case). PARS has 0 local dams; the cross-WSG dams live only in persist. Fix: pre-persist barriers, let views default to persist (province-wide).
+
+### Cause 3 — persist INSERT projection missing the flags (Phase 3 — THE actual NONE bug)
+
+Even after Phase 1 added the DDL columns and Phase 2 fixed view source, persist `streams_access` flags came back ALL FALSE. Isolated repro against a surviving `working_pars_dbg` schema pinned it:
+
+- in-memory access tibble: flags populated (anth 48559, dams 48559, dam_ind 32406) ✓
+- working `streams_access` (dbWriteTable): flags populated ✓
+- persist `streams_access` (lnk_pipeline_persist INSERT): flags ALL FALSE ✗
+
+`lnk_pipeline_persist:122-123` built `access_cols_v <- c(cols_streams_access_base, .lnk_cols_streams_access_per_sp(species))` — omitting `.lnk_cols_streams_access_source_flags()`. DDL had the columns; INSERT projected only base + per-species. The 6 flag columns got their default (NULL) on every INSERT.
+
+**Lesson**: DDL change (lnk_persist_init) and INSERT-projection change (lnk_pipeline_persist) are a matched pair. The Phase 1 code-check asserted "INSERT picks up new columns automatically (iterates names(access_cols_v))" — false, because `access_cols_v` is independently constructed and didn't include the flags. Verify DDL + INSERT together against live data, not by reading one side.
+
+## Isolation-debug technique that worked
+
+The killed run's `working_pars_dbg` schema survived the docker restart (data volume persists across container restart). It had all prerequisite barrier tables (`barriers_anthropogenic`, `barriers_pscis`, `barriers_bt`, etc.) but no `_unified` views or `streams_access` (died before mapping_code phase). Reproduced the mapping_code phase steps (lnk_barriers_views → lnk_pipeline_access → inspect) in ~30s instead of re-running the 16-min pipeline. Much faster bug isolation.
+
+CAUTION: running `lnk_pipeline_persist` against the incomplete `working_pars_dbg` DELETE-WHERE-WSG'd the good PARS habitat (streams_habitat_bt 48559 → 0) and replaced with the half-built working schema's (empty) data. Debug-induced data damage — needs a clean full run to repair. Don't persist from a half-built working schema.
+
+## Verified facts
+
+- persist.barriers had PARS (68254 rows, 33104 BT-blockers) — data was upstream-correct throughout; bug was purely in the persist-write projection.
+- `barriers_dams_unified` (view over persist) = 178 dams province-wide; PARS-local `barriers_dams` = 0. Confirms cross-WSG dams only visible via persist.
+- bcfp `streams_mapping_code` has no `watershed_group_code`; JOIN `bcfishpass.streams ON segmented_stream_id`.
+
+## Open
+
+- Wall time 956s (~16 min) for one PARS run — double-persist overhead. See task_plan Phase 5.
+- BULK also needs a clean rebuild (damaged in earlier debug churn).

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -49,12 +49,67 @@ Result: link emits `SPAWN` / `REAR` / `` (blank). bcfp emits `SPAWN;DAM` / `ACCE
 
 This is the v0.40.0 methodology shift at the semantic level: pre-#187 access used bcfp-staged barriers → matched bcfp (98.63%). Post-#187 access uses link's own cross-WSG-aware barriers → all PARS segments read blocked → tokens collapse.
 
-**DECISION NEEDED (user domain call)**:
-1. Match bcfp — emit token2 (DAM/MODELLED/etc) + keep habitat token1 regardless of `accessible`. Change the `accessible` gating in lnk_pipeline_mapping_code:262-277.
-2. Keep link's stricter semantics (blocked → suppress habitat token). More defensible biologically but won't match bcfp.
-3. Read bcfp's mapping_code SQL (smnorris/bcfishpass) to learn their exact accessibility definition first.
+**RESOLVED — was NOT a methodology decision, was the wrong barriers table.**
 
-This is NOT in #196's original scope (persist flags). #196's 3 commits are correct + shippable on their own merit (flags should persist). The token semantics is a separate concern — likely a new issue, possibly intertwined with #197 (rules engine) since the `accessible`-gating IS a rule.
+Grounded in the pre-#187 matching code (`git show 0cd48d0:R/lnk_compare_wsg.R`) + the research doc canonical call sequence + reading `.lnk_pipeline_prep_minimal:574-592`:
+
+- `barriers_<sp>_min` = gradient + falls ONLY (natural barriers, per-species, minimal-reduced). These are the correct `barriers_per_sp` for access. A segment downstream of a dam is still gradient-accessible → token1 = SPAWN/ACCESS.
+- `barriers_<sp>_unified` (what #187 Phase 4 wrongly used) = ALL barriers incl dams → every dam-downstream segment reads blocked → accessible FALSE → token1/2 collapse to bare SPAWN/REAR.
+- Dams belong in `barrier_sources` (cross-WSG `barriers_dams_unified`) → drive token2 (`DAM`) + `dam_dnstr_ind`, NEVER blocking `accessible`. That's how bcfp emits `SPAWN;DAM`: gradient-accessible habitat + dam noted.
+- link#152 cross-WSG fix is in `barrier_sources` (untouched). Natural barriers are inherently local (gradient/falls don't cross WSG) so `_min` stays tunnel-free.
+
+**Fix applied** (uncommitted, on branch): `lnk_pipeline_run` Phase 4 `barriers_per_sp` swapped `_unified` → `_min`. Verification run in flight (PARS, cleanup_working=FALSE). Expected: token1 ACCESS/SPAWN/REAR restored, token2 DAM/MODELLED/ASSESSED present (`SPAWN;DAM` etc.), match_pct vs bcfp back toward ~98%.
+
+The 3 persist commits (DDL, pre-persist, INSERT projection) remain correct + necessary (the source flags must persist for token2). The `_min` swap is the 4th + final piece.
+
+**Tunnel-free confirmed**: build path uses `_min` (local gradient/falls) + `barrier_sources` views over persist (local). NO tunnel needed for the build. Tunnel only for the parity DIFF (validation). Aligns with user direction: "we will go tunnel free eventually, cannot depend on it for testing."
+
+### Cause 4 fix attempt #1 — `_min` swap FAILED (mechanical, 2026-05-23)
+
+The `_min` swap broke fast: `ERROR: column b.barriers_bt_min_id does not exist`. Root: `lnk_pipeline_access:152-161` derives `feature_id_col <- paste0(table_only, "_id")` and passes the table to `fresh::frs_network_features`, which needs a surrogate feature id. The `_min` tables are **break-position specs** (`blue_line_key, downstream_route_measure, wscode_ltree, localcode_ltree` ONLY — no id) built for `frs_break_apply`, NOT feature tables. The `_unified` views ARE feature-shaped (`id_barrier AS barriers_<sp>_unified_id`, geom, blocks_species). So `barriers_per_sp` mechanically REQUIRES `frs_network_features`-shaped tables; `_min` cannot be dropped in.
+
+**What `barriers_<sp>_unified` actually is** (live viewdef): `SELECT id_barrier AS barriers_bt_unified_id, barrier_source, ..., blocks_species, ..., geom FROM <persist>.barriers WHERE 'BT' = ANY(blocks_species)`. It's all persist barriers (cross-WSG) where the species is in `blocks_species` (#152 predicate). The over-blocking question reduces to: **is DAM in `blocks_species` for BT?** If yes, every PARS dam-upstream segment reads blocked → Cause 4 token collapse.
+
+**Correct fix shape (not yet built):** a per-species feature view that keeps the `_unified` shape + id but filters OUT anthropogenic/dam sources — natural barriers only (`barrier_source NOT IN ('DAM', ...)` or `barrier_subtype`-based). That gives `frs_network_features` its id AND the gradient/falls-only access set. BUT this is gated on confirming bcfp's actual semantics — see below.
+
+### RESOLVED 2026-05-23 — bcfp source read; the access set is natural-only + override-filtered
+
+Read authoritatively from `smnorris/bcfishpass@v0.7.15` (`gh api`, read-only):
+- `model/01_access/sql/model_access_bt.sql` — `bcfishpass.barriers_bt` =
+  `(gradient WHERE barrier_type IN ('GRADIENT_25','GRADIENT_30') ∪ falls ∪ subsurface)`
+  MINUS barriers with upstream BT/salmon/steelhead **observations** (`obs_upstr`,
+  20 m tol) MINUS barriers with upstream confirmed **habitat**
+  (`user_habitat_classification`, `hab_upstr` 200 m tol) ∪ ALL
+  `barriers_user_definite`. **No dams / PSCIS / modelled crossings.**
+- `model/01_access/sql/load_streams_access.sql` — `barriers_<sp>_dnstr` (per-sp,
+  natural) is SEPARATE from `barriers_anthropogenic_dnstr` / `barriers_dams_dnstr`.
+  `dam_dnstr_ind = array[barriers_anthropogenic_dnstr[1]] && barriers_dams_dnstr`.
+- `model/02_habitat_linear/sql/load_streams_mapping_code.sql` — token2 gated on
+  `barriers_bt_dnstr = array[]::text[]` (accessible) — identical to link.
+
+So `SPAWN;DAM` = natural-accessible (`barriers_bt_dnstr=[]`) + spawning>0 + dam
+downstream. The dam annotates access; it doesn't block it.
+
+**link's two divergences (fully characterized):**
+1. `barriers_per_sp = barriers_<sp>_unified` = ALL barriers incl dams (wrong
+   content; bcfp = natural only).
+2. The observation/habitat override (`lnk_barrier_overrides` →
+   `<schema>.barrier_overrides`) feeds `lnk_pipeline_classify` (habitat) only —
+   NOT `lnk_pipeline_access` (mapping_code accessibility). bcfp applies it to
+   `barriers_<sp>`.
+
+Note `access_<sp>` integer (lnk_pipeline_access.R:364) IS obs-aware (matches
+bcfp `access_bt`) — but mapping_code uses `has_barriers_<sp>_dnstr`, not it.
+
+**Fix shape:** per-species *feature* view (has-id) of natural-only barriers
+(gradient@species-threshold + falls + subsurface) + override + user_definite =
+reproduce bcfp `barriers_<sp>`. Real builder, not a swap. Full writeup in
+`RUNBOOK.md` §5. Design implication: `blocks_species` binary conflates
+natural-access + anthropogenic-descriptor — candidate redesign.
+
+### (superseded) The decisive question is empirical, not theoretical — redo snapshot
+
+Whether bcfp gates token1/token2 on dam-accessibility must be read from bcfp's ACTUAL output, not reasoned about. Tunnel is down again (stale, timed out). Per user direction ("rerun the snapshot locally") + ("cannot depend on tunnel for testing"): running `data-raw/snapshot_bcfp.sh --with-bcfp-views --force` against local docker fwapg (tunnel-free, public sources) to land this week's bcfp into `fresh.streams_bcfp`. Then row-level diff: for PARS segments above Bennett/Peace Canyon dams, what does bcfp's `mapping_code_bt` say (`SPAWN;DAM`? bare `SPAWN`? `NONE`?) AND is the segment in bcfp's accessible set? That answer dictates the fix shape.
 
 ## Open
 

--- a/planning/active/issue_blocks_species_redesign_draft.md
+++ b/planning/active/issue_blocks_species_redesign_draft.md
@@ -1,0 +1,44 @@
+# DRAFT ISSUE — review before filing (not filed)
+
+**Title:** Rethink `blocks_species` — carry barrier ingredients, classify access late + per-context; add evidence-based dam-override
+
+**Labels:** design, research
+
+## Motivation
+
+`blocks_species text[]` (computed once in `lnk_barriers_unify`) bakes a binary
+per-species blocks/doesn't onto every barrier at unify time. Two problems
+surfaced in #196 (see `RUNBOOK.md` §5):
+
+1. It conflates two orthogonal axes bcfp keeps separate: **natural access**
+   (per-species, gradient-typed, observation/habitat-overridden) vs.
+   **anthropogenic descriptor** (dam/pscis/modelled, passability-typed). Dams
+   get baked into access wrongly.
+2. It's computed before the override is known, so the "fish above ⟹ passable"
+   evidence (observations/habitat) can't subtract from it.
+
+bcfp has no binary blocks predicate — it builds per-species access sets from
+*ingredients* (gradient class, falls, subsurface) + evidence overrides, and
+tracks anthropogenic barriers separately. "Nothing is black-white."
+
+## Direction (research/design)
+
+- Carry barrier **ingredients** on the unified table: `barrier_type`,
+  `gradient_class`, `passability` (CABD status), `up_passage_type` (fishway),
+  source — instead of (or alongside) the pre-baked `blocks_species`.
+- Classify access **late + per-context**, per species, reusing fresh's existing
+  `label` / `label_block` gradation rather than a fresh binary.
+- **dam-override** (the renamed "dam-passability" idea): let dams be overridden
+  out of the relevant set by the SAME evidence rules as natural barriers
+  (`lnk_barrier_overrides`: observations / confirmed habitat / control) — many
+  CABD dams exist on paper but are passable (decommissioned, partial, fishway,
+  or fish demonstrably above). Reuse the rules engine; do NOT build a bespoke
+  fishway model. The name shouldn't bake in the mechanism (fishway is one case).
+- **This is a deliberate departure from bcfp** (bcfp never overrides dams
+  per-species) — opt-in, and it breaks the exact-reproduction correctness bar
+  (CLAUDE.md). Sequence it AFTER the match-bcfp access fix (Phase 4d issue).
+
+## Depends on
+
+- Phase 4d (access-set reproduction) lands first — establishes the natural-only
+  per-species access view this generalizes.

--- a/planning/active/issue_phase4d_draft.md
+++ b/planning/active/issue_phase4d_draft.md
@@ -1,0 +1,50 @@
+# DRAFT ISSUE — review before filing (not filed)
+
+**Title:** mapping_code accessibility: reproduce bcfp `barriers_<sp>` (natural-only + override) so dam-downstream segments emit `;DAM`
+
+**Labels:** bug, mapping_code
+
+## Problem
+
+link's per-species mapping_code accessibility (`barriers_per_sp` →
+`accessible`) uses `barriers_<sp>_unified` = ALL barriers (incl dams/PSCIS/
+modelled) where the species is in `blocks_species`. bcfp's per-species access
+set (`barriers_<sp>`) is **natural barriers only** (gradient at the species
+threshold + falls + subsurface), MINUS barriers with upstream observations /
+confirmed habitat, ∪ all `user_barriers_definite`. Dams are never in the access
+set — they're a downstream descriptor (token2) only.
+
+Consequence: every segment below a dam reads inaccessible for that species, so
+the `;DAM`/`;MODELLED`/`;ASSESSED` second token is suppressed (token2 is gated
+on `accessible`, correctly, matching bcfp). link emits bare `SPAWN`/`REAR` where
+bcfp emits `SPAWN;DAM`. Full trace + authoritative bcfp source refs in
+`RUNBOOK.md` §5; bcfp files: `smnorris/bcfishpass@v0.7.15`
+`model/01_access/sql/model_access_bt.sql`, `load_streams_access.sql`,
+`model/02_habitat_linear/sql/load_streams_mapping_code.sql`.
+
+## Fix (composition + wiring — link has all the pieces)
+
+Build `<schema>.barriers_<sp>_access` (feature-shaped, keeps `_id`):
+
+```
+barriers_<sp>_unified WHERE barrier_source IN ('GRADIENT','FALLS','SUBSURFACE_FLOW')  -- natural only
+  ANTI-JOIN <schema>.barrier_overrides ON (blue_line_key, ~downstream_route_measure, species_code)
+  UNION ALL <schema>.barriers_definite                                                 -- all species
+```
+
+Repoint `lnk_pipeline_run` `barriers_per_sp` → `_access`. Dams stay in
+`barrier_sources` (token2). Implementation detail in
+`planning/active/phase4d_plan_draft.md`.
+
+## Open sub-questions
+
+- `barriers_definite` id (synthesize if absent).
+- cross-WSG natural overrides (barrier_overrides is per-WSG; may need persist-wide).
+- subsurface opt-in.
+
+## Acceptance
+
+PARS (resident/BT) + LFRA (anadromous, Coquitlam/Alouette/Stave/Ruskin) parity
+vs bcfp `streams_vw_bcfp`: dam-downstream-but-accessible segments emit
+`SPAWN;DAM`/`REAR;DAM`/`ACCESS;DAM`. (Needs the 1.6 GB bcfp streams baseline —
+snapshot bug, see RUNBOOK §6.)

--- a/planning/active/phase4d_plan_draft.md
+++ b/planning/active/phase4d_plan_draft.md
@@ -1,0 +1,94 @@
+# Phase 4d — DRAFT plan: per-species natural-access set (reproduce bcfp `barriers_<sp>`)
+
+Status: **draft for review — not approved, no code written.** Fixes the
+mapping_code dam divergence (RUNBOOK §5). Match-bcfp first; the **dam-override**
+extension (let dams be overridden by the same evidence rules — RUNBOOK §5) is
+deliberately out of scope here.
+
+## Goal
+
+Make `barriers_per_sp` (the set that drives `accessible` → token1 ACCESS + the
+token2 gate) reproduce bcfp's `barriers_<sp>`:
+
+```
+natural barriers blocking species S        -- gradient@S-threshold ∪ falls ∪ subsurface
+  MINUS barriers with upstream S-observations / confirmed habitat   -- the override
+  ∪ ALL user_barriers_definite                                      -- never overridden
+```
+
+Dams/PSCIS/modelled stay OUT of the access set; they remain in `barrier_sources`
+→ token2 descriptor only (already correct).
+
+## link already has every ingredient
+
+| Need | Existing link object |
+|---|---|
+| Natural barriers, per-species threshold | `barriers_<sp>_unified` (persist `barriers` WHERE S ∈ `blocks_species`) filtered `barrier_source IN ('GRADIENT','FALLS','SUBSURFACE_FLOW')` — gradient threshold is already encoded in `blocks_species` |
+| Override skip list (fish/habitat above) | `<schema>.barrier_overrides` `(blue_line_key, downstream_route_measure, species_code)`, built by `lnk_barrier_overrides` in `lnk_pipeline_prepare.R:519`, per-species thresholds from `parameters_fresh` (already match bcfp) |
+| User hard barriers | `<schema>.barriers_definite` (`lnk_pipeline_prepare.R:182-197`) |
+
+So this is **composition + wiring**, not new modelling.
+
+## Implementation
+
+1. **New per-species access view** — extend `lnk_barriers_views` (or a sibling
+   `lnk_barriers_access_views`) to emit `<schema>.barriers_<sp>_access`:
+   ```sql
+   SELECT id_barrier AS barriers_<sp>_access_id, blue_line_key,
+          downstream_route_measure, wscode_ltree, localcode_ltree, geom
+   FROM <persist>.barriers
+   WHERE '<SP>' = ANY(blocks_species)
+     AND barrier_source IN ('GRADIENT','FALLS','SUBSURFACE_FLOW')   -- natural only
+     AND NOT EXISTS (                                               -- override removal
+       SELECT 1 FROM <schema>.barrier_overrides o
+       WHERE o.species_code = '<SP>'
+         AND o.blue_line_key = barriers.blue_line_key
+         AND abs(o.downstream_route_measure - barriers.downstream_route_measure) < 1)
+   UNION ALL
+   SELECT <namespaced id>, blue_line_key, downstream_route_measure,
+          wscode_ltree, localcode_ltree, geom
+   FROM <schema>.barriers_definite                                  -- all species, no override
+   ```
+   Keeps the feature shape (`_id` col) `frs_network_features` requires (RUNBOOK §2b).
+
+2. **Repoint** `lnk_pipeline_run` `barriers_per_sp` → `barriers_<sp>_access`
+   (currently `_unified`). One-line change + comment.
+
+3. **Ordering**: `barrier_overrides` + `barriers_definite` are built in
+   `lnk_pipeline_prepare` (before the mapping_code phase), so they exist when the
+   access views are created. Confirm in `lnk_pipeline_run` phase order.
+
+4. `barrier_sources` (dams/pscis/anthropogenic/remediations) unchanged → token2.
+
+## Open sub-questions (resolve during impl)
+
+- **`barriers_definite` id**: does it carry a usable id for the feature view? If
+  not, namespace one (mirror `lnk_barriers_unify`'s `3e9 + row_number()` trick).
+- **Cross-WSG natural overrides**: `barrier_overrides` is per-WSG (working
+  schema). Natural barriers downstream of an AOI but in *another* WSG (e.g. a
+  fall in PCEA downstream of a PARS segment) would be in persist `barriers` but
+  not covered by the AOI's local override. bcfp computes overrides province-wide.
+  Likely minor (the dominant PARS downstream barriers are the dams = anthropogenic
+  = excluded), but verify on LFRA where above-dam salmon obs are the whole point.
+  May need a persist-wide `barrier_overrides` (parallel to the persist barriers).
+- **subsurface presence**: only built when the config opts in; view filter is
+  harmless when absent.
+
+## Validation (parity targets)
+
+- **PARS** (resident/BT, Peace dams, `mcbi_r`) and **LFRA** (anadromous,
+  Coquitlam/Alouette/Stave/Ruskin dams, `mcbi_a`, above-dam sockeye obs).
+- Need bcfp baseline: `fresh.streams_vw_bcfp` (1.6 GB download — currently
+  missing, snapshot bug RUNBOOK §6) or tunnel.
+- Acceptance: link `mapping_code_<sp>` distribution matches bcfp for PARS + LFRA
+  within tolerance; specifically dam-downstream-but-accessible segments emit
+  `SPAWN;DAM`/`REAR;DAM`/`ACCESS;DAM` not bare `SPAWN`/`REAR`.
+
+## Sequencing question (for the user)
+
+- #196's 3 persist commits (DDL, pre-persist, INSERT projection) are correct +
+  independent — **ship as v0.40.3** now?
+- Open Phase 4d as its **own issue** (access-set reproduction) — distinct from
+  #196's persist-flag scope? Draft body for review before filing.
+- Separately, `blocks_species` redesign + dam-passability extension = a third,
+  later issue (RUNBOOK §5 design implication).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -8,7 +8,9 @@
 - Phase 3 (`475e397`): `lnk_pipeline_persist` INSERT projection now includes the source flags — THE actual NONE-token bug. Verified in isolation: persist streams_access flags populate (anth 48559, dams 48559, dam_ind 32406).
 - Branch `196-streams-access-source-flags`, 3 commits ahead of main.
 - Phase 4 IN FLIGHT: clean PARS `lnk_pipeline_run(mapping_code=TRUE)` (task `btkkjqxlp`) — rebuilds habitat (damaged by debug shortcut persisting from half-built working_pars_dbg) + verifies end-to-end token output.
-- Next: confirm PARS BT tokens include DAM/MODELLED/ASSESSED; decide Phase 5 (wall-time double-persist); rebuild BULK; release v0.40.3.
+- Phase 4 result: streams_access flags NOW persist (dams 48561, dam_ind 32370). BUT tokens still wrong — found **Cause 4** (methodology, not bug): access_bt=0 (blocked) for ALL PARS segments because cross-WSG dams are downstream → `accessible=FALSE` → token1/2/3 collapse to SPAWN/REAR/blank. bcfp emits SPAWN;DAM regardless. See findings Cause 4. **Paused for user decision** on accessibility-gating semantics.
+- 3 persist commits (91f3f90, e23819a, 475e397) are correct + shippable on their own (flags should persist). Token semantics is separate — likely new issue, possibly tied to #197 rules engine.
+- Next: (a) user decides Cause-4 semantics; (b) decide Phase 5 wall-time; (c) rebuild BULK; (d) ship v0.40.3 (persist fixes) maybe independent of the token-semantics work.
 
 ### Environment
 - docker `fresh-db` up (was down mid-session; `open -a Docker` + `docker compose up -d db` in fresh/docker/).

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -12,6 +12,27 @@
 - 3 persist commits (91f3f90, e23819a, 475e397) are correct + shippable on their own (flags should persist). Token semantics is separate — likely new issue, possibly tied to #197 rules engine.
 - Next: (a) user decides Cause-4 semantics; (b) decide Phase 5 wall-time; (c) rebuild BULK; (d) ship v0.40.3 (persist fixes) maybe independent of the token-semantics work.
 
+## Session 2026-05-23
+
+- Resumed via `/loop continue phase 7`. Tested the Cause-4 `_min` swap (uncommitted edit to lnk_pipeline_run barriers_per_sp).
+- `_min` swap **FAILED mechanically** (PARS run `bpzeq473w`): `barriers_bt_min_id does not exist`. `_min` tables are break-specs (no surrogate id); `frs_network_features` (via lnk_pipeline_access) requires a feature id. `_unified` views are the feature-shaped tables (id_barrier + geom + blocks_species). `barriers_per_sp` mechanically requires `_unified`-shape input.
+- Architectural truth: `barriers_<sp>_unified` = persist.barriers WHERE sp ∈ blocks_species. Over-blocking reduces to "is DAM in blocks_species for BT". Correct fix = per-species natural-only feature view (keeps id, drops dams) — BUT gated on confirming bcfp's real semantics.
+- Tunnel down again (stale, timeout). Per user ("rerun the snapshot locally"): launched `snapshot_bcfp.sh --with-bcfp-views --force` against local docker fwapg (tunnel-free, public sources) → task `be94vol3c`. Lands this week's bcfp into `fresh.streams_bcfp` for the row-level dam-segment diff that decides the fix shape.
+- The `_min` swap is still in the working tree (uncommitted) — to be reverted once snapshot confirms direction.
+- Next: snapshot completes → inspect bcfp dam-upstream segment mapping_code → decide fix shape → surface to user.
+
+## Session 2026-05-23 (cont.) — mechanism resolved by reading bcfp source
+
+- User pushed hard: "dam blockage is species specific based on our rules", "fish are above these dams, dam means nothing on its own", "how does bcfp do it? understand mechanisms", "blocks_species maybe the wrong design — nothing black-white", "we have species overrides (fish above → override)", "do our homework and DOCUMENT so we can find it. tricky to carry all this knowledge". → wrote **RUNBOOK.md** (repo root) + CLAUDE.md pointer.
+- Read bcfp source authoritatively (`gh api`, smnorris/bcfishpass@v0.7.15):
+  `model_access_bt.sql`, `load_streams_access.sql`, `load_streams_mapping_code.sql`.
+  **Finding:** bcfp `barriers_<sp>` = natural-only (gradient@species-threshold + falls + subsurface) MINUS upstream-observation/habitat overrides ∪ user_definite. Dams NEVER in the access set — they annotate (token2) via separate `barriers_dams_dnstr`. token2 gate identical to link.
+- **link's bug, fully characterized:** (1) `barriers_per_sp = barriers_<sp>_unified` carries dams (wrong content); (2) `lnk_barrier_overrides` output feeds classify (habitat) not access (mapping_code). Documented in RUNBOOK §5 + findings.
+- Reverted broken `_min` swap → `_unified` (runnable, known-divergent), comment → RUNBOOK §5.
+- Confirmed user's instincts on every point. The real fix = build a natural-only per-species feature view reproducing bcfp barriers_<sp> + wire overrides into access. Real work (Phase 4d), needs scoping.
+- streams_vw_bcfp load failed on transient gzip (snapshot otherwise OK exit 0); retrying (task b122hazyb) for empirical parity numbers.
+- Next: user reviews the mechanism/runbook; scope Phase 4d; decide whether blocks_species redesign is its own issue.
+
 ### Environment
 - docker `fresh-db` up (was down mid-session; `open -a Docker` + `docker compose up -d db` in fresh/docker/).
 - bcfp tunnel `localhost:63333` flaky (dropped 3×); needs PG_PASS_SHARE. Build is tunnel-free; only parity diff needs it.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,15 @@
+# Progress — #196 streams_access per-source flags + cross-WSG mapping_code
+
+## Session 2026-05-19
+
+- PWF scaffolded retroactively (started #196 without it; scope grew to 3 bugs).
+- Phase 1 (`91f3f90`): persist DDL per-source flag cols via `.lnk_cols_streams_access_source_flags()`.
+- Phase 2 (`e23819a`): pre-persist barriers so views default to persist (cross-WSG dam visibility).
+- Phase 3 (`475e397`): `lnk_pipeline_persist` INSERT projection now includes the source flags — THE actual NONE-token bug. Verified in isolation: persist streams_access flags populate (anth 48559, dams 48559, dam_ind 32406).
+- Branch `196-streams-access-source-flags`, 3 commits ahead of main.
+- Phase 4 IN FLIGHT: clean PARS `lnk_pipeline_run(mapping_code=TRUE)` (task `btkkjqxlp`) — rebuilds habitat (damaged by debug shortcut persisting from half-built working_pars_dbg) + verifies end-to-end token output.
+- Next: confirm PARS BT tokens include DAM/MODELLED/ASSESSED; decide Phase 5 (wall-time double-persist); rebuild BULK; release v0.40.3.
+
+### Environment
+- docker `fresh-db` up (was down mid-session; `open -a Docker` + `docker compose up -d db` in fresh/docker/).
+- bcfp tunnel `localhost:63333` flaky (dropped 3×); needs PG_PASS_SHARE. Build is tunnel-free; only parity diff needs it.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,58 @@
+# Task: streams_access per-source flag persistence + cross-WSG mapping_code (#196)
+
+Retroactive PWF — #196 was started as a "quick single-file fix" without PWF, then ballooned into a 3-bug investigation. Scaffolded mid-flight 2026-05-19 to capture the trace.
+
+## Problem
+
+Post-#187 `lnk_mapping_code` second token defaulted to `NONE` for every segment (should be `DAM`/`MODELLED`/`ASSESSED`/`REMEDIATED`/`NONE`). PARS BT match_pct vs bcfp dropped from historic ~98% to ~30-50%. Three coupled root causes, fixed in three commits.
+
+## Phase 1 — persist DDL: per-source flag columns
+
+- [x] `.lnk_cols_streams_access_source_flags()` helper in `lnk_persist_init.R` — 6 boolean cols (`has_barriers_{anthropogenic,pscis,dams,remediations}_dnstr`, `dam_dnstr_ind`, `remediated_dnstr_ind`).
+- [x] Wired into `streams_access` CREATE TABLE.
+- [x] `/code-check` clean.
+- [x] Commit `91f3f90`.
+
+## Phase 2 — cross-WSG visibility: pre-persist barriers
+
+- [x] `lnk_pipeline_run` mapping_code phase: pre-persist current WSG's barriers BEFORE `lnk_barriers_views`, so views default to persist (province-wide, cross-WSG dam visibility per link#152). Reverted #187 Phase 4's `barriers_table = working` override.
+- [x] `/code-check` clean.
+- [x] Commit `e23819a`.
+
+## Phase 3 — persist INSERT projection (the actual NONE bug)
+
+- [x] `lnk_pipeline_persist`: `access_cols_v` was `base + per_sp` only — MISSING `.lnk_cols_streams_access_source_flags()`. DDL had the cols (Phase 1) but INSERT never populated them → NULL → NONE token. Added the generator to the projection.
+- [x] Verified in isolation: persist `streams_access` flags now populate (anth 48559, dams 48559, dam_ind 32406 of 48559 for PARS).
+- [x] `/code-check` — SKIPPED on this commit (verified empirically instead; the earlier code-check that missed this gap was the cautionary tale).
+- [x] Commit `475e397`.
+
+## Phase 4 — end-to-end verification (IN FLIGHT)
+
+- [ ] Clean `lnk_pipeline_run(aoi="PARS", mapping_code=TRUE)` — rebuilds habitat (damaged by debug shortcut) + access + mapping_code. (task `btkkjqxlp`, ~16 min)
+- [ ] Verify PARS BT `mapping_code_bt` distribution includes `ACCESS;DAM`/`ACCESS;MODELLED`/`ACCESS;ASSESSED` (not just `ACCESS;NONE`).
+- [ ] Tunnel up → `lnk_compare_wsg(aoi="PARS", mapping_code=TRUE)` → match_pct vs bcfp ≥ ~95%.
+- [ ] Re-run BULK too (also damaged / needs rebuild).
+
+## Phase 5 — performance concern (NEW — decide before merge)
+
+- [ ] Wall time blew up to 956s (~16 min) vs normal ~3.5 min for PARS — the double-persist (pre-persist barriers + final persist) re-writes streams + habitat + barriers twice. Decide:
+  - (a) Accept it (correctness over speed; provincial run adds ~hours though).
+  - (b) Pre-persist ONLY barriers (not streams + habitat) — the views only need barriers. Smaller helper / `only=` arg on lnk_pipeline_persist.
+  - (c) Reorder so persist runs once, mapping_code phase after.
+  - Likely (b). File as part of #196 or follow-up.
+
+## Phase 6 — release v0.40.3
+
+- [ ] DESCRIPTION 0.40.2 → 0.40.3, Date.
+- [ ] NEWS.md entry.
+- [ ] CLAUDE.md branch ref.
+- [ ] `/planning-archive`.
+- [ ] `/gh-pr-push` + `/gh-pr-merge`.
+
+## Validation
+
+- [ ] PARS BT tokens include DAM/MODELLED/ASSESSED
+- [ ] match_pct vs bcfp restored to ~98%
+- [ ] `devtools::test()` passing
+- [ ] wall-time decision made (Phase 5)
+- [ ] `/code-check` clean on any remaining commits

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -51,14 +51,15 @@ Post-#187 `lnk_mapping_code` second token defaulted to `NONE` for every segment 
 - [x] Documented authoritatively in RUNBOOK.md (§2a, §5) + CLAUDE.md pointer + findings. (user ask: "do our homework and document so we can find it")
 - [ ] streams_vw_bcfp retry (task b122hazyb) for empirical parity numbers (snapshot's streams view failed on transient gzip).
 
-## Phase 4d — the real fix (NEW, needs scoping/approval)
+## Phase 4d — the real fix (FILED as #200; #201 = redesign follow-up)
 
+- [x] Filed #200 (access-set reproduction) + #201 (blocks_species redesign + dam-override, depends on #200).
 - [ ] Build per-species NATURAL-only *feature* view reproducing bcfp `barriers_<sp>`:
   gradient@species-threshold + falls + subsurface, MINUS observation/habitat
   overrides, ∪ user_barriers_definite. Has-id (feature shape, §2b).
 - [ ] Wire `lnk_barrier_overrides` output into the access path (currently classify-only).
 - [ ] Point `barriers_per_sp` at the new view; dams stay in barrier_sources (token2).
-- [ ] Candidate issue: `blocks_species` redesign (carry ingredients, classify access late) — RUNBOOK §5 design implication. Draft + review before filing (no unreviewed issues).
+- [x] `blocks_species` redesign (carry ingredients, classify access late) + dam-override — filed as #201 (RUNBOOK §5 design implication).
 
 ## Phase 5 — performance concern (NEW — decide before merge)
 

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -33,6 +33,33 @@ Post-#187 `lnk_mapping_code` second token defaulted to `NONE` for every segment 
 - [ ] Tunnel up → `lnk_compare_wsg(aoi="PARS", mapping_code=TRUE)` → match_pct vs bcfp ≥ ~95%.
 - [ ] Re-run BULK too (also damaged / needs rebuild).
 
+## Phase 4b — Cause 4 fix: barriers_per_sp `_unified` → `_min` (NEW)
+
+- [x] Root-caused: `_unified` (all barriers) over-blocks; `_min` (gradient+falls natural barriers) is correct per-species access set. Dams stay in `barrier_sources` (token2 only). Grounded in pre-#187 matching code + prep_minimal source.
+- [x] Swap applied in `lnk_pipeline_run` Phase 4 (uncommitted).
+- [x] Verify: PARS run (task `bpzeq473w`) → **FAILED mechanically**. `barriers_bt_min_id does not exist` — `_min` tables are break-specs (no id col); `frs_network_features` needs a feature id. `_min` cannot feed `barriers_per_sp`. See findings.
+- [x] Architectural finding: `barriers_<sp>_unified` = persist barriers WHERE species ∈ blocks_species (#152), feature-shaped w/ id. Correct fix = per-species feature view, `_unified` shape, natural-only filter — but gated on bcfp semantics.
+- [ ] **REVERT the `_min` swap** in lnk_pipeline_run (restore `_unified`) — known state for the data investigation. (deferred until snapshot confirms direction)
+
+## Phase 4c — empirical bcfp semantics (BLOCKING — redo snapshot)
+
+- [x] Tunnel down (stale). Snapshot script is tunnel-free (public sources). Run `snapshot_bcfp.sh --with-bcfp-views --force` → local `fresh.streams_bcfp` (task `be94vol3c`).
+- [ ] Inspect `fresh.streams_bcfp` columns — does it carry `mapping_code_bt` + access cols per segment?
+- [ ] Row-level: PARS segments above Bennett/Peace Canyon dams — bcfp `mapping_code_bt` value? In bcfp's accessible set or not?
+- [x] **RESOLVED by reading bcfp source** (not data — authoritative). Fix shape = (a): per-species access set is natural-only + override-filtered; dams never block access. See findings (RESOLVED 2026-05-23) + RUNBOOK.md §5.
+- [x] Reverted broken `_min` swap → `_unified` (runnable, known-divergent) w/ comment → RUNBOOK §5.
+- [x] Documented authoritatively in RUNBOOK.md (§2a, §5) + CLAUDE.md pointer + findings. (user ask: "do our homework and document so we can find it")
+- [ ] streams_vw_bcfp retry (task b122hazyb) for empirical parity numbers (snapshot's streams view failed on transient gzip).
+
+## Phase 4d — the real fix (NEW, needs scoping/approval)
+
+- [ ] Build per-species NATURAL-only *feature* view reproducing bcfp `barriers_<sp>`:
+  gradient@species-threshold + falls + subsurface, MINUS observation/habitat
+  overrides, ∪ user_barriers_definite. Has-id (feature shape, §2b).
+- [ ] Wire `lnk_barrier_overrides` output into the access path (currently classify-only).
+- [ ] Point `barriers_per_sp` at the new view; dams stay in barrier_sources (token2).
+- [ ] Candidate issue: `blocks_species` redesign (carry ingredients, classify access late) — RUNBOOK §5 design implication. Draft + review before filing (no unreviewed issues).
+
 ## Phase 5 — performance concern (NEW — decide before merge)
 
 - [ ] Wall time blew up to 956s (~16 min) vs normal ~3.5 min for PARS — the double-persist (pre-persist barriers + final persist) re-writes streams + habitat + barriers twice. Decide:


### PR DESCRIPTION
## Summary
- Persist the six per-source downstream-barrier flag columns in `streams_access` (`has_barriers_{anthropogenic,pscis,dams,remediations}_dnstr`, `dam_dnstr_ind`, `remediated_dnstr_ind`) so `lnk_pipeline_mapping_code`'s second token populates instead of defaulting to `NONE`. Three coupled fixes: DDL (`lnk_persist_init`), pre-persist barriers for cross-WSG dam visibility (`lnk_pipeline_run`), INSERT projection (`lnk_pipeline_persist` — the missing projection was the actual bug).
- Adds **`RUNBOOK.md`** — durable mental model of the barrier → access → mapping_code machinery + the authoritative bcfp access-set mechanism (read from `smnorris/bcfishpass@v0.7.15`).

## Known follow-up (not in this PR)
The per-species *accessibility* set still carries dams; it should be natural-only + observation/habitat-overridden (bcfp's model). So dam-downstream segments still emit a bare habitat token, not `SPAWN;DAM`. Fully characterized in RUNBOOK §5 with a scoped fix — see `planning/active/phase4d_plan_draft.md` + `issue_phase4d_draft.md`.

## Handoff
Mid-stream handoff to M1 in progress — see `planning/active/HANDOFF.md`.

## Test plan
- [x] Persist flags populate (verified in isolation: PARS anth/dams 48559, dam_ind 32406)
- [x] Package parses
- [ ] `devtools::test()` + `check()` on M1 before merge
- [ ] PARS + LFRA parity (Phase 4d, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)