### PR TITLE
Keep comms/ and research/ out of the built package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^\.lintr$
 ^\.claude$
 ^inst/testdata/\.gitkeep$
+^comms$
+^research$


### PR DESCRIPTION
## Summary

`R CMD build` ships every top-level directory not named in `.Rbuildignore`. `link` is an installable package, so `pak::pak("NewGraphEnvironment/link")` was putting internal cross-repo coordination notes (`comms/`) and research working files (`research/`) into the installer's library.

`R CMD check` reports this only as a NOTE, and `.gitignore` does **not** cover it.

## Verification

Against the built tarball rather than the config, since the `.Rbuildignore` regex is easy to get subtly wrong:

| | `comms/` | `research/` |
|---|---|---|
| before | 15 entries | 22 entries |
| after | 0 | 0 |

## Why it was missed

`planning`, `dev`, `.claude` and `CLAUDE.md` were already excluded. `comms/` and `research/` were added to the repo later and never added to the ignore list — the gap opens over time rather than at scaffold.

This matters for the three-layer repo split: `comms/` is internal by definition, so a package that flips public while shipping it leaks exactly what the flip was meant to purge.

## Notes

Only `.Rbuildignore` is touched. The branch was cut from a working tree with 226 unrelated in-flight changes; none of them are staged or committed here.

Convention entry and an audit loop covering the other repos: NewGraphEnvironment/soul#60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPc4Xkk81mE4JHuP5A1SnS
