### PR TITLE
study_area_run.sh: pre-flight bcfp-ref view is fresh., not $SCHEMA. (v0.41.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.41.1
+Version: 0.41.2
 Date: 2026-05-27
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# link 0.41.2
+
+`data-raw/study_area_run.sh` pre-flight bug fix exposed by v0.41.1's `--schema=` flag. The pre-flight check for the bcfp reference view was looking in `$SCHEMA.streams_vw_bcfp` (the override-able persist schema), but the bcfp reference is hard-coded to `fresh.streams_vw_bcfp` in `R/lnk_compare_mapping_code.R:78` — it's a constant comparison reference, not a per-run output. The coincidence held while `$SCHEMA` was always `"fresh"`; the new flag exposed the latent bug. Now the pre-flight always checks `fresh.streams_vw_bcfp`, independent of `$SCHEMA`.
+
 # link 0.41.1
 
 `data-raw/study_area_run.sh` gains a `--schema=<persist-schema>` flag for side-by-side bundle compares. Without the flag, behaviour is unchanged (config's YAML `pipeline$schema` default). With the flag, the driver exports `LNK_SCHEMA` so all per-WSG R scripts (`wsg_run_one.R`, `wsg_recompute_one.R`, `study_area_compare.R`) override `cfg$pipeline$schema` at runtime. The propagation works through SSH to cyphers too (each remote shell exports `LNK_SCHEMA` before its WSG loop). Use case: `--config=default --schema=fresh_default` lets a default-config run land in `fresh_default` without clobbering an earlier `--config=bcfishpass` baseline in `fresh`. Empty `--schema=` value errors loudly rather than silently falling through to the YAML default. Live-validated on ADMS (2.2 min, 11 species habitat tables landed in `fresh_default`, `fresh` untouched).

--- a/data-raw/study_area_run.sh
+++ b/data-raw/study_area_run.sh
@@ -132,9 +132,12 @@ trap burn_cyphers EXIT
 echo "=== pre-flight ==="
 fail=0
 pg_isready -h localhost -p 5432 >/dev/null 2>&1 || { echo "  ✗ local fwapg down (:5432)"; fail=1; }
+# bcfp reference view is a constant (fresh.streams_vw_bcfp) — it lives in
+# its own schema independent of $SCHEMA (the persist target). All compare
+# code paths (R/lnk_compare_mapping_code.R:78 default) read it from `fresh`.
 HAS_VW=$(PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d fwapg -t -A -c \
-  "SELECT 1 FROM information_schema.tables WHERE table_schema='$SCHEMA' AND table_name='streams_vw_bcfp'" 2>/dev/null || true)
-[ "$HAS_VW" = "1" ] || { echo "  ✗ $SCHEMA.streams_vw_bcfp missing (run snapshot_bcfp.sh --with-bcfp-views)"; fail=1; }
+  "SELECT 1 FROM information_schema.tables WHERE table_schema='fresh' AND table_name='streams_vw_bcfp'" 2>/dev/null || true)
+[ "$HAS_VW" = "1" ] || { echo "  ✗ fresh.streams_vw_bcfp missing (run snapshot_bcfp.sh --with-bcfp-views)"; fail=1; }
 if [ "$N_CY" -gt 0 ]; then
   doctl compute droplet list --no-header >/dev/null 2>&1 || { echo "  ✗ doctl not authed"; fail=1; }
   (cd "$CYPHER_TF" && tofu workspace list >/dev/null 2>&1) || { echo "  ✗ tofu workspace list failed"; fail=1; }


### PR DESCRIPTION
## Summary

Latent bug exposed by v0.41.1's `--schema=` flag.

The pre-flight check at `data-raw/study_area_run.sh:135` was looking for `streams_vw_bcfp` in `$SCHEMA` (the override-able persist schema). The bcfp reference view is a **constant** — `R/lnk_compare_mapping_code.R:78` hard-codes `ref_table = "fresh.streams_vw_bcfp"`. While `$SCHEMA` was always `"fresh"`, the coincidence held. With `--schema=` overridable, the check broke (FATAL "fresh_default.streams_vw_bcfp missing").

Fix: pre-flight now checks `fresh.streams_vw_bcfp` literally, independent of `$SCHEMA`.

## Related Issues

- Relates to NewGraphEnvironment/sred#24

## Test plan

- [x] Discovered by trying to launch `--config=default --schema=fresh_default`: FATAL on the wrong-schema check.
- [x] One-line fix: hard-code the pre-flight ref-view check to `fresh.streams_vw_bcfp` (matches `lnk_compare_mapping_code.R:78`).
- [ ] Re-run with the fix; pre-flight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)