### PR TITLE
lnk_wsg_resolve: optional conn arg + study_area_wsgs.R passes local-fwapg conn (v0.41.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: link
 Title: Stream Network Habitat Interpretation (Experimental)
-Version: 0.41.2
+Version: 0.41.3
 Date: 2026-05-27
 Authors@R: c(
     person("Allan", "Irvine", , "airvine@newgraphenvironment.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# link 0.41.3
+
+`lnk_wsg_resolve()` gains an optional `conn` argument so callers can control the DB connection rather than relying on env-var-driven `lnk_db_conn()`. When `conn = NULL` (default), behaviour is unchanged — `lnk_db_conn()` is used as before. The change matters in environments where `PG_*_SHARE` env vars (or `~/.Renviron`) point at a tunnel that isn't reachable: `data-raw/study_area_wsgs.R` now opens a local docker fwapg connection explicitly and passes it through, matching every other driver script's `localhost:5432/fwapg postgres/postgres` pattern (and the pre-#207 inline behaviour). Strict mode and province mode remain DB-free; `conn` is consulted only in closure mode (`wsgs` non-`NULL` + `expand = TRUE`). Latent on the v0.41.0 release; exposed by the v0.41.1 study-area run when the dispatcher's `~/.Renviron` was pinned to the dead db_newgraph tunnel.
+
 # link 0.41.2
 
 `data-raw/study_area_run.sh` pre-flight bug fix exposed by v0.41.1's `--schema=` flag. The pre-flight check for the bcfp reference view was looking in `$SCHEMA.streams_vw_bcfp` (the override-able persist schema), but the bcfp reference is hard-coded to `fresh.streams_vw_bcfp` in `R/lnk_compare_mapping_code.R:78` — it's a constant comparison reference, not a per-run output. The coincidence held while `$SCHEMA` was always `"fresh"`; the new flag exposed the latent bug. Now the pre-flight always checks `fresh.streams_vw_bcfp`, independent of `$SCHEMA`.

--- a/R/lnk_wsg_resolve.R
+++ b/R/lnk_wsg_resolve.R
@@ -14,7 +14,9 @@
 #'   - `wsgs = c(...)` + `expand = TRUE` (default) — *closure mode*:
 #'     expand the focal set to its drainage closure (focal + every WSG
 #'     they flow through, ordered downstream-first), then species-filter.
-#'     Opens a connection via [lnk_db_conn()] and closes it on exit.
+#'     Requires a DB connection — pass `conn` explicitly, or one is
+#'     opened from [lnk_db_conn()] (defaults to env-var-driven) and
+#'     closed on exit.
 #'   - `wsgs = c(...)` + `expand = FALSE` — *strict mode*: species-filter
 #'     the input verbatim, no closure expansion, no DB.
 #'
@@ -30,6 +32,11 @@
 #' @param expand Logical. When `wsgs` is non-`NULL`, `TRUE` (default)
 #'   closure-expands via [fresh::frs_wsg_drainage()]; `FALSE` uses the
 #'   input as-is (species-filter only).
+#' @param conn Optional [DBI::DBIConnection-class]. Only used in closure
+#'   mode (`wsgs` non-`NULL` and `expand = TRUE`). When `NULL` (default),
+#'   one is opened via [lnk_db_conn()] (env-var-driven) and closed on
+#'   exit. Pass an explicit conn to control the target DB (e.g. local
+#'   docker fwapg vs an env-pinned tunnel) — recommended in scripts.
 #'
 #' @return Character vector of WSG codes. Province mode returns the
 #'   species-filtered set sorted alphabetically; closure mode preserves the
@@ -57,7 +64,8 @@
 #' # Strict mode — exactly these, species-filtered, no closure
 #' lnk_wsg_resolve(cfg, loaded, wsgs = c("BBAR", "BULK"), expand = FALSE)
 #' }
-lnk_wsg_resolve <- function(cfg, loaded, wsgs = NULL, expand = TRUE) {
+lnk_wsg_resolve <- function(cfg, loaded, wsgs = NULL, expand = TRUE,
+                            conn = NULL) {
   if (!inherits(cfg, "lnk_config")) {
     stop("cfg must be an lnk_config object (from lnk_config())",
          call. = FALSE)
@@ -111,8 +119,10 @@ lnk_wsg_resolve <- function(cfg, loaded, wsgs = NULL, expand = TRUE) {
   }
 
   # Closure mode ---------------------------------------------------------
-  conn <- lnk_db_conn()
-  on.exit(try(DBI::dbDisconnect(conn), silent = TRUE), add = TRUE)
+  if (is.null(conn)) {
+    conn <- lnk_db_conn()
+    on.exit(try(DBI::dbDisconnect(conn), silent = TRUE), add = TRUE)
+  }
   closure <- fresh::frs_wsg_drainage(conn, focal)
   # Preserve DS-first order from frs_wsg_drainage by indexing closure,
   # not the modelable set

--- a/data-raw/study_area_wsgs.R
+++ b/data-raw/study_area_wsgs.R
@@ -25,9 +25,19 @@ if (identical(Sys.getenv("LNK_LOAD"), "loadall")) {
   suppressPackageStartupMessages(library(link))
 }
 
+suppressPackageStartupMessages({
+  library(DBI); library(RPostgres)
+})
+# Force local docker fwapg regardless of PG_*_SHARE env (matches every
+# other driver script and the pre-#207 inline behaviour) — env-var
+# defaults point at the db_newgraph tunnel which is dead on M1.
+conn <- DBI::dbConnect(RPostgres::Postgres(), host = "localhost", port = 5432,
+                       dbname = "fwapg", user = "postgres", password = "postgres")
+on.exit(try(DBI::dbDisconnect(conn), silent = TRUE), add = TRUE)
+
 cfg    <- lnk_config(config)
 loaded <- lnk_load_overrides(cfg)
-keep   <- lnk_wsg_resolve(cfg, loaded, wsgs = focal)
+keep   <- lnk_wsg_resolve(cfg, loaded, wsgs = focal, conn = conn)
 
 if (length(keep) == 0L) {
   stop("no modelable WSGs after species-presence filter", call. = FALSE)

--- a/man/lnk_wsg_resolve.Rd
+++ b/man/lnk_wsg_resolve.Rd
@@ -4,7 +4,7 @@
 \alias{lnk_wsg_resolve}
 \title{Resolve the Set of Watershed Groups to Model}
 \usage{
-lnk_wsg_resolve(cfg, loaded, wsgs = NULL, expand = TRUE)
+lnk_wsg_resolve(cfg, loaded, wsgs = NULL, expand = TRUE, conn = NULL)
 }
 \arguments{
 \item{cfg}{An \code{lnk_config} object from \code{\link[=lnk_config]{lnk_config()}}.}
@@ -18,6 +18,12 @@ for province mode. Codes are upper-cased internally before use.}
 \item{expand}{Logical. When \code{wsgs} is non-\code{NULL}, \code{TRUE} (default)
 closure-expands via \code{\link[fresh:frs_wsg_drainage]{fresh::frs_wsg_drainage()}}; \code{FALSE} uses the
 input as-is (species-filter only).}
+
+\item{conn}{Optional \link[DBI:DBIConnection-class]{DBI::DBIConnection}. Only used in closure
+mode (\code{wsgs} non-\code{NULL} and \code{expand = TRUE}). When \code{NULL} (default),
+one is opened via \code{\link[=lnk_db_conn]{lnk_db_conn()}} (env-var-driven) and closed on
+exit. Pass an explicit conn to control the target DB (e.g. local
+docker fwapg vs an env-pinned tunnel) — recommended in scripts.}
 }
 \value{
 Character vector of WSG codes. Province mode returns the
@@ -42,7 +48,9 @@ Three call patterns dispatched by \code{wsgs} + \code{expand}:
 \item \code{wsgs = c(...)} + \code{expand = TRUE} (default) — \emph{closure mode}:
 expand the focal set to its drainage closure (focal + every WSG
 they flow through, ordered downstream-first), then species-filter.
-Opens a connection via \code{\link[=lnk_db_conn]{lnk_db_conn()}} and closes it on exit.
+Requires a DB connection — pass \code{conn} explicitly, or one is
+opened from \code{\link[=lnk_db_conn]{lnk_db_conn()}} (defaults to env-var-driven) and
+closed on exit.
 \item \code{wsgs = c(...)} + \code{expand = FALSE} — \emph{strict mode}: species-filter
 the input verbatim, no closure expansion, no DB.
 }


### PR DESCRIPTION
## Summary

`lnk_wsg_resolve()`s closure mode opened its own connection via `lnk_db_conn()`, which honours `PG_*_SHARE` env vars. On M1 those `~/.Renviron`-pinned defaults point at the db_newgraph tunnel (`:63333`) which is dead — every other driver script already dodges this by passing explicit `host`/`port` to `lnk_db_conn()` (or opening `DBI::dbConnect` directly to `localhost:5432/fwapg`).

- Adds `conn = NULL` (default) optional argument to `lnk_wsg_resolve()`. When NULL, behaviour is unchanged — opens via `lnk_db_conn()` as before. When provided, that conn is used (no internal `on.exit`-cleanup; caller owns lifecycle).
- `data-raw/study_area_wsgs.R` now opens a local docker fwapg connection explicitly and passes it through. Matches the pre-#207 inline behaviour and every other driver script (`wsg_run_one.R`, `wsg_compare.R`).
- Strict + province modes remain DB-free; `conn` consulted only in closure mode.

## Related Issues

- Relates to NewGraphEnvironment/sred#24

## Test plan

- [x] Existing 22 tests still pass (new `conn` arg has default, no test breakage)
- [x] Discovered live: `bash data-raw/study_area_run.sh --config=default --schema=fresh_default ...` failed at the bucket-resolve step with `connection to server at ":::1", port 63333 failed: Connection refused` — fix lets it through
- [ ] Relaunch the study-area run after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)